### PR TITLE
Fix GGML_OP_COUNT assertion for RPC

### DIFF
--- a/ggml/include/ggml-rpc.h
+++ b/ggml/include/ggml-rpc.h
@@ -8,10 +8,10 @@ extern "C" {
 
 #define RPC_PROTO_MAJOR_VERSION    3
 #define RPC_PROTO_MINOR_VERSION    6
-#define RPC_PROTO_PATCH_VERSION    1
+#define RPC_PROTO_PATCH_VERSION    2
 
 #ifdef  __cplusplus
-static_assert(GGML_OP_COUNT == 96, "GGML_OP_COUNT has changed - update RPC_PROTO_PATCH_VERSION");
+static_assert(GGML_OP_COUNT == 97, "GGML_OP_COUNT has changed - update RPC_PROTO_PATCH_VERSION");
 #endif
 
 #define GGML_RPC_MAX_SERVERS       16


### PR DESCRIPTION


## Overview
When compiling with the `-DGGML_RPC=ON` option, a static assert fails for `GGML_OP_COUNT == 96`. It should be 97.

## Additional information



Specifically, compiling fails at:

```
/home/caleb/Downloads/llama-cpp-turboquant/ggml/src/../include/ggml-rpc.h:14:29: error: static assertion failed: GGML_OP_COUNT has changed - update RPC_PROTO_PATCH_VERSION
```
