### PR TITLE
Fix VRAM usage increase on HIP/ROCm with RDNA3 and possibly more

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -1336,14 +1336,15 @@ void launch_fattn(
             const int  * kv_max_ptr,
             float      * dst_out,
             float2     * meta_out,
-            dim3         blk_num) {
+            dim3         blk_num,
+            const char * sinks_ptr = nullptr) {
         GGML_ASSERT(block_dim.x % warp_size == 0);
         fattn_kernel<<<blk_num, block_dim, nbytes_shared, main_stream>>>(
             (const char *) Q->data,
             kd,
             vd,
             mask_ptr,
-            sinks ? ((const char *) sinks->data) : nullptr,
+            sinks_ptr,
             kv_max_ptr,
             dst_out, meta_out,
             scale, max_bias, m0, m1, n_head_log2, logit_softcap,
@@ -1521,7 +1522,8 @@ void launch_fattn(
             KV_max.ptr,
             !stream_k && parallel_blocks > 1 ? dst_tmp.ptr : (float *) KQV->data,
             dst_tmp_meta.ptr,
-            blocks_num
+            blocks_num,
+            sinks ? ((const char *) sinks->data) : nullptr
         );
 
         if (stream_k) {
@@ -1635,7 +1637,8 @@ void launch_fattn(
                 knb11, knb12, knb13, vnb21, vnb22, vnb23,
                 mask_ptr, nullptr,  // KV_max not used in batched path
                 dst_out, meta_out,
-                batch_blocks
+                batch_blocks,
+                b == 0 ? (sinks ? (const char *) sinks->data : nullptr) : nullptr  // sinks only on first batch
             );
         };
 

--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -8,6 +8,7 @@
 #include <cstdint>
 
 #define FATTN_KQ_STRIDE       256
+#define FATTN_KV_CONV_BATCH   1024 // max KV tokens converted to f16 at once to bound pool allocation growth
 #define HALF_MAX_HALF         __float2half(65504.0f/2) // Use neg. of this instead of -INFINITY to initialize KQ max vals to avoid NaN upon subtraction.
 #define SOFTMAX_FTZ_THRESHOLD -20.0f                   // Softmax exp. of values smaller than this are flushed to zero to avoid NaNs.
 
@@ -1177,6 +1178,78 @@ static __global__ void flash_attn_combine_results(
     dst[tid] = VKQ_numerator / VKQ_denominator;
 }
 
+// Merges a new batch of partial flash-attention results (new_parts/new_meta) into the running
+// accumulator (acc_parts/acc_meta) in-place.  Both arrays are in [n_rows][D] layout.
+// Used by the batched-conversion path to combine partial results without allocating per-batch
+// temporary buffers (which would scale with KV length).
+template<int D>
+__launch_bounds__(D, 1)
+static __global__ void flash_attn_combine2_inplace(
+        float  * __restrict__ acc_parts,        // [n_rows][D], updated in-place
+        float2 * __restrict__ acc_meta,         // [n_rows],    updated in-place
+        const float  * __restrict__ new_parts,  // [n_rows][D]
+        const float2 * __restrict__ new_meta) { // [n_rows]
+    // Same grid layout as flash_attn_combine_results.
+    const int ne01 = gridDim.x;
+    const int ne02 = gridDim.y;
+    const int j = (blockIdx.z * ne01 + blockIdx.x) * ne02 + blockIdx.y;
+
+    const int tid = threadIdx.x;
+    __builtin_assume(tid < D);
+
+    const float2 ma = acc_meta[j];
+    const float2 mb = new_meta[j];
+    const float kqmax = max(ma.x, mb.x);
+    const float sa    = expf(ma.x - kqmax);
+    const float sb    = expf(mb.x - kqmax);
+
+    acc_parts[j*D + tid] = sa * acc_parts[j*D + tid] + sb * new_parts[j*D + tid];
+
+    if (tid == 0) {
+        acc_meta[j] = {kqmax, sa * ma.y + sb * mb.y};
+    }
+}
+
+// Convert a slice of kv_count tokens starting at kv_start from a K or V tensor into a contiguous
+// f16 buffer dst with layout [ne3][ne2][kv_count][ne0].  Uses the nc (non-contiguous) converter
+// when available so that a single kernel handles arbitrary source strides; falls back to iterating
+// over (head, batch) pairs with the flat contiguous converter for types that only have the latter.
+static void convert_kv_to_f16_slice(
+        const char   * src,
+        half         * dst,
+        ggml_type      type,
+        int64_t        ne0,        // head dim
+        int64_t        kv_start,
+        int64_t        kv_count,
+        int64_t        ne2,        // KV head count
+        int64_t        ne3,        // batch size
+        size_t         nb1,        // source stride for KV sequence dim (bytes)
+        size_t         nb2,        // source stride for head dim (bytes)
+        size_t         nb3,        // source stride for batch dim (bytes)
+        cudaStream_t   stream) {
+    to_fp16_nc_cuda_t to_fp16_nc = ggml_get_to_fp16_nc_cuda(type);
+
+    if (to_fp16_nc) {
+        const size_t ts = ggml_type_size(type);
+        to_fp16_nc(src + kv_start * nb1, dst,
+                   ne0, kv_count, ne2, ne3,
+                   (int64_t)(nb1/ts), (int64_t)(nb2/ts), (int64_t)(nb3/ts),
+                   stream);
+    } else {
+        // Types without an nc converter (Q4_K, Q5_K, Q6_K, IQ*, …) are always contiguously
+        // allocated, so we can convert each (head, batch) row separately.
+        to_fp16_cuda_t to_fp16 = ggml_get_to_fp16_cuda(type);
+        GGML_ASSERT(to_fp16 != nullptr);
+        for (int64_t b = 0; b < ne3; ++b) {
+            for (int64_t h = 0; h < ne2; ++h) {
+                const char * src_slice = src + kv_start * nb1 + h * nb2 + b * nb3;
+                half       * dst_slice = dst + (b * ne2 * kv_count + h * kv_count) * ne0;
+                to_fp16(src_slice, dst_slice, kv_count * ne0, stream);
+            }
+        }
+    }
+}
+
 template <int DV, int ncols1, int ncols2>
 void launch_fattn(
     ggml_backend_cuda_context & ctx, ggml_tensor * dst, fattn_kernel_t fattn_kernel, const int nwarps, const size_t nbytes_shared,
@@ -1210,169 +1283,16 @@ void launch_fattn(
     const int cc  = ggml_cuda_info().devices[id].cc;
     const int nsm = ggml_cuda_info().devices[id].nsm;
 
-    ggml_cuda_pool_alloc<half>   K_f16(pool);
-    ggml_cuda_pool_alloc<half>   V_f16(pool);
-    ggml_cuda_pool_alloc<int>    KV_max(pool);
-    ggml_cuda_pool_alloc<float>  dst_tmp(pool);
-    ggml_cuda_pool_alloc<float2> dst_tmp_meta(pool);
+    // Whether K or V need type conversion to f16.
+    const bool need_conv_K = need_f16_K && K->type != GGML_TYPE_F16;
+    const bool need_conv_V = need_f16_V && V->type != GGML_TYPE_F16 && !V_is_K_view;
 
-    const char * K_data = (const char *) K->data;
-    size_t nb11 = K->nb[1];
-    size_t nb12 = K->nb[2];
-    size_t nb13 = K->nb[3];
+    // Use batched conversion when a conversion is required and the KV length exceeds the cap.
+    // This keeps the f16 conversion buffer bounded in the pool regardless of context length.
+    // When K->ne[1] <= FATTN_KV_CONV_BATCH the fast path's upfront allocation is already bounded.
+    const bool use_kv_batching = (need_conv_K || need_conv_V) && K->ne[1] > FATTN_KV_CONV_BATCH;
 
-    const char * V_data = (const char *) V->data;
-    size_t nb21 = V->nb[1];
-    size_t nb22 = V->nb[2];
-    size_t nb23 = V->nb[3];
-
-    if (need_f16_K && K->type != GGML_TYPE_F16) {
-        const size_t bs = ggml_blck_size(K->type);
-        const size_t ts = ggml_type_size(K->type);
-
-        K_f16.alloc(ggml_nelements(K));
-        if (ggml_is_contiguously_allocated(K)) {
-            to_fp16_cuda_t to_fp16 = ggml_get_to_fp16_cuda(K->type);
-            to_fp16(K_data, K_f16.ptr, ggml_nelements(K), main_stream);
-
-            nb11 = nb11*bs*sizeof(half)/ts;
-            nb12 = nb12*bs*sizeof(half)/ts;
-            nb13 = nb13*bs*sizeof(half)/ts;
-        } else {
-            GGML_ASSERT(K->nb[0] == ts);
-            to_fp16_nc_cuda_t to_fp16 = ggml_get_to_fp16_nc_cuda(K->type);
-            const int64_t s01 = nb11 / ts;
-            const int64_t s02 = nb12 / ts;
-            const int64_t s03 = nb13 / ts;
-            to_fp16(K_data, K_f16.ptr, K->ne[0], K->ne[1], K->ne[2], K->ne[3], s01, s02, s03, main_stream);
-
-            nb11 = K->ne[0] * sizeof(half);
-            nb12 = K->ne[1] * nb11;
-            nb13 = K->ne[2] * nb12;
-        }
-        K_data = (char *) K_f16.ptr;
-    }
-
-    if (need_f16_V && V->type != GGML_TYPE_F16) {
-        if (V_is_K_view) {
-            V_data = K_data;
-            nb21   = nb11;
-            nb22   = nb12;
-            nb23   = nb13;
-        } else {
-            const size_t bs = ggml_blck_size(V->type);
-            const size_t ts = ggml_type_size(V->type);
-
-            V_f16.alloc(ggml_nelements(V));
-            if (ggml_is_contiguously_allocated(V)) {
-                to_fp16_cuda_t to_fp16 = ggml_get_to_fp16_cuda(V->type);
-                to_fp16(V_data, V_f16.ptr, ggml_nelements(V), main_stream);
-                V_data = (char *) V_f16.ptr;
-
-                nb21 = nb21*bs*sizeof(half)/ts;
-                nb22 = nb22*bs*sizeof(half)/ts;
-                nb23 = nb23*bs*sizeof(half)/ts;
-            } else {
-                GGML_ASSERT(V->nb[0] == ts);
-                to_fp16_nc_cuda_t to_fp16 = ggml_get_to_fp16_nc_cuda(V->type);
-                const int64_t s01 = nb21 / ts;
-                const int64_t s02 = nb22 / ts;
-                const int64_t s03 = nb23 / ts;
-                to_fp16(V_data, V_f16.ptr, V->ne[0], V->ne[1], V->ne[2], V->ne[3], s01, s02, s03, main_stream);
-
-                nb21 = V->ne[0] * sizeof(half);
-                nb22 = V->ne[1] * nb21;
-                nb23 = V->ne[2] * nb22;
-            }
-            V_data = (char *) V_f16.ptr;
-        }
-    }
-
-    const int ntiles_x     = ((Q->ne[1] + ncols1 - 1) / ncols1);
-    const int gqa_ratio    = Q->ne[2] / K->ne[2];
-    const int ntiles_z_gqa = ((gqa_ratio + ncols2 - 1) / ncols2);
-    const int ntiles_dst   = ntiles_x * ntiles_z_gqa * K->ne[2] * Q->ne[3];
-
-    // Optional optimization where the mask is scanned to determine whether part of the calculation can be skipped.
-    // Only worth the overhead if there is at lease one FATTN_KQ_STRIDE x FATTN_KQ_STRIDE square to be skipped or
-    //     multiple sequences of possibly different lengths.
-    if (mask && K->ne[1] % FATTN_KQ_STRIDE == 0 && (Q->ne[1] >= 1024 || Q->ne[3] > 1)) {
-        const int s31 = mask->nb[1] / sizeof(half2);
-        const int s33 = mask->nb[3] / sizeof(half2);
-
-        const dim3 blocks_num_KV_max(ntiles_x, Q->ne[3], 1);
-        const dim3 block_dim_KV_max(FATTN_KQ_STRIDE/2, 1, 1);
-
-        const int ne_KV_max = blocks_num_KV_max.x*blocks_num_KV_max.y;
-        const int iter_k = K->ne[1] / FATTN_KQ_STRIDE;
-
-        KV_max.alloc(ne_KV_max);
-        flash_attn_mask_to_KV_max<ncols1><<<blocks_num_KV_max, block_dim_KV_max, 0, main_stream>>>
-            ((const half2 *) mask->data, KV_max.ptr, iter_k, s31, s33);
-        CUDA_CHECK(cudaGetLastError());
-    }
-
-    const dim3 block_dim(warp_size, nwarps, 1);
-    int max_blocks_per_sm = 1; // Max. number of active blocks limited by occupancy.
-    CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks_per_sm, fattn_kernel, block_dim.x * block_dim.y * block_dim.z, nbytes_shared));
-    GGML_ASSERT(max_blocks_per_sm > 0);
-    int parallel_blocks = max_blocks_per_sm;
-
-    const int ntiles_KV = (K->ne[1] + nbatch_fa - 1) / nbatch_fa; // Max. number of parallel blocks limited by KV cache length.
-
-    dim3 blocks_num;
-    if (stream_k) {
-        // For short contexts it can be faster to have the SMs work on whole tiles because this lets us skip the fixup.
-        const int max_blocks = max_blocks_per_sm*nsm;
-        const int tiles_nwaves = (ntiles_dst + max_blocks - 1) / max_blocks;
-        const int tiles_efficiency_percent = 100 * ntiles_dst / (max_blocks*tiles_nwaves);
-
-        const int nblocks_stream_k = std::min(max_blocks, ntiles_KV*ntiles_dst);
-
-        const bool use_stream_k = cc >= GGML_CUDA_CC_ADA_LOVELACE || amd_wmma_available(cc) || tiles_efficiency_percent < 75;
-
-        blocks_num.x = use_stream_k ? nblocks_stream_k : ntiles_dst;
-        blocks_num.y = 1;
-        blocks_num.z = 1;
-
-        if (ntiles_dst % blocks_num.x != 0) { // Fixup is only needed if the SMs work on fractional tiles.
-            dst_tmp_meta.alloc((size_t(blocks_num.x) * ncols * (2 + DV/2)));
-        }
-    } else {
-        // parallel_blocks must not be larger than what the tensor size allows:
-        parallel_blocks = std::min(parallel_blocks, ntiles_KV);
-
-        // If ntiles_total % blocks_per_wave != 0 then some efficiency is lost due to tail effects.
-        // Test whether parallel_blocks can be set to a higher value for better efficiency.
-        const int blocks_per_wave = nsm * max_blocks_per_sm;
-        int nwaves_best = 0;
-        int efficiency_percent_best = 0;
-        for (int parallel_blocks_test = parallel_blocks; parallel_blocks_test <= ntiles_KV; ++parallel_blocks_test) {
-            const int nblocks_total = ntiles_dst * parallel_blocks_test;
-            const int nwaves = (nblocks_total + blocks_per_wave - 1) / blocks_per_wave;
-            const int efficiency_percent = 100 * nblocks_total / (nwaves*blocks_per_wave);
-
-            // Stop trying configurations with more waves if we already have good efficiency to avoid excessive overhead.
-            if (efficiency_percent_best >= 95 && nwaves > nwaves_best) {
-                break;
-            }
-
-            if (efficiency_percent > efficiency_percent_best) {
-                nwaves_best = nwaves;
-                efficiency_percent_best = efficiency_percent;
-                parallel_blocks = parallel_blocks_test;
-            }
-        }
-
-        blocks_num.x = ntiles_x;
-        blocks_num.y = parallel_blocks;
-        blocks_num.z = ntiles_z_gqa*K->ne[2]*Q->ne[3];
-
-        if (parallel_blocks > 1) {
-            dst_tmp.alloc(parallel_blocks*ggml_nelements(KQV));
-            dst_tmp_meta.alloc(parallel_blocks*ggml_nrows(KQV));
-        }
-    }
+    // --- Shared setup (used by both paths) ---
 
     float scale         = 1.0f;
     float max_bias      = 0.0f;
@@ -1395,41 +1315,348 @@ void launch_fattn(
     // TODO other tensor dimensions after removal of WMMA kernel:
     const uint3 ne01 = init_fastdiv_values(Q->ne[1]);
 
-    GGML_ASSERT(block_dim.x % warp_size == 0);
-    fattn_kernel<<<blocks_num, block_dim, nbytes_shared, main_stream>>>(
-        (const char *) Q->data,
-        K_data,
-        V_data,
-        mask ? ((const char *) mask->data) : nullptr,
-        sinks ? ((const char *) sinks->data) : nullptr,
-        KV_max.ptr,
-        !stream_k && parallel_blocks > 1 ? dst_tmp.ptr : (float *) KQV->data, dst_tmp_meta.ptr,
-        scale, max_bias, m0, m1, n_head_log2, logit_softcap,
-        Q->ne[0], ne01,     Q->ne[2], Q->ne[3], Q->nb[1], Q->nb[2], Q->nb[3],
-        K->ne[0], K->ne[1], K->ne[2], K->ne[3], nb11, nb12, nb13,
-        nb21, nb22, nb23,
-        mask ? mask->ne[1] : 0, mask ? mask->ne[2] : 0, mask ? mask->ne[3] : 0,
-        mask ? mask->nb[1] : 0, mask ? mask->nb[2] : 0, mask ? mask->nb[3] : 0
-    );
-    CUDA_CHECK(cudaGetLastError());
+    const int ntiles_x     = ((Q->ne[1] + ncols1 - 1) / ncols1);
+    const int gqa_ratio    = Q->ne[2] / K->ne[2];
+    const int ntiles_z_gqa = ((gqa_ratio + ncols2 - 1) / ncols2);
+    const int ntiles_dst   = ntiles_x * ntiles_z_gqa * K->ne[2] * Q->ne[3];
 
-    if (stream_k) {
-        if (ntiles_dst % blocks_num.x != 0) { // Fixup is only needed if the SMs work on fractional tiles.
-            const dim3 block_dim_combine(DV, 1, 1);
-            const dim3 blocks_num_combine = {blocks_num.x, ncols1, ncols2};
+    const dim3 block_dim(warp_size, nwarps, 1);
+    int max_blocks_per_sm = 1;
+    CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks_per_sm, fattn_kernel, block_dim.x * block_dim.y * block_dim.z, nbytes_shared));
+    GGML_ASSERT(max_blocks_per_sm > 0);
 
-            flash_attn_stream_k_fixup<DV, ncols1, ncols2>
-                <<<blocks_num_combine, block_dim_combine, 0, main_stream>>>
-                ((float *) KQV->data, dst_tmp_meta.ptr, Q->ne[1], Q->ne[2], Q->ne[3], K->ne[1], K->ne[2], nbatch_fa);
+    // Lambda that fires the fattn kernel with a given KV slice and output location, avoiding
+    // repetition of the long parameter list between the fast path and the batched path.
+    auto do_kernel_call = [&](
+            const char * kd, const char * vd,
+            int64_t kne1,
+            size_t nb11, size_t nb12, size_t nb13,
+            size_t nb21, size_t nb22, size_t nb23,
+            const char * mask_ptr,
+            const int  * kv_max_ptr,
+            float      * dst_out,
+            float2     * meta_out,
+            dim3         blk_num) {
+        GGML_ASSERT(block_dim.x % warp_size == 0);
+        fattn_kernel<<<blk_num, block_dim, nbytes_shared, main_stream>>>(
+            (const char *) Q->data,
+            kd,
+            vd,
+            mask_ptr,
+            sinks ? ((const char *) sinks->data) : nullptr,
+            kv_max_ptr,
+            dst_out, meta_out,
+            scale, max_bias, m0, m1, n_head_log2, logit_softcap,
+            Q->ne[0], ne01,  Q->ne[2], Q->ne[3], Q->nb[1], Q->nb[2], Q->nb[3],
+            K->ne[0], kne1,  K->ne[2], K->ne[3], nb11, nb12, nb13,
+            nb21, nb22, nb23,
+            mask ? (int)mask->ne[1] : 0, mask ? (int)mask->ne[2] : 0, mask ? (int)mask->ne[3] : 0,
+            mask ? mask->nb[1] : 0,      mask ? mask->nb[2] : 0,      mask ? mask->nb[3] : 0
+        );
+        CUDA_CHECK(cudaGetLastError());
+    };
+
+    if (!use_kv_batching) {
+        // ---- Fast path: convert K/V upfront (full tensor), then launch with full optimisations ----
+
+        ggml_cuda_pool_alloc<half>   K_f16(pool);
+        ggml_cuda_pool_alloc<half>   V_f16(pool);
+        ggml_cuda_pool_alloc<int>    KV_max(pool);
+        ggml_cuda_pool_alloc<float>  dst_tmp(pool);
+        ggml_cuda_pool_alloc<float2> dst_tmp_meta(pool);
+
+        const char * K_data = (const char *) K->data;
+        size_t nb11 = K->nb[1];
+        size_t nb12 = K->nb[2];
+        size_t nb13 = K->nb[3];
+
+        const char * V_data = (const char *) V->data;
+        size_t nb21 = V->nb[1];
+        size_t nb22 = V->nb[2];
+        size_t nb23 = V->nb[3];
+
+        if (need_f16_K && K->type != GGML_TYPE_F16) {
+            const size_t bs = ggml_blck_size(K->type);
+            const size_t ts = ggml_type_size(K->type);
+
+            K_f16.alloc(ggml_nelements(K));
+            if (ggml_is_contiguously_allocated(K)) {
+                to_fp16_cuda_t to_fp16 = ggml_get_to_fp16_cuda(K->type);
+                to_fp16(K_data, K_f16.ptr, ggml_nelements(K), main_stream);
+
+                nb11 = nb11*bs*sizeof(half)/ts;
+                nb12 = nb12*bs*sizeof(half)/ts;
+                nb13 = nb13*bs*sizeof(half)/ts;
+            } else {
+                GGML_ASSERT(K->nb[0] == ts);
+                to_fp16_nc_cuda_t to_fp16 = ggml_get_to_fp16_nc_cuda(K->type);
+                const int64_t s01 = nb11 / ts;
+                const int64_t s02 = nb12 / ts;
+                const int64_t s03 = nb13 / ts;
+                to_fp16(K_data, K_f16.ptr, K->ne[0], K->ne[1], K->ne[2], K->ne[3], s01, s02, s03, main_stream);
+
+                nb11 = K->ne[0] * sizeof(half);
+                nb12 = K->ne[1] * nb11;
+                nb13 = K->ne[2] * nb12;
+            }
+            K_data = (char *) K_f16.ptr;
         }
-    } else if (parallel_blocks > 1) {
+
+        if (need_f16_V && V->type != GGML_TYPE_F16) {
+            if (V_is_K_view) {
+                V_data = K_data;
+                nb21   = nb11;
+                nb22   = nb12;
+                nb23   = nb13;
+            } else {
+                const size_t bs = ggml_blck_size(V->type);
+                const size_t ts = ggml_type_size(V->type);
+
+                V_f16.alloc(ggml_nelements(V));
+                if (ggml_is_contiguously_allocated(V)) {
+                    to_fp16_cuda_t to_fp16 = ggml_get_to_fp16_cuda(V->type);
+                    to_fp16(V_data, V_f16.ptr, ggml_nelements(V), main_stream);
+                    V_data = (char *) V_f16.ptr;
+
+                    nb21 = nb21*bs*sizeof(half)/ts;
+                    nb22 = nb22*bs*sizeof(half)/ts;
+                    nb23 = nb23*bs*sizeof(half)/ts;
+                } else {
+                    GGML_ASSERT(V->nb[0] == ts);
+                    to_fp16_nc_cuda_t to_fp16 = ggml_get_to_fp16_nc_cuda(V->type);
+                    const int64_t s01 = nb21 / ts;
+                    const int64_t s02 = nb22 / ts;
+                    const int64_t s03 = nb23 / ts;
+                    to_fp16(V_data, V_f16.ptr, V->ne[0], V->ne[1], V->ne[2], V->ne[3], s01, s02, s03, main_stream);
+
+                    nb21 = V->ne[0] * sizeof(half);
+                    nb22 = V->ne[1] * nb21;
+                    nb23 = V->ne[2] * nb22;
+                }
+                V_data = (char *) V_f16.ptr;
+            }
+        }
+
+        // Optional optimization where the mask is scanned to determine whether part of the calculation can be skipped.
+        // Only worth the overhead if there is at lease one FATTN_KQ_STRIDE x FATTN_KQ_STRIDE square to be skipped or
+        //     multiple sequences of possibly different lengths.
+        if (mask && K->ne[1] % FATTN_KQ_STRIDE == 0 && (Q->ne[1] >= 1024 || Q->ne[3] > 1)) {
+            const int s31 = mask->nb[1] / sizeof(half2);
+            const int s33 = mask->nb[3] / sizeof(half2);
+
+            const dim3 blocks_num_KV_max(ntiles_x, Q->ne[3], 1);
+            const dim3 block_dim_KV_max(FATTN_KQ_STRIDE/2, 1, 1);
+
+            const int ne_KV_max = blocks_num_KV_max.x*blocks_num_KV_max.y;
+            const int iter_k = K->ne[1] / FATTN_KQ_STRIDE;
+
+            KV_max.alloc(ne_KV_max);
+            flash_attn_mask_to_KV_max<ncols1><<<blocks_num_KV_max, block_dim_KV_max, 0, main_stream>>>
+                ((const half2 *) mask->data, KV_max.ptr, iter_k, s31, s33);
+            CUDA_CHECK(cudaGetLastError());
+        }
+
+        int parallel_blocks = max_blocks_per_sm;
+        const int ntiles_KV = (K->ne[1] + nbatch_fa - 1) / nbatch_fa;
+
+        dim3 blocks_num;
+        if (stream_k) {
+            // For short contexts it can be faster to have the SMs work on whole tiles because this lets us skip the fixup.
+            const int max_blocks = max_blocks_per_sm*nsm;
+            const int tiles_nwaves = (ntiles_dst + max_blocks - 1) / max_blocks;
+            const int tiles_efficiency_percent = 100 * ntiles_dst / (max_blocks*tiles_nwaves);
+
+            const int nblocks_stream_k = std::min(max_blocks, ntiles_KV*ntiles_dst);
+
+            const bool use_stream_k = cc >= GGML_CUDA_CC_ADA_LOVELACE || amd_wmma_available(cc) || tiles_efficiency_percent < 75;
+
+            blocks_num.x = use_stream_k ? nblocks_stream_k : ntiles_dst;
+            blocks_num.y = 1;
+            blocks_num.z = 1;
+
+            if (ntiles_dst % blocks_num.x != 0) { // Fixup is only needed if the SMs work on fractional tiles.
+                dst_tmp_meta.alloc((size_t(blocks_num.x) * ncols * (2 + DV/2)));
+            }
+        } else {
+            // parallel_blocks must not be larger than what the tensor size allows:
+            parallel_blocks = std::min(parallel_blocks, ntiles_KV);
+
+            // If ntiles_total % blocks_per_wave != 0 then some efficiency is lost due to tail effects.
+            // Test whether parallel_blocks can be set to a higher value for better efficiency.
+            const int blocks_per_wave = nsm * max_blocks_per_sm;
+            int nwaves_best = 0;
+            int efficiency_percent_best = 0;
+            for (int parallel_blocks_test = parallel_blocks; parallel_blocks_test <= ntiles_KV; ++parallel_blocks_test) {
+                const int nblocks_total = ntiles_dst * parallel_blocks_test;
+                const int nwaves = (nblocks_total + blocks_per_wave - 1) / blocks_per_wave;
+                const int efficiency_percent = 100 * nblocks_total / (nwaves*blocks_per_wave);
+
+                // Stop trying configurations with more waves if we already have good efficiency to avoid excessive overhead.
+                if (efficiency_percent_best >= 95 && nwaves > nwaves_best) {
+                    break;
+                }
+
+                if (efficiency_percent > efficiency_percent_best) {
+                    nwaves_best = nwaves;
+                    efficiency_percent_best = efficiency_percent;
+                    parallel_blocks = parallel_blocks_test;
+                }
+            }
+
+            blocks_num.x = ntiles_x;
+            blocks_num.y = parallel_blocks;
+            blocks_num.z = ntiles_z_gqa*K->ne[2]*Q->ne[3];
+
+            if (parallel_blocks > 1) {
+                dst_tmp.alloc(parallel_blocks*ggml_nelements(KQV));
+                dst_tmp_meta.alloc(parallel_blocks*ggml_nrows(KQV));
+            }
+        }
+
+        do_kernel_call(
+            K_data, V_data, K->ne[1],
+            nb11, nb12, nb13,
+            nb21, nb22, nb23,
+            mask ? ((const char *) mask->data) : nullptr,
+            KV_max.ptr,
+            !stream_k && parallel_blocks > 1 ? dst_tmp.ptr : (float *) KQV->data,
+            dst_tmp_meta.ptr,
+            blocks_num
+        );
+
+        if (stream_k) {
+            if (ntiles_dst % blocks_num.x != 0) { // Fixup is only needed if the SMs work on fractional tiles.
+                const dim3 block_dim_combine(DV, 1, 1);
+                const dim3 blocks_num_combine = {blocks_num.x, ncols1, ncols2};
+
+                flash_attn_stream_k_fixup<DV, ncols1, ncols2>
+                    <<<blocks_num_combine, block_dim_combine, 0, main_stream>>>
+                    ((float *) KQV->data, dst_tmp_meta.ptr, Q->ne[1], Q->ne[2], Q->ne[3], K->ne[1], K->ne[2], nbatch_fa);
+            }
+        } else if (parallel_blocks > 1) {
+            const dim3 block_dim_combine(DV, 1, 1);
+            const dim3 blocks_num_combine(Q->ne[1], Q->ne[2], Q->ne[3]);
+            const size_t nbytes_shared_combine = parallel_blocks*sizeof(float2);
+
+            flash_attn_combine_results<DV>
+                <<<blocks_num_combine, block_dim_combine, nbytes_shared_combine, main_stream>>>
+                (dst_tmp.ptr, dst_tmp_meta.ptr, (float *) KQV->data, parallel_blocks);
+        }
+        CUDA_CHECK(cudaGetLastError());
+
+    } else {
+        // ---- Batched-conversion path ----
+        // Convert K/V in slices of FATTN_KV_CONV_BATCH tokens so that the pool allocation for
+        // the f16 buffers is bounded regardless of how large the KV cache grows.
+        // stream_k and the parallel_blocks optimisation are not used here to keep the partial
+        // result layout simple; each batch produces exactly one partial result per query row.
+        // KV_max is also skipped since last-batch alignment is non-trivial and the optimisation
+        // matters less for quantised types that trigger this path.
+
+        const int64_t kv_total  = K->ne[1];
+        const int64_t n_batches = (kv_total + FATTN_KV_CONV_BATCH - 1) / FATTN_KV_CONV_BATCH;
+        // Conversion buffer capacity: enough for the largest possible batch.
+        const int64_t kv_cap    = std::min((int64_t)FATTN_KV_CONV_BATCH, kv_total);
+
+        // Capped f16 conversion buffers — allocated once before the loop so the pool entry stays
+        // at this bounded size and is reused for every iteration.
+        ggml_cuda_pool_alloc<half> K_f16_batch(pool);
+        ggml_cuda_pool_alloc<half> V_f16_batch(pool);
+        if (need_conv_K) {
+            K_f16_batch.alloc(kv_cap * K->ne[0] * K->ne[2] * K->ne[3]);
+        }
+        if (need_conv_V) {
+            V_f16_batch.alloc(kv_cap * V->ne[0] * V->ne[2] * V->ne[3]);
+        }
+
+        // Two fixed-size partial-result buffers: acc (running accumulation) + tmp (current batch).
+        // Both scale with Q dimensions only, so pool usage is bounded regardless of KV length.
+        // Contrast with allocating n_batches slots upfront, which would scale as O(kv_len).
+        const int n_rows = ggml_nrows(KQV);
+        ggml_cuda_pool_alloc<float>  acc_parts(pool);
+        ggml_cuda_pool_alloc<float2> acc_meta(pool);
+        ggml_cuda_pool_alloc<float>  tmp_parts(pool);
+        ggml_cuda_pool_alloc<float2> tmp_meta(pool);
+        acc_parts.alloc(ggml_nelements(KQV));
+        acc_meta.alloc(n_rows);
+        tmp_parts.alloc(ggml_nelements(KQV));
+        tmp_meta.alloc(n_rows);
+
+        // One partial result per query row per batch; no within-batch KV parallelism (y dim = 1).
+        const dim3 batch_blocks(ntiles_x, 1, ntiles_z_gqa * K->ne[2] * Q->ne[3]);
         const dim3 block_dim_combine(DV, 1, 1);
         const dim3 blocks_num_combine(Q->ne[1], Q->ne[2], Q->ne[3]);
-        const size_t nbytes_shared_combine = parallel_blocks*sizeof(float2);
 
+        // Build the K and V slice pointers/strides for one batch and fire the kernel.
+        auto do_batch = [&](int64_t b, float * dst_out, float2 * meta_out) {
+            const int64_t kv_start = b * FATTN_KV_CONV_BATCH;
+            const int64_t kv_count = std::min((int64_t)FATTN_KV_CONV_BATCH, kv_total - kv_start);
+
+            const char * K_slice;
+            size_t knb11, knb12, knb13;
+            if (need_conv_K) {
+                convert_kv_to_f16_slice(
+                    (const char *) K->data, K_f16_batch.ptr, K->type,
+                    K->ne[0], kv_start, kv_count, K->ne[2], K->ne[3],
+                    K->nb[1], K->nb[2], K->nb[3], main_stream);
+                K_slice = (const char *) K_f16_batch.ptr;
+                knb11 = K->ne[0] * sizeof(half);
+                knb12 = kv_count * knb11;
+                knb13 = K->ne[2] * knb12;
+            } else {
+                K_slice = (const char *) K->data + kv_start * K->nb[1];
+                knb11 = K->nb[1]; knb12 = K->nb[2]; knb13 = K->nb[3];
+            }
+
+            const char * V_slice;
+            size_t vnb21, vnb22, vnb23;
+            if (V_is_K_view) {
+                V_slice = K_slice;
+                vnb21 = knb11; vnb22 = knb12; vnb23 = knb13;
+            } else if (need_conv_V) {
+                convert_kv_to_f16_slice(
+                    (const char *) V->data, V_f16_batch.ptr, V->type,
+                    V->ne[0], kv_start, kv_count, V->ne[2], V->ne[3],
+                    V->nb[1], V->nb[2], V->nb[3], main_stream);
+                V_slice = (const char *) V_f16_batch.ptr;
+                vnb21 = V->ne[0] * sizeof(half);
+                vnb22 = kv_count * vnb21;
+                vnb23 = V->ne[2] * vnb22;
+            } else {
+                V_slice = (const char *) V->data + kv_start * V->nb[1];
+                vnb21 = V->nb[1]; vnb22 = V->nb[2]; vnb23 = V->nb[3];
+            }
+
+            // Offset the mask into the KV slice (mask->nb[0] == sizeof(half) for an f16 mask).
+            const char * mask_ptr = mask ? (const char *) mask->data + kv_start * mask->nb[0] : nullptr;
+
+            do_kernel_call(
+                K_slice, V_slice, kv_count,
+                knb11, knb12, knb13, vnb21, vnb22, vnb23,
+                mask_ptr, nullptr,  // KV_max not used in batched path
+                dst_out, meta_out,
+                batch_blocks
+            );
+        };
+
+        // Batch 0 goes straight into the accumulator.
+        do_batch(0, acc_parts.ptr, acc_meta.ptr);
+
+        // Each subsequent batch is written to tmp, then merged into acc in-place.
+        for (int64_t b = 1; b < n_batches; ++b) {
+            do_batch(b, tmp_parts.ptr, tmp_meta.ptr);
+
+            flash_attn_combine2_inplace<DV>
+                <<<blocks_num_combine, block_dim_combine, 0, main_stream>>>
+                (acc_parts.ptr, acc_meta.ptr, tmp_parts.ptr, tmp_meta.ptr);
+            CUDA_CHECK(cudaGetLastError());
+        }
+
+        // Normalise: divide the accumulated unnormalized numerators by their denominators.
+        // flash_attn_combine_results with parallel_blocks=1 reads acc_parts[j*D+tid] / acc_meta[j].y.
         flash_attn_combine_results<DV>
-            <<<blocks_num_combine, block_dim_combine, nbytes_shared_combine, main_stream>>>
-            (dst_tmp.ptr, dst_tmp_meta.ptr, (float *) KQV->data, parallel_blocks);
+            <<<blocks_num_combine, block_dim_combine, sizeof(float2), main_stream>>>
+            (acc_parts.ptr, acc_meta.ptr, (float *) KQV->data, 1);
+        CUDA_CHECK(cudaGetLastError());
     }
-    CUDA_CHECK(cudaGetLastError());
 }

--- a/ggml/src/ggml-cuda/fattn-tile.cuh
+++ b/ggml/src/ggml-cuda/fattn-tile.cuh
@@ -1069,7 +1069,7 @@ static __global__ void flash_attn_tile(
             return;
         }
 
-        const float scale = gridDim.y == 1 ? 1.0f/KQ_sum[jc0] : 1.0f;
+        const float scale = dst_meta == nullptr ? 1.0f/KQ_sum[jc0] : 1.0f;
 
         const int j_dst_unrolled = ((sequence*int(ne01.z) + col_Q_0 + j)*ne02 + head0 + c)*gridDim.y + blockIdx.y;
 
@@ -1105,7 +1105,7 @@ static __global__ void flash_attn_tile(
         }
 #endif // FAST_FP16_AVAILABLE
 
-        if (gridDim.y != 1 && threadIdx.x == 0) {
+        if (dst_meta != nullptr && threadIdx.x == 0) {
             dst_meta[j_dst_unrolled] = make_float2(KQ_max[jc0], KQ_sum[jc0]);
         }
     }

--- a/ggml/src/ggml-cuda/fattn-vec.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec.cuh
@@ -278,7 +278,7 @@ static __global__ void flash_attn_ext_vec(
                 }
 
                 if (mask && (ncols == 1 || ic0 + j < int(ne01.z))) {
-                    sum += slope*__half2float(maskh[j*ne11 + i_KQ]);
+                    sum += slope*__half2float(maskh[j*(nb31/(int32_t)sizeof(half)) + i_KQ]);
                 }
 
                 KQ_max_new[j] = fmaxf(KQ_max_new[j], sum + FATTN_KQ_MAX_OFFSET);

--- a/ggml/src/ggml-cuda/fattn-vec.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec.cuh
@@ -519,7 +519,7 @@ static __global__ void flash_attn_ext_vec(
                         dst_val += float(KQ[w*V_cols_per_iter*D + v*D + i0 + tid]);
                     }
                 }
-                if (gridDim.y == 1) {
+                if (dst_meta == nullptr) {
                     dst_val /= KQ_sum[j_VKQ];
                 }
                 dst[(((sequence*int(ne01.z) + ic0 + j_VKQ)*ne02 + head)*gridDim.y + blockIdx.y)*D + i0 + tid] = dst_val;
@@ -532,7 +532,7 @@ static __global__ void flash_attn_ext_vec(
 
     }
 
-    if (gridDim.y != 1 && tid < ncols && (ncols == 1 || ic0 + tid < int(ne01.z))) {
+    if (dst_meta != nullptr && tid < ncols && (ncols == 1 || ic0 + tid < int(ne01.z))) {
         dst_meta[((sequence*int(ne01.z) + ic0 + tid)*ne02 + head)*gridDim.y + blockIdx.y] = make_float2(KQ_max[tid], KQ_sum[tid]);
     }
 #else

--- a/ggml/src/ggml-cuda/fattn-wmma-f16.cu
+++ b/ggml/src/ggml-cuda/fattn-wmma-f16.cu
@@ -473,13 +473,13 @@ static __global__ void flash_attn_ext_f16(
                 break;
             }
             float dst_val = VKQ[j_VKQ*D_padded + i];
-            if (gridDim.y == 1) {
+            if (dst_meta == nullptr) {
                 dst_val /= KQ_rowsum_j;
             }
             dst[j_dst_unrolled*D + i] = dst_val;
         }
 
-        if (gridDim.y == 1 || threadIdx.x != 0) {
+        if (dst_meta == nullptr || threadIdx.x != 0) {
             continue;
         }
 


### PR DESCRIPTION
## Overview

Fixes unbounded VRAM usage growth when using flash attention and quantized kv cache types on HIP/ROCm with RDNA3 architecture (and possibly more)

## Additional details

This PR batches flash attention kernel invocation with a fixed size batch when quantized kv cache types are used. Without this change, the kernels would increasingly allocate more vram as they require the entire kv cache to be dequantized to f16 types. A compounding problem existed when using the legacy memory pool ggml_cuda_pool_leg (e.g. when using HIP with at least RDNA3). The memory pool allocates fragments of a fixed size, and allocation requests use a best-fit algorithm. Allocation requests that don't fit into any of the existing individual fragments trigger allocation of a new fragment. The pool never deallocates fragments until the pool itself is destructed. Due to the ever-growing sizes of the allocation requests, new allocations would not fit in a previously created fragment, thus another new fragment would be allocated. This rapidly consumes more and more vram, completely cancelling out any benefit to be had from using quantized kv cache types for non-synthetic workloads.

The VEC flash attention kernel solves this by dequantizing the kv cache entries one by one instead of all in advance. Simple, however, this has a very significant impact on prompt processing speed (easily ~50% reduction compared to the other kernels like TILE). While this does completely solve the growing vram usage problem, the performance impact is not acceptable.

Thus, I chose a hybrid solution where we don't fall back to slow VEC, but instead the flash attention kernel calls are batched with a maximum batch size if quantized kv types are used. The code will choose the previous unbatched path for maximum performance if batching is not required. Benchmarks show that prompt processing speeds for a 30k prompt and turbo3 k/v types are ~700 tokens per seconds, versus ~3xx tokens/sec when using the VEC kernel. VRAM usage stays stable, also tested with a 120k bench that shows 0 new allocations after prompt processing starts.

Token generation speed should be unaffected by these changes.

This SHOULD work on the other flash attention kernels as well, but I did not test this.

Passed basic coding challenge using opencode against llama-server with turbo3/turbo3 k/v quants

Tested on an arch linux system with a 7900 XTX/24GB and rocm-7.2.1

## Benchmarks

Before changes:

```
VRAM flat at 18024
| qwen35 27B Q4_K - Medium       |  15.39 GiB |    26.90 B | ROCm       | 100 |  1 |         pp30000 |        697.66 ± 0.00 |
| qwen35 27B Q4_K - Medium       |  15.39 GiB |    26.90 B | ROCm       | 100 |  1 |           tg128 |         28.81 ± 0.00 |

VRAM grows steadily during run to 17856, will keep increasing with longer prompts
| qwen35 27B Q4_K - Medium       |  15.39 GiB |    26.90 B | ROCm       | 100 |   q8_0 |   q8_0 |  1 |         pp30000 |        697.05 ± 0.00 |
| qwen35 27B Q4_K - Medium       |  15.39 GiB |    26.90 B | ROCm       | 100 |   q8_0 |   q8_0 |  1 |           tg128 |         28.35 ± 0.00 |

VRAM grows steadily during run to 17222, will keep increasing with longer prompts
| qwen35 27B Q4_K - Medium       |  15.39 GiB |    26.90 B | ROCm       | 100 | turbo3 | turbo3 |  1 |         pp30000 |        695.24 ± 0.00 |
| qwen35 27B Q4_K - Medium       |  15.39 GiB |    26.90 B | ROCm       | 100 | turbo3 | turbo3 |  1 |           tg128 |         28.18 ± 0.00 |
```

```
After changes:
```
VRAM flat at 18024
| qwen35 27B Q4_K - Medium       |  15.39 GiB |    26.90 B | ROCm       | 100 |  1 |         pp30000 |        695.04 ± 0.00 |
| qwen35 27B Q4_K - Medium       |  15.39 GiB |    26.90 B | ROCm       | 100 |  1 |           tg128 |         27.92 ± 0.00 |

VRAM usage stable at 17124MB
| qwen35 27B Q4_K - Medium       |  15.39 GiB |    26.90 B | ROCm       | 100 |   q8_0 |   q8_0 |  1 |         pp30000 |        698.56 ± 0.00 |
| qwen35 27B Q4_K - Medium       |  15.39 GiB |    26.90 B | ROCm       | 100 |   q8_0 |   q8_0 |  1 |           tg128 |         28.82 ± 0.00 |

VRAM stable at 16508MB
| qwen35 27B Q4_K - Medium       |  15.39 GiB |    26.90 B | ROCm       | 100 | turbo3 | turbo3 |  1 |         pp30000 |        675.35 ± 0.00 |
| qwen35 27B Q4_K - Medium       |  15.39 GiB |    26.90 B | ROCm       | 100 | turbo3 | turbo3 |  1 |           tg128 |         27.47 ± 0.00 |
```



- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, used claude to assist finding the problem, and prototype solutions
