### PR TITLE
fix: Windows MSVC build errors in turboquant-kv-cache branch

### DIFF
--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -12,6 +12,8 @@
 #include <cfloat>
 #include <cmath>
 
+extern "C" void ggml_set_turbo3_wht_group_size(int gs);
+
 // ggml_compute_forward_dup
 
 static void ggml_compute_forward_dup_same_cont(
@@ -4928,10 +4930,9 @@ static void ggml_compute_forward_set_rows_f32(
 
     // For turbo types: communicate WHT group size to the quantize function via global
     if (dst->type == GGML_TYPE_TURBO3_0 || dst->type == GGML_TYPE_TURBO4_0 || dst->type == GGML_TYPE_TURBO2_0) {
-        extern int turbo3_cpu_wht_group_size;
         int gs = 0;
         memcpy(&gs, dst->op_params, sizeof(int));
-        turbo3_cpu_wht_group_size = (gs == 64 || gs == 128) ? gs : 0;
+        ggml_set_turbo3_wht_group_size((gs == 64 || gs == 128) ? gs : 0);
     }
 
     for (int64_t i03 = 0; i03 < ne03; ++i03) {

--- a/ggml/src/ggml-cuda/turbo-innerq.cuh
+++ b/ggml/src/ggml-cuda/turbo-innerq.cuh
@@ -1,21 +1,23 @@
 #pragma once
-
-// TurboQuant InnerQ per-channel equalization — cross-TU shared state
-// The host-side state lives in turbo-innerq.cu; device-side state is per-TU
-// in turbo-quant.cuh (only set-rows.cu needs device access).
+// TurboQuant InnerQ per-channel equalization - cross-TU shared state
 
 #define INNERQ_MAX_CHANNELS 128
 
+// DLL export/import macro
+#if defined(_WIN32)
+#  if defined(GGML_BACKEND_BUILD)
+#    define TURBO_INNERQ_API __declspec(dllexport)
+#  else
+#    define TURBO_INNERQ_API __declspec(dllimport)
+#  endif
+#else
+#  define TURBO_INNERQ_API
+#endif
+
 // Host-side shared state (defined in turbo-innerq.cu)
-extern bool  g_innerq_finalized;
-extern float g_innerq_scale_inv_host[INNERQ_MAX_CHANNELS];
+extern TURBO_INNERQ_API bool  g_innerq_finalized;
+extern TURBO_INNERQ_API float g_innerq_scale_inv_host[INNERQ_MAX_CHANNELS];
 
-// Called from set-rows.cu after InnerQ finalization to publish scale_inv
-void turbo_innerq_publish(const float * scale_inv, int group_size);
-
-// Called from llama-kv-cache.cpp (or equivalent) to check if tensor needs update
-// Returns true if there are new scale_inv values to upload
-bool turbo_innerq_needs_tensor_update(void);
-
-// Called after tensor update to clear the flag
-void turbo_innerq_mark_tensor_updated(void);
+TURBO_INNERQ_API void turbo_innerq_publish(const float * scale_inv, int group_size);
+TURBO_INNERQ_API bool turbo_innerq_needs_tensor_update(void);
+TURBO_INNERQ_API void turbo_innerq_mark_tensor_updated(void);

--- a/ggml/src/ggml-turbo-quant.c
+++ b/ggml/src/ggml-turbo-quant.c
@@ -10,6 +10,9 @@
 #include "ggml-common.h"
 #include "ggml-impl.h"
 
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
 #include <math.h>
 #include <string.h>
 #include <assert.h>
@@ -17,6 +20,11 @@
 
 /* Global: WHT group size for CPU quantize path (set by CPU SET_ROWS handler) */
 int turbo3_cpu_wht_group_size = 0;
+
+/* Setter called from CPU backend (DLL boundary safe) */
+GGML_API void ggml_set_turbo3_wht_group_size(int gs) {
+    turbo3_cpu_wht_group_size = gs;
+}
 
 /* ---------- constants ---------- */
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -161,6 +161,10 @@ target_include_directories(llama PUBLIC ../include)
 target_compile_features   (llama PRIVATE cxx_std_17) # don't bump
 
 target_link_libraries(llama PUBLIC ggml)
+if (GGML_CUDA)
+    target_link_libraries(llama PRIVATE ggml-cuda)
+    target_compile_definitions(llama PRIVATE GGML_USE_CUDA) 
+endif()
 
 if (BUILD_SHARED_LIBS)
     set_target_properties(llama PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -21,17 +21,13 @@
 #endif
 
 #ifdef GGML_USE_CUDA
-extern bool  g_innerq_finalized;
-extern float g_innerq_scale_inv_host[INNERQ_MAX_CHANNELS];
-extern bool turbo_innerq_needs_tensor_update(void);
-extern void turbo_innerq_mark_tensor_updated(void);
+#include "../ggml/src/ggml-cuda/turbo-innerq.cuh"
 #else
 static bool  g_innerq_finalized = false;
 static float g_innerq_scale_inv_host[INNERQ_MAX_CHANNELS] = {};
 static bool turbo_innerq_needs_tensor_update(void) { return false; }
 static void turbo_innerq_mark_tensor_updated(void) {}
 #endif
-
 //
 // llama_kv_cache
 //


### PR DESCRIPTION
## Overview
Fix Windows MSVC build errors in the feature/turboquant-kv-cache branch.
This branch does not build on Windows due to several MSVC-specific issues.

## Changes
- Add `_USE_MATH_DEFINES` for `M_PI` in `ggml-turbo-quant.c` (MSVC does not define it by default)
- Fix DLL boundary issue for `turbo3_cpu_wht_group_size` via `GGML_API` setter function
- Add `TURBO_INNERQ_API` export macros to `turbo-innerq.cuh` for Windows DLL compatibility
- Include `turbo-innerq.cuh` directly in `llama-kv-cache.cpp` instead of raw extern declarations
- Link `ggml-cuda` and define `GGML_USE_CUDA` for llama target when CUDA is enabled

## Test environment
- Windows 11, MSVC 19.44, CUDA 13.1, RTX 4080 Super (SM89)
- Ubuntu 24.04.4 LTS, CUDA 12.0, RTX 3060 12GB (SM86)

## AI usage disclosure
Diagnosed and fixed with assistance from Claude (Anthropic).

🤖 Generated with [Claude](https://claude.ai/claude-code)