### PR TITLE
fix nix build: Add spirv-headers to vulkanBuildInputs

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -16,6 +16,7 @@
   rocmPackages,
   vulkan-headers,
   vulkan-loader,
+  spirv-headers,
   openssl,
   shaderc,
   useBlas ?
@@ -102,6 +103,7 @@ let
     vulkan-headers
     vulkan-loader
     shaderc
+    spirv-headers
   ];
 in
 


### PR DESCRIPTION
ref: https://github.com/TheTom/llama-cpp-turboquant/issues/81

spirv-headers were introduced by https://github.com/TheTom/llama-cpp-turboquant/commit/1f30ac0ceac0e2b4400069d81857089b6e04872a

but not added to the nix build environment

closes: https://github.com/TheTom/llama-cpp-turboquant/issues/81