### PR TITLE
(fix) Add missing async quants to hip cmake

### DIFF
--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -85,14 +85,17 @@ else()
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo3_0-turbo3_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo3_0-q8_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-q8_0-turbo3_0.cu
+        ../ggml-cuda/template-instances/fattn-vec-instance-f16-turbo3_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo2_0-turbo2_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo2_0-q8_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-q8_0-turbo2_0.cu
+        ../ggml-cuda/template-instances/fattn-vec-instance-f16-turbo2_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo3_0-turbo2_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo2_0-turbo3_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo4_0-turbo4_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo4_0-q8_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-q8_0-turbo4_0.cu
+        ../ggml-cuda/template-instances/fattn-vec-instance-f16-turbo4_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo4_0-turbo3_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo3_0-turbo4_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo4_0-turbo2_0.cu


### PR DESCRIPTION
#84 introduced some new quant types to cuda. Those were not added to the hip version even though they were expected.

Fixes #96

## Overview

Added quant types that were required but missing from hip cmake.
<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
