### PR TITLE
fix(nix): remove duplicate spirv-headers function arg (#81)

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -19,7 +19,6 @@
   spirv-headers,
   openssl,
   shaderc,
-  spirv-headers,
   useBlas ?
     builtins.all (x: !x) [
       useCuda


### PR DESCRIPTION
Fixes #81 — re-reported on current HEAD by @alanscodelog ([comment](https://github.com/TheTom/llama-cpp-turboquant/issues/81)).

`.devops/nix/package.nix` had `spirv-headers` declared twice in the function pattern arglist (line 19 and line 22), causing every nix evaluation to fail at parse time:

```
error: duplicate formal function argument 'spirv-headers'
       at .devops/nix/package.nix:22:3:
           21|   shaderc,
           22|   spirv-headers,
             |   ^
           23|   useBlas ?
```

Two prior fix attempts both added the same line — this PR drops the duplicate.

## Verification

Tested with `nixos/nix:latest` Docker container:

- **Pre-fix:** `nix-instantiate --parse` errors with the exact message above (verified by injecting the duplicate back into a copy of the fixed file).
- **Post-fix:** `nix-instantiate --parse .devops/nix/package.nix` exits 0 and emits the parsed AST. Single `spirv-headers` declaration remains, consumed by `vulkanBuildInputs` and `nativeBuildInputs`.

```
docker run --rm -v "\$PWD:/src" -w /src nixos/nix:latest \
    nix-instantiate --parse .devops/nix/package.nix
# exit 0
```

## Closes

- Closes #81 (re-confirmed alive on HEAD by @alanscodelog)