### PR TITLE
security: cherry-pick CVE-2026-21869 (n_discard heap-buffer-overflow in server)

### DIFF
--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -269,6 +269,7 @@ task_params server_task::params_from_json_cmpl(
     params.n_indent         = json_value(data,       "n_indent",           defaults.n_indent);
     params.n_keep           = json_value(data,       "n_keep",             defaults.n_keep);
     params.n_discard        = json_value(data,       "n_discard",          defaults.n_discard);
+    params.n_discard        = std::max(0, params.n_discard);
     params.n_cmpl           = json_value(data,       "n_cmpl",             json_value(data, "n", 1));
     params.n_cache_reuse    = json_value(data,       "n_cache_reuse",      defaults.n_cache_reuse);
     //params.t_max_prompt_ms  = json_value(data,       "t_max_prompt_ms",    defaults.t_max_prompt_ms); // TODO: implement


### PR DESCRIPTION
## Summary

Cherry-picks the upstream fix for **CVE-2026-21869** (CVSS 8.8 HIGH).

A negative `n_discard` from client JSON causes heap-buffer-overflow in the `update_slots()` context-shift loop (CWE-787). One-line clamp at the JSON parse boundary in `tools/server/server-task.cpp`.

Upstream commit: ggml-org/llama.cpp@c78fb909b (PR ggml-org/llama.cpp#22267, merged Apr 23 2026, by @SongLi-arm and @ggerganov).

## Impact

Affects anyone running `llama-server` from this fork. Single malformed JSON request crashes the server with a heap corruption. Trivially exploitable; no auth required if the server is reachable.

## Changes

- `tools/server/server-task.cpp` — one-line clamp `n_discard = std::max(n_discard, 0)` at JSON parse.

## Test plan

- [x] Local rebuild of `llama-server` target (M5 Max, macOS 26): clean compile, binary launches normally
- [x] Cherry-pick applied with no conflicts (upstream patch is one line, file already exists in fork)
- [ ] (optional) reproduce the crash with a curl POST containing `{"n_discard": -1}` to confirm the fix lands

Recommend merging quickly given the CVSS rating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)