### PR TITLE
fix(cuda): allow f16/bf16 + q8_0 KV without GGML_CUDA_FA_ALL_QUANTS

### DIFF
--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -419,11 +419,14 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
 
 #ifndef GGML_CUDA_FA_ALL_QUANTS
     if (K->type != V->type) {
-        // Allow mixed turbo KV types (any combination of turbo2, turbo3, q8_0)
-        auto is_turbo = [](ggml_type t) {
-            return t == GGML_TYPE_TURBO2_0 || t == GGML_TYPE_TURBO3_0 || t == GGML_TYPE_TURBO4_0 || t == GGML_TYPE_Q8_0;
+        // Allow mixed KV types for combinations that have FA template instances compiled in:
+        // - turbo2/3/4 + q8_0 (turbo cache work)
+        // - f16/bf16 + q8_0 (common K=f16, V=q8_0 setup)
+        auto is_kv_compat = [](ggml_type t) {
+            return t == GGML_TYPE_TURBO2_0 || t == GGML_TYPE_TURBO3_0 || t == GGML_TYPE_TURBO4_0
+                || t == GGML_TYPE_Q8_0 || t == GGML_TYPE_F16 || t == GGML_TYPE_BF16;
         };
-        if (!is_turbo(K->type) || !is_turbo(V->type)) {
+        if (!is_kv_compat(K->type) || !is_kv_compat(V->type)) {
             return BEST_FATTN_KERNEL_NONE;
         }
     }


### PR DESCRIPTION
## Summary
Fixes CUDA flash attention dispatcher rejecting `K=f16, V=q8_0` (and similar mixed combos) when not built with `-DGGML_CUDA_FA_ALL_QUANTS=ON`, causing CPU fallback.

## Background
Reported by @dentity007 on the discussions: turbo3/turbo4/q8_0 KV configs falling back to CPU on RTX 4090 (sm_89) and DGX Spark GB10 (sm_121). Confirmed via 0% GPU utilization and 340x slowdown (1696 → 4.98 t/s on pp8192 when switching V from f16 to q8_0).

## Root cause
The fork added a carve-out for turbo+q8_0 mixed KV in `fattn.cu`, but the predicate was too narrow:

```cpp
auto is_turbo = [](ggml_type t) {
    return t == GGML_TYPE_TURBO2_0 || ... || t == GGML_TYPE_Q8_0;
};
if (!is_turbo(K->type) || !is_turbo(V->type)) {
    return BEST_FATTN_KERNEL_NONE;  // ← f16/q8_0 falls through here
}
```

`f16` and `bf16` aren't in the set, so common `K=f16, V=q8_0` configs return `KERNEL_NONE` and get punted to CPU — even though the FA template instances `fattn-vec-instance-{f16,bf16}-q8_0.cu` are already compiled in.

## Fix
Extend the predicate to include `f16` and `bf16`. One-line addition; no kernel changes; no template instance changes.

## Testing
- [x] Builds clean on Metal
- [ ] @dentity007 — could you cherry-pick this onto your build and re-test the q8_0/turbo3/turbo4 KV combos on sm_89 (4090) and sm_121 (GB10)? Should now run on GPU without `-DGGML_CUDA_FA_ALL_QUANTS=ON`.
- [ ] Coherence + throughput sanity on CUDA (any volunteer welcome)

## Workaround (if you need it now)
Add `-DGGML_CUDA_FA_ALL_QUANTS=ON` to the cmake command. This compiles the full matrix of FA quant combinations and bypasses the dispatcher gate. Costs longer build time + larger binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)