### PR TITLE
fix: turbo4 on non-128 heads + KV state serialization with padded tensors (issue #28)

### DIFF
--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -1992,9 +1992,10 @@ void llama_kv_cache::state_write_data(llama_io_write_i & io, const cell_ranges_t
     for (const auto & layer : layers) {
         const uint32_t il = layer.il;
 
-        const uint32_t n_embd_k_gqa = hparams.n_embd_k_gqa(il);
-
         auto * k = layer.k_stream[cr.strm];
+
+        // Use actual tensor width (may be padded for turbo types: e.g. 576→640)
+        const uint32_t n_embd_k_gqa = (uint32_t) k->ne[0];
 
         // Write key type
         const int32_t k_type_i = (int32_t) k->type;
@@ -2016,12 +2017,13 @@ void llama_kv_cache::state_write_data(llama_io_write_i & io, const cell_ranges_t
         for (const auto & layer : layers) {
             const uint32_t il = layer.il;
 
-            const uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa(il);
-
             auto * v = layer.v_stream[cr.strm];
             if (!v) {
                 continue;
             }
+
+            // Use actual tensor width (may be padded for turbo types)
+            const uint32_t n_embd_v_gqa = (uint32_t) v->ne[0];
 
             // Write value type
             const int32_t v_type_i = (int32_t) v->type;
@@ -2224,9 +2226,10 @@ bool llama_kv_cache::state_read_data(llama_io_read_i & io, uint32_t strm, uint32
     for (const auto & layer : layers) {
         const uint32_t il = layer.il;
 
-        const uint32_t n_embd_k_gqa = hparams.n_embd_k_gqa(il);
-
         auto * k = layer.k_stream[strm];
+
+        // Use actual tensor width (may be padded for turbo types)
+        const uint32_t n_embd_k_gqa = (uint32_t) k->ne[0];
 
         // Read type of key
         int32_t k_type_i_ref;
@@ -2265,12 +2268,13 @@ bool llama_kv_cache::state_read_data(llama_io_read_i & io, uint32_t strm, uint32
         for (const auto & layer : layers) {
             const uint32_t il = layer.il;
 
-            const uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa(il);
-
             auto * v = layer.v_stream[strm];
             if (!v) {
                 continue;
             }
+
+            // Use actual tensor width (may be padded for turbo types)
+            const uint32_t n_embd_v_gqa = (uint32_t) v->ne[0];
 
             // Read type of value
             int32_t v_type_i_ref;


### PR DESCRIPTION
## Summary

Two fixes for turbo KV cache on models with non-128-aligned heads
(GLM-4.7 Flash head_dim=576):

1. **Context init check**: `llama-context.cpp` rejected turbo4
   (QK=128) at head_dim=576 before the KV cache zero-padding code
   ran. Now computes padded head_dim first (576→640).

2. **KV state serialization**: `state_write_data` / `state_read_data`
   used `hparams.n_embd_k_gqa` (576) for `ggml_row_size`, but turbo
   types pad to 640. Assertion failure on prompt cache save during
   `llama-server` slot reuse. Now uses `k->ne[0]` / `v->ne[0]`
   (actual padded tensor width).

Bug 2 only triggers in `llama-server` with prompt cache enabled on
multi-request slot reuse — missed by `llama-cli --single-turn` tests.

## Test plan

- [x] GLM-4.7 Flash turbo4 loads (was crashing)
- [x] Server smoke test: 3 request types × 3 turbo types (new test script)
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)