### PR TITLE
Fix/turbo4 wht dequant

### DIFF
--- a/ggml/src/ggml-turbo-quant.c
+++ b/ggml/src/ggml-turbo-quant.c
@@ -451,9 +451,10 @@ void quantize_row_turbo4_0_ref(const float * GGML_RESTRICT x, block_turbo4_0 * G
             memset(normalized, 0, d * sizeof(float));
         }
 
-        /* Step 2: Rotate */
+        /* Step 2: Forward WHT rotation (matches CUDA set_rows) */
         float rotated[TURBO_D];
-        matvec(turbo_rotation, normalized, rotated, d);
+        memcpy(rotated, normalized, d * sizeof(float));
+        turbo_cpu_fwht(rotated, d);
 
 #if TURBO4_USE_4BIT
         /* Step 3: 4-bit quantization (16 centroids) */
@@ -554,14 +555,15 @@ void dequantize_row_turbo4_0(const block_turbo4_0 * GGML_RESTRICT x, float * GGM
     };
     for (int block = 0; block < nb; block++) {
         float norm = GGML_FP16_TO_FP32(x[block].norm);
-        float rotated[QK_TURBO4];
+        float * dst = y + block * d;
         for (int i = 0; i < d; i++) {
             uint8_t idx = (x[block].qs[i / 2] >> ((i % 2) * 4)) & 0xF;
-            rotated[i] = CENTROIDS_4BIT[idx];
+            dst[i] = CENTROIDS_4BIT[idx] * norm;
         }
-        float * dst = y + block * d;
-        matvec(turbo_rotation_t, rotated, dst, d);
-        for (int i = 0; i < d; i++) dst[i] *= norm;
+        /* No inverse WHT, dequant stays in the rotated domain.
+        * Q is WHT-rotated by the graph, so <Q_rot, K_rot> gives correct attention scores.
+        * The inverse WHT is applied to the attention output via GGML_OP_TURBO_WHT (direction=1) in the graph. 
+        */
     }
 #else
     /* Legacy 3-bit + QJL dequant */


### PR DESCRIPTION
  ## Summary                                                                                
  Fixes the C reference path for #17, the CUDA port (PR #24) added WHT-based set_rows/dequant but the C reference `quantize_row_turbo4_0_ref` and `dequantize_row_turbo4_0` were not updated to match, causing turbo4 to produce garbage when the C path is used.

  turbo4 produces gibberish on all models and platforms (CUDA + CPU). turbo3 works fine.    
  Root cause: the C reference `quantize_row_turbo4_0_ref` and `dequantize_row_turbo4_0` use a dense random rotation matrix (`matvec(turbo_rotation, ...)`), while the CUDA `k_set_rows_turbo4` uses WHT. This creates a transform mismatch that corrupts all turbo4 KV cache data.

  ## Changes (one file, two fixes)

  **`ggml/src/ggml-turbo-quant.c`**                                                         
   
  1. **quantize_row_turbo4_0_ref**: replaced `matvec(turbo_rotation, normalized, rotated,   
  d)` with `memcpy + turbo_cpu_fwht(rotated, d)` to match the CUDA set_rows WHT path.
                                                                                            
  2. **dequantize_row_turbo4_0**: replaced `centroid lookup → matvec(turbo_rotation_t, ...) 
  -> scale by norm` with `centroid * norm` (no inverse transform). The dequant must stay in the rotated domain because Q is WHT-rotated by the graph (`GGML_OP_TURBO_WHT`, direction=0), and the inverse WHT is applied to the attention output by a separate graph op (direction=1).

  ## Why turbo3 was unaffected

  turbo3's C reference (`quantize_row_turbo3_0_ref`) already uses `turbo_cpu_fwht`. Its dequant uses the separate legacy 3-bit+QJL path. Only turbo4's C code still used the dense rotation.                                                                                
                                                               
  ## Testing

  - **Before fix**: turbo4 produces gibberish on Llama 3.1 8B Instruct and Qwen 2.5 7B Instruct (Q4_K_M), both CUDA and CPU
  - **After fix**: turbo4 produces coherent output matching turbo3 quality                  
  - **Hardware**: RTX 4070 Ti Super (sm_89), CUDA 12.6, Ubuntu Linux                        
                                                                                            
  ### Reproduction                                                                          
                                                                                            
  ```bash                                                      
  # turbo3 works (before and after fix):
  ./build/bin/llama-cli --hf-repo bartowski/Meta-Llama-3.1-8B-Instruct-GGUF \               
    --hf-file Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf \                                      
    --cache-type-k turbo3 --cache-type-v turbo3 --flash-attn on \                           
    -p "Explain vector quantization in one paragraph" -n 100                                
                                                                                            
  # turbo4 broken before fix, works after:                                                  
  ./build/bin/llama-cli --hf-repo bartowski/Meta-Llama-3.1-8B-Instruct-GGUF \               
    --hf-file Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf \                                      
    --cache-type-k turbo4 --cache-type-v turbo4 --flash-attn on \                           
    -p "Explain vector quantization in one paragraph" -n 100  