### PR TITLE
fix(metal): add turbo2/3/4 types to FLASH_ATTN_EXT and CPY support ch…

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1221,6 +1221,9 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
                 case GGML_TYPE_Q4_1:
                 case GGML_TYPE_Q5_0:
                 case GGML_TYPE_Q5_1:
+                case GGML_TYPE_TURBO2_0:
+                case GGML_TYPE_TURBO3_0:
+                case GGML_TYPE_TURBO4_0:
                     break;
                 case GGML_TYPE_BF16:
                     if (!has_bfloat) {
@@ -1264,6 +1267,9 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
                            case GGML_TYPE_Q5_1:
                            case GGML_TYPE_IQ4_NL:
                            case GGML_TYPE_I32:
+                           case GGML_TYPE_TURBO2_0:
+                           case GGML_TYPE_TURBO3_0:
+                           case GGML_TYPE_TURBO4_0:
                                 return true;
                            default:
                                 return false;


### PR DESCRIPTION
**Fix: Enable GPU offloading for TurboQuant KV cache types in Metal backend**

*   **Issue:** `GGML_OP_FLASH_ATTN_EXT` and `GGML_OP_CPY` were falling back to the CPU for TurboQuant KV cache types due to missing support in the Metal backend's `supports_op` check.
*   **Solution:** Updated `ggml/src/ggml-metal/ggml-metal-device.m` to explicitly support the following types for these operations:
    *   `GGML_TYPE_TURBO2_0`
    *   `GGML_TYPE_TURBO3_0`
    *   `GGML_TYPE_TURBO4_0`
*   **Result:** Operations are now correctly offloaded to the GPU.
*   **Verification:** The project builds successfully with these changes.