### PR TITLE
fix: stack overflow, non-128-aligned head dims, constant coupling

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1659,6 +1659,7 @@ int ggml_metal_op_turbo_wht(ggml_metal_op_t ctx, int idx) {
     memcpy(&direction, op->op_params, sizeof(int));
 
     const int64_t n_elements = ggml_nelements(op->src[0]);
+    GGML_ASSERT(n_elements % 128 == 0 && "TURBO_WHT requires element count to be a multiple of 128");
     const int64_t n_groups = n_elements / 128;
 
     auto pipeline = ggml_metal_library_get_pipeline_turbo_wht(lib);

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -9712,25 +9712,38 @@ kernel void kernel_set_rows_turbo(
           device block_q * dst_row = (      device block_q *) ((      device char *) dst  +  i1*args.nb1  + i02*args.nb2  + i03*args.nb3);
     const device float   * src_row = (const device float   *) ((const device char *) src0 + i01*args.nb01 + i02*args.nb02 + i03*args.nb03);
 
-    // Process in groups of 4 blocks (128 elements) for rotation
+    // Process in groups of 4 blocks (128 elements) for rotation.
+    // Use ceiling division so models with non-128-aligned head dims (e.g. GLM-4.7
+    // Flash head_dim=576, deepseek2 K head_dim=192) don't silently drop tail blocks.
     const int blocks_per_group = QK_TURBO3_GROUP / QK;  // 128/32 = 4
-    const int n_groups = args.nk0 / blocks_per_group;
+    const int n_groups = (args.nk0 + blocks_per_group - 1) / blocks_per_group;
 
     for (int grp = tiitg%tptg.x; grp < n_groups; grp += tptg.x) {
         const device float * grp_src = src_row + QK_TURBO3_GROUP * grp;
 
-        // Normalize and rotate the full 128-element group
+        // How many blocks/elements are valid in this group (< 4 blocks for tail)
+        const int grp_start_block = grp * blocks_per_group;
+        const int grp_blocks = min(blocks_per_group, (int)args.nk0 - grp_start_block);
+        const int grp_elems  = grp_blocks * QK;
+
+        // Normalize valid elements, zero-pad remainder for WHT rotation.
+        // Loop bounds use compile-time QK_TURBO3_GROUP (128) for full groups
+        // and runtime grp_elems only for tail groups.
         float norm_sq = 0.0f;
-        for (int j = 0; j < QK_TURBO3_GROUP; j++) norm_sq += grp_src[j] * grp_src[j];
+        for (int j = 0; j < QK_TURBO3_GROUP; j++) {
+            float v = (j < grp_elems) ? grp_src[j] : 0.0f;
+            norm_sq += v * v;
+        }
         float grp_norm = sqrt(norm_sq);
         float inv_norm = grp_norm > 1e-10f ? 1.0f / grp_norm : 0.0f;
 
         float x[128];
-        for (int j = 0; j < 128; j++) x[j] = grp_src[j] * inv_norm;
+        for (int j = 0; j < 128; j++) {
+            x[j] = (j < grp_elems) ? grp_src[j] * inv_norm : 0.0f;
+        }
         turbo_rotate_forward(x, turbo_wht_signs1, turbo_wht_signs2);
 
-        // Split into 4 blocks of 32 elements each
-        // All blocks store the SAME group norm — centroids are in normalized space
+        // Split into blocks of QK elements each.
         // Norm correction (ported from @spiritbuun's CUDA implementation):
         // Accumulate ||centroid_vector||^2 across all 128 elements, then store
         // grp_norm / ||centroid_vector|| instead of raw grp_norm. This makes
@@ -9738,7 +9751,8 @@ kernel void kernel_set_rows_turbo(
         float recon_norm_sq = 0.0f;
 
         for (int b = 0; b < blocks_per_group; b++) {
-            device block_q & blk = dst_row[grp * blocks_per_group + b];
+            if (grp_start_block + b >= (int)args.nk0) break;  // tail guard
+            device block_q & blk = dst_row[grp_start_block + b];
             const int off = b * QK;
 
             for (int j = 0; j < QK / 4; j++) blk.qs[j] = 0;
@@ -9770,8 +9784,8 @@ kernel void kernel_set_rows_turbo(
         // Zero decode cost — dequant already multiplies by stored norm.
         float recon_norm = sqrt(recon_norm_sq);
         float corrected_norm = (recon_norm > 1e-10f) ? grp_norm / recon_norm : grp_norm;
-        for (int b = 0; b < blocks_per_group; b++) {
-            dst_row[grp * blocks_per_group + b].norm = half(corrected_norm);
+        for (int b = 0; b < grp_blocks; b++) {
+            dst_row[grp_start_block + b].norm = half(corrected_norm);
         }
     }
 }

--- a/ggml/src/ggml-turbo-quant.c
+++ b/ggml/src/ggml-turbo-quant.c
@@ -19,8 +19,15 @@
 
 #define TURBO_SEED_ROTATION 42
 #define TURBO_SEED_QJL      1042
-#define TURBO_D             128  /* rotation group size = head_dim (independent of block size) */
 #define TURBO_QJL_CONST     1.2533141373155003f  /* sqrt(pi/2) */
+
+/* Rotation group size = QK_TURBO3_GROUP (from ggml-common.h), NOT a separate constant.
+ * turbo4 block size (QK_TURBO4) happens to equal the rotation group size today,
+ * but they are semantically different. Assert they match so turbo4 code can safely
+ * use QK_TURBO4 for both array sizing and loop bounds. */
+static_assert(QK_TURBO4 == QK_TURBO3_GROUP,
+    "turbo4 block size must equal rotation group size (both 128)");
+#define TURBO_ROT_DIM QK_TURBO3_GROUP
 
 /* Optimal centroids from paper (scaled by 1/sqrt(d)) */
 /* 1-bit: ±sqrt(2/(pi*d)) */
@@ -37,8 +44,8 @@ static const float CENTROIDS_3BIT[8] = {
 
 /* ---------- rotation matrix (lazy init) ---------- */
 
-static float turbo_rotation[TURBO_D * TURBO_D];
-static float turbo_rotation_t[TURBO_D * TURBO_D]; /* transpose */
+static float turbo_rotation[TURBO_ROT_DIM * TURBO_ROT_DIM];
+static float turbo_rotation_t[TURBO_ROT_DIM * TURBO_ROT_DIM]; /* transpose */
 static int   turbo_rotation_initialized = 0;
 
 /* Simple LCG PRNG for deterministic rotation generation */
@@ -61,18 +68,19 @@ static double turbo_prng_normal(void) {
 static void turbo_init_rotation(void) {
     if (turbo_rotation_initialized) return;
 
-    const int d = TURBO_D;
+    const int d = TURBO_ROT_DIM;
 
-    /* Generate random Gaussian matrix */
+    /* Generate random Gaussian matrix directly into turbo_rotation.
+     * Previous code used a 64KB stack-local G[] then memcpy'd — this
+     * caused stack overflow on llama.cpp worker threads with reduced
+     * stack sizes (typically 512KB on macOS, 64KB on some Linux). */
     turbo_prng_seed(TURBO_SEED_ROTATION);
-    float G[TURBO_D * TURBO_D];
     for (int i = 0; i < d * d; i++) {
-        G[i] = (float)turbo_prng_normal();
+        turbo_rotation[i] = (float)turbo_prng_normal();
     }
 
     /* QR decomposition via modified Gram-Schmidt */
     /* Q stored column-major in turbo_rotation */
-    memcpy(turbo_rotation, G, d * d * sizeof(float));
 
     for (int j = 0; j < d; j++) {
         /* Normalize column j */
@@ -111,14 +119,14 @@ static void turbo_init_rotation(void) {
 
 /* ---------- QJL projection matrix (lazy init, seed-based) ---------- */
 
-static float turbo_qjl_matrix[TURBO_D * TURBO_D];
-static float turbo_qjl_matrix_t[TURBO_D * TURBO_D];
+static float turbo_qjl_matrix[TURBO_ROT_DIM * TURBO_ROT_DIM];
+static float turbo_qjl_matrix_t[TURBO_ROT_DIM * TURBO_ROT_DIM];
 static int   turbo_qjl_initialized = 0;
 
 static void turbo_init_qjl(void) {
     if (turbo_qjl_initialized) return;
 
-    const int d = TURBO_D;
+    const int d = TURBO_ROT_DIM;
     turbo_prng_seed(TURBO_SEED_QJL);
 
     for (int i = 0; i < d * d; i++) {
@@ -255,7 +263,7 @@ void quantize_row_turbo4_0_ref(const float * GGML_RESTRICT x, block_turbo4_0 * G
         float norm = sqrtf(norm_sq);
 
         /* Normalize */
-        float normalized[TURBO_D];
+        float normalized[TURBO_ROT_DIM];
         if (norm > 1e-10f) {
             const float inv = 1.0f / norm;
             for (int i = 0; i < d; i++) normalized[i] = src[i] * inv;
@@ -264,7 +272,7 @@ void quantize_row_turbo4_0_ref(const float * GGML_RESTRICT x, block_turbo4_0 * G
         }
 
         /* Step 2: Rotate */
-        float rotated[TURBO_D];
+        float rotated[TURBO_ROT_DIM];
         matvec(turbo_rotation, normalized, rotated, d);
 
 #if TURBO4_USE_4BIT
@@ -275,7 +283,7 @@ void quantize_row_turbo4_0_ref(const float * GGML_RESTRICT x, block_turbo4_0 * G
              0.006938f,  0.020989f,  0.035597f,  0.051262f,
              0.068756f,  0.089527f,  0.117195f,  0.173926f
         };
-        uint8_t indices[TURBO_D];
+        uint8_t indices[TURBO_ROT_DIM];
         for (int i = 0; i < d; i++) {
             indices[i] = (uint8_t)nearest_centroid_4bit(rotated[i]);
         }
@@ -290,26 +298,26 @@ void quantize_row_turbo4_0_ref(const float * GGML_RESTRICT x, block_turbo4_0 * G
         y[block].norm = GGML_FP32_TO_FP16(corrected_norm);
 #else
         /* Step 3: 3-bit quantization (8 centroids) */
-        uint8_t indices[TURBO_D];
+        uint8_t indices[TURBO_ROT_DIM];
         for (int i = 0; i < d; i++) {
             indices[i] = (uint8_t)nearest_centroid_3bit(rotated[i]);
         }
 
         /* Step 4: Residual */
-        float reconstructed[TURBO_D];
+        float reconstructed[TURBO_ROT_DIM];
         for (int i = 0; i < d; i++) {
             reconstructed[i] = CENTROIDS_3BIT[indices[i]];
         }
-        float mse_recon[TURBO_D];
+        float mse_recon[TURBO_ROT_DIM];
         matvec(turbo_rotation_t, reconstructed, mse_recon, d);
 
-        float residual[TURBO_D];
+        float residual[TURBO_ROT_DIM];
         for (int i = 0; i < d; i++) {
             residual[i] = normalized[i] - mse_recon[i];
         }
 
         /* Step 5: QJL */
-        float projected[TURBO_D];
+        float projected[TURBO_ROT_DIM];
         matvec(turbo_qjl_matrix, residual, projected, d);
 #endif
 
@@ -380,7 +388,7 @@ void dequantize_row_turbo4_0(const block_turbo4_0 * GGML_RESTRICT x, float * GGM
     for (int block = 0; block < nb; block++) {
         float norm  = GGML_FP16_TO_FP32(x[block].norm);
 
-        uint8_t indices[TURBO_D];
+        uint8_t indices[TURBO_ROT_DIM];
         for (int i = 0; i < d; i++) {
             int bit_offset = i * 3;
             int byte_idx   = bit_offset / 8;
@@ -392,7 +400,7 @@ void dequantize_row_turbo4_0(const block_turbo4_0 * GGML_RESTRICT x, float * GGM
             indices[i] = (uint8_t)((raw >> bit_pos) & 0x7);
         }
 
-        float signs[TURBO_D];
+        float signs[TURBO_ROT_DIM];
         for (int i = 0; i < d; i++) {
             signs[i] = (x[block].signs[i / 8] & (1 << (i % 8))) ? 1.0f : -1.0f;
         }
@@ -400,14 +408,14 @@ void dequantize_row_turbo4_0(const block_turbo4_0 * GGML_RESTRICT x, float * GGM
         float rnorm = GGML_FP16_TO_FP32(x[block].rnorm);
         const float qjl_scale = TURBO_QJL_CONST / (float)d * rnorm;
 
-        float rotated_recon[TURBO_D];
+        float rotated_recon[TURBO_ROT_DIM];
         for (int i = 0; i < d; i++) {
             rotated_recon[i] = CENTROIDS_3BIT[indices[i]];
         }
-        float mse_recon[TURBO_D];
+        float mse_recon[TURBO_ROT_DIM];
         matvec(turbo_rotation_t, rotated_recon, mse_recon, d);
 
-        float qjl_recon[TURBO_D];
+        float qjl_recon[TURBO_ROT_DIM];
         matvec(turbo_qjl_matrix_t, signs, qjl_recon, d);
         for (int i = 0; i < d; i++) {
             qjl_recon[i] *= qjl_scale;


### PR DESCRIPTION
Resubmission of the non-breaking fixes from PR #4, rebased on current HEAD (turbo4 4-bit PolarQuant).

Dropped the turbo3/turbo4 kernel split that caused the regression. The turbo4 fixes are obsolete now that turbo4 has been redesigned. What's left:

## Changes

1. **Stack overflow in `turbo_init_rotation()`** — the 64KB stack-local `float G[]` segfaults on llama.cpp worker threads with reduced stack sizes (512KB macOS, 64KB some Linux). Fix: generate directly into `turbo_rotation`, eliminating both the stack allocation and the memcpy.

2. **Non-128-aligned head dims** (fixes #13) — `n_groups = args.nk0 / blocks_per_group` silently drops tail blocks for models like GLM-4.7 Flash (head_dim=576, 18 blocks → 4.5 groups) and deepseek2 K heads (head_dim=192, 6 blocks → 1.5 groups). Fix: ceiling division + tail handling in the **shared** `kernel_set_rows_turbo` template. All loop bounds remain at compile-time `QK_TURBO3_GROUP` (128) with `(j < grp_elems)` conditionals for zero-padding — avoids dynamic loop bounds that may have caused the v1 regression.

3. **Constant coupling** — standalone `TURBO_D 128` replaced with `TURBO_ROT_DIM = QK_TURBO3_GROUP` + `static_assert(QK_TURBO4 == QK_TURBO3_GROUP)` guard.

4. **WHT dispatch assert** — `GGML_ASSERT(n_elements % 128 == 0)` in `ggml_metal_op_turbo_wht` for early failure with clear error message.

## What's NOT included (vs PR #4)

- No turbo3/turbo4 kernel split (caused the PPL regression)
- No turbo4 SET_ROWS fixes (turbo4 completely redesigned)

## Testing notes

For 128-aligned models (the common case), `grp_elems == 128` and `grp_blocks == blocks_per_group` — the conditionals are always true and the break never fires. Zero behavior change for existing models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)