### PR TITLE
ci: fix turbo build + test failures on feature/turboquant-kv-cache

### DIFF
--- a/ggml/include/ggml-rpc.h
+++ b/ggml/include/ggml-rpc.h
@@ -8,10 +8,10 @@ extern "C" {
 
 #define RPC_PROTO_MAJOR_VERSION    3
 #define RPC_PROTO_MINOR_VERSION    6
-#define RPC_PROTO_PATCH_VERSION    1
+#define RPC_PROTO_PATCH_VERSION    2
 
 #ifdef  __cplusplus
-static_assert(GGML_OP_COUNT == 96, "GGML_OP_COUNT has changed - update RPC_PROTO_PATCH_VERSION");
+static_assert(GGML_OP_COUNT == 97, "GGML_OP_COUNT has changed - update RPC_PROTO_PATCH_VERSION");
 #endif
 
 #define GGML_RPC_MAX_SERVERS       16

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -5594,6 +5594,9 @@ void ggml_compute_forward_clamp(
         case GGML_TYPE_TQ2_0:
         case GGML_TYPE_TQ3_1S:
         case GGML_TYPE_TQ4_1S:
+        case GGML_TYPE_TURBO2_0:
+        case GGML_TYPE_TURBO3_0:
+        case GGML_TYPE_TURBO4_0:
         case GGML_TYPE_IQ2_XXS:
         case GGML_TYPE_IQ2_XS:
         case GGML_TYPE_IQ3_XXS:

--- a/ggml/src/ggml-cuda/turbo-quant.cuh
+++ b/ggml/src/ggml-cuda/turbo-quant.cuh
@@ -176,10 +176,10 @@ static void turbo_innerq_init(void) {
     // Zero accumulators and set calibrating flag on device
     float zeros[INNERQ_MAX_CHANNELS] = {0};
     int zero = 0, one = 1;
-    cudaMemcpyToSymbol(d_innerq_sq_accum, zeros, sizeof(zeros));
-    cudaMemcpyToSymbol(d_innerq_count, &zero, sizeof(int));
-    cudaMemcpyToSymbol(d_innerq_active, &zero, sizeof(int));
-    cudaMemcpyToSymbol(d_innerq_calibrating, &one, sizeof(int));
+    CUDA_CHECK(cudaMemcpyToSymbol(d_innerq_sq_accum, zeros, sizeof(zeros)));
+    CUDA_CHECK(cudaMemcpyToSymbol(d_innerq_count, &zero, sizeof(int)));
+    CUDA_CHECK(cudaMemcpyToSymbol(d_innerq_active, &zero, sizeof(int)));
+    CUDA_CHECK(cudaMemcpyToSymbol(d_innerq_calibrating, &one, sizeof(int)));
 
     GGML_LOG_INFO("%s: InnerQ calibration started (target=%d tokens, strength=%.2f)\n",
                    __func__, innerq_target_tokens, innerq_strength);
@@ -190,14 +190,14 @@ static void turbo_innerq_finalize(int group_size) {
     // Read accumulators from device
     float sq_accum[INNERQ_MAX_CHANNELS];
     int count = 0;
-    cudaMemcpyFromSymbol(sq_accum, d_innerq_sq_accum, group_size * sizeof(float));
-    cudaMemcpyFromSymbol(&count, d_innerq_count, sizeof(int));
+    CUDA_CHECK(cudaMemcpyFromSymbol(sq_accum, d_innerq_sq_accum, group_size * sizeof(float)));
+    CUDA_CHECK(cudaMemcpyFromSymbol(&count, d_innerq_count, sizeof(int)));
 
     if (count <= 0) {
         GGML_LOG_WARN("%s: InnerQ calibration got 0 tokens, disabling\n", __func__);
         innerq_enabled = 0;
         int zero = 0;
-        cudaMemcpyToSymbol(d_innerq_calibrating, &zero, sizeof(int));
+        CUDA_CHECK(cudaMemcpyToSymbol(d_innerq_calibrating, &zero, sizeof(int)));
         return;
     }
 
@@ -231,17 +231,17 @@ static void turbo_innerq_finalize(int group_size) {
                        __func__, max_ratio);
         innerq_enabled = 0;
         int zero = 0;
-        cudaMemcpyToSymbol(d_innerq_calibrating, &zero, sizeof(int));
+        CUDA_CHECK(cudaMemcpyToSymbol(d_innerq_calibrating, &zero, sizeof(int)));
         return;
     }
 
     // Stop calibrating, upload scales, activate
     int zero = 0, one = 1;
-    cudaMemcpyToSymbol(d_innerq_calibrating, &zero, sizeof(int));
-    cudaMemcpyToSymbol(d_innerq_scale, scale, group_size * sizeof(float));
-    cudaMemcpyToSymbol(d_innerq_scale_inv, scale_inv, group_size * sizeof(float));
-    cudaDeviceSynchronize();  // ensure scales are visible before activating
-    cudaMemcpyToSymbol(d_innerq_active, &one, sizeof(int));
+    CUDA_CHECK(cudaMemcpyToSymbol(d_innerq_calibrating, &zero, sizeof(int)));
+    CUDA_CHECK(cudaMemcpyToSymbol(d_innerq_scale, scale, group_size * sizeof(float)));
+    CUDA_CHECK(cudaMemcpyToSymbol(d_innerq_scale_inv, scale_inv, group_size * sizeof(float)));
+    CUDA_CHECK(cudaDeviceSynchronize());  // ensure scales are visible before activating
+    CUDA_CHECK(cudaMemcpyToSymbol(d_innerq_active, &one, sizeof(int)));
 
     innerq_enabled = 2;  // active
 
@@ -272,7 +272,7 @@ static void turbo_innerq_check_finalize(int group_size, int64_t ne00) {
                            __func__, (long long)ne00, group_size);
             innerq_enabled = 0;
             int zero = 0;
-            cudaMemcpyToSymbol(d_innerq_calibrating, &zero, sizeof(int));
+            CUDA_CHECK(cudaMemcpyToSymbol(d_innerq_calibrating, &zero, sizeof(int)));
         }
         return;
     }
@@ -280,7 +280,7 @@ static void turbo_innerq_check_finalize(int group_size, int64_t ne00) {
     // Check if calibration is complete
     if (innerq_enabled == 1) {
         int count = 0;
-        cudaMemcpyFromSymbol(&count, d_innerq_count, sizeof(int));
+        CUDA_CHECK(cudaMemcpyFromSymbol(&count, d_innerq_count, sizeof(int)));
         if (count >= innerq_target_tokens) {
             turbo_innerq_finalize(group_size);
         }

--- a/tests/test-quantize-fns.cpp
+++ b/tests/test-quantize-fns.cpp
@@ -48,7 +48,10 @@ static float array_rmse(const float * a1, const float * a2, size_t n) {
 
 // Total quantization error on test data
 static float total_quantization_error(const ggml_type_traits * qfns, const ggml_type_traits_cpu * qfns_cpu, size_t test_size, const float * test_data) {
-    std::vector<uint8_t> tmp_q(2*test_size);
+    // Buffer must be large enough for the row's byte size. For types whose
+    // vec_dot_type is GGML_TYPE_F32 (e.g. turbo quants), from_float writes
+    // test_size*sizeof(float) bytes, which exceeds the legacy 2*test_size sizing.
+    std::vector<uint8_t> tmp_q(std::max<size_t>(2*test_size, test_size * sizeof(float)));
     std::vector<float> tmp_out(test_size);
 
     qfns_cpu->from_float(test_data, tmp_q.data(), test_size);
@@ -58,7 +61,7 @@ static float total_quantization_error(const ggml_type_traits * qfns, const ggml_
 
 // Total quantization error on test data
 static float reference_quantization_error(const ggml_type_traits * qfns, const ggml_type_traits_cpu * qfns_cpu, size_t test_size, const float * test_data) {
-    std::vector<uint8_t> tmp_q(2*test_size);
+    std::vector<uint8_t> tmp_q(std::max<size_t>(2*test_size, test_size * sizeof(float)));
     std::vector<float> tmp_out(test_size);
     std::vector<float> tmp_out_ref(test_size);
 
@@ -84,8 +87,10 @@ static float dot_product(const float * a1, const float * a2, size_t test_size) {
 static float dot_product_error(const ggml_type_traits * qfns, const ggml_type_traits_cpu * qfns_cpu, size_t test_size, const float * test_data1, const float * test_data2) {
     GGML_UNUSED(qfns);
 
-    std::vector<uint8_t> tmp_q1(2*test_size);
-    std::vector<uint8_t> tmp_q2(2*test_size);
+    // For turbo quants vec_dot_type is GGML_TYPE_F32, so vdot->from_float writes
+    // test_size*sizeof(float) bytes. Size buffers accordingly.
+    std::vector<uint8_t> tmp_q1(std::max<size_t>(2*test_size, test_size * sizeof(float)));
+    std::vector<uint8_t> tmp_q2(std::max<size_t>(2*test_size, test_size * sizeof(float)));
 
     const auto * vdot = ggml_get_type_traits_cpu(qfns_cpu->vec_dot_type);
 
@@ -137,6 +142,16 @@ int main(int argc, char * argv[]) {
             continue;
         }
 
+        // TurboQuant KV-cache types (TURBO2_0/TURBO3_0/TURBO4_0) intentionally keep
+        // their dequantized output in the WHT-rotated domain; the inverse WHT is
+        // applied separately via GGML_OP_TURBO_WHT in the attention graph. They do
+        // not round-trip through float space, so the total/reference/dot-product
+        // error tests in this harness are not applicable.
+        if (type == GGML_TYPE_TURBO2_0 || type == GGML_TYPE_TURBO3_0 || type == GGML_TYPE_TURBO4_0) {
+            printf("Testing %s (skipped: rotated-domain KV quant)\n", ggml_type_name(type));
+            continue;
+        }
+
         const ggml_type ei = (ggml_type)i;
 
         printf("Testing %s\n", ggml_type_name((ggml_type) i));
@@ -152,6 +167,7 @@ int main(int argc, char * argv[]) {
                 type == GGML_TYPE_Q3_K    ? MAX_QUANTIZATION_TOTAL_ERROR_3BITS :
                 type == GGML_TYPE_IQ3_S   ? MAX_QUANTIZATION_TOTAL_ERROR_3BITS :
                 type == GGML_TYPE_IQ3_XXS ? MAX_QUANTIZATION_TOTAL_ERROR_3BITS_XXS :
+                type == GGML_TYPE_TQ3_1S  ? MAX_QUANTIZATION_TOTAL_ERROR_3BITS :
                 type == GGML_TYPE_NVFP4   ? MAX_QUANTIZATION_TOTAL_ERROR_FP4 : MAX_QUANTIZATION_TOTAL_ERROR;
             failed = !(total_error < max_quantization_error);
             num_failed += failed;
@@ -168,7 +184,8 @@ int main(int argc, char * argv[]) {
 
             const float vec_dot_error = dot_product_error(qfns, qfns_cpu, test_size, test_data.data(), test_data2.data());
             const float max_allowed_error = type == GGML_TYPE_Q2_K || type == GGML_TYPE_IQ2_XS || type == GGML_TYPE_IQ2_XXS ||
-                                            type == GGML_TYPE_IQ3_XXS || type == GGML_TYPE_IQ3_S || type == GGML_TYPE_IQ2_S
+                                            type == GGML_TYPE_IQ3_XXS || type == GGML_TYPE_IQ3_S || type == GGML_TYPE_IQ2_S ||
+                                            type == GGML_TYPE_TQ3_1S
                                           ? MAX_DOT_PRODUCT_ERROR_LOWBIT
                                           : type == GGML_TYPE_TQ1_0 || type == GGML_TYPE_TQ2_0
                                           ? MAX_DOT_PRODUCT_ERROR_TERNARY


### PR DESCRIPTION
Picks the CI back up to green on top of `feature/turboquant-kv-cache` after the recent turbo merges. Every fix is the minimum needed to unblock the corresponding job.

## Changes

### 1. `ggml-cpu/ops.cpp` — `ggml_compute_forward_clamp`
The abort branch is guarded by `-Werror=switch` but is missing the three TurboQuant KV-cache types, which breaks every GCC build after the turbo types were introduced. Added `TURBO2_0 / TURBO3_0 / TURBO4_0` alongside the existing `TQ*` cases so they fall through to `GGML_ABORT`.

### 2. `ggml/include/ggml-rpc.h` — static_assert
`GGML_OP_TURBO_WHT` bumped `GGML_OP_COUNT` from 96 → 97 but the RPC `static_assert` wasn't updated. Bumped `RPC_PROTO_PATCH_VERSION` 1 → 2 and the assert to 97. This unblocks `ubuntu-latest-rpc`, `windows-latest-hip`, and every other RPC-linked job.

### 3. `tests/test-quantize-fns.cpp`
Three related problems:

**a. Heap-buffer-overflow (ASan) in `dot_product_error` / `total_quantization_error`**
`std::vector<uint8_t> tmp_q(2*test_size)` is too small when `vec_dot_type == GGML_TYPE_F32` (the case for turbo quants), because `from_float` writes `test_size * sizeof(float)` bytes into it. ASan trace:

```
==ERROR: heap-buffer-overflow ... WRITE of size 16384 at 0x... (8-byte region)
    #1 ggml_cpu_fp32_to_fp32 ggml/src/ggml-cpu/ggml-cpu.c:3487
    #2 dot_product_error     tests/test-quantize-fns.cpp:93
```

Fix: size the scratch buffers to `std::max(2*test_size, test_size*sizeof(float))`.

**b. Skip TURBO2_0 / TURBO3_0 / TURBO4_0 in the harness**
Their `dequantize_row_turbo*_0` intentionally stays in the WHT-rotated domain — the inverse WHT is applied separately via `GGML_OP_TURBO_WHT` in the attention graph, so a round-trip against the original float buffer is not meaningful. (This is documented right in the turbo4 dequant: *"No inverse WHT, dequant stays in the rotated domain … The inverse WHT is applied to the attention output via GGML_OP_TURBO_WHT (direction=1) in the graph."*) The existing threshold table can't describe that, so we skip these types with an explanatory message, same pattern as deprecated types skipped via `blck_size == 0`.

**c. TQ3_1S error budget**
TQ3_1S is a 3-bit weight quant but currently pays the default 4-bit budgets. Added it to the 3-bit buckets (`MAX_QUANTIZATION_TOTAL_ERROR_3BITS` / `MAX_DOT_PRODUCT_ERROR_LOWBIT`), matching Q3_K / IQ3_S.

### 4. `ggml-cuda/turbo-quant.cuh`
`cudaMemcpyToSymbol`, `cudaMemcpyFromSymbol`, and `cudaDeviceSynchronize` are wrapped in `CUDA_CHECK(...)` so the HIP build (where `hipError_t` is `[[nodiscard]]`) no longer trips `-Werror` on unused-result. Fourteen call sites touched.

## Verification

Local, on Arch Linux (CPU build only):

```
ctest -L main -E "test-llama-archs|test-tokenizers-ggml-vocabs" --timeout 300
...
100% tests passed, 0 tests failed out of 41
```

`test-tokenizers-ggml-vocabs` is excluded only because `test-tokenizer-0` wasn't built in the partial target — CI builds it.

`test-quantize-fns` was also run under AddressSanitizer (`build-sanitize`-style config) and is now clean. Before this PR it aborted with `malloc(): corrupted top size`.

## Related

- Mirrors the `RPC_PROTO_PATCH_VERSION` bump approach used in #65 (cpburnz).
- Does **not** alter any turbo kernels or quant math — only switch coverage, buffer sizing, test thresholds, and CUDA_CHECK wrappers.