### PR TITLE
fix(perplexity): cast n_ctx * nv to size_t in KL logits save (Qwen3 16K crash)

### DIFF
--- a/tools/perplexity/perplexity.cpp
+++ b/tools/perplexity/perplexity.cpp
@@ -524,7 +524,12 @@ static results_perplexity perplexity(llama_context * ctx, const common_params & 
         logits_stream.write((const char *)&n_chunk, sizeof(n_chunk));
         logits_stream.write((const char *)tokens.data(), n_chunk*n_ctx*sizeof(tokens[0]));
         const int nv = 2*((n_vocab + 1)/2) + 4;
-        log_probs.resize(n_ctx * nv);
+        // size_t cast: int * int overflows on Qwen-class large-vocab models at
+        // n_ctx >= 16K (e.g. n_ctx=16384 * nv=151940 = 2.49B > INT32_MAX=2.15B);
+        // overflow wraps negative, sign-extends to a giant size_t when passed to
+        // resize(), trips vector::max_size and throws std::length_error. Matches
+        // the existing size_t cast on line 514 above for the same reason.
+        log_probs.resize(size_t(n_ctx) * nv);
     }
 
     // We get the logits for all the tokens in the context window (params.n_ctx)


### PR DESCRIPTION
## What this fixes

When `llama-perplexity` is run with `--kl-divergence-base` to save logits for KL-divergence comparison, the `log_probs` vector at `tools/perplexity/perplexity.cpp:527` is sized with an int×int multiplication that can overflow on Qwen3-class large-vocab models at 16K context.

```cpp
// before
log_probs.resize(n_ctx * nv);

// after
log_probs.resize(size_t(n_ctx) * nv);
```

The same `size_t` cast already exists 13 lines above (line 514) for the parallel `logits.reserve(size_t(n_ctx) * n_vocab)` allocation, so this just brings line 527 to the same convention.

## The math

For Qwen3 family (vocab = 151,936):

```
nv          = 2 * ((n_vocab + 1) / 2) + 4 = 151,940
n_ctx * nv  = 16384 * 151,940              = 2,489,610,240
INT32_MAX                                  = 2,147,483,647
                                              ↑ overflow
```

The wrapped negative result sign-extends to a giant `size_t` when passed to `vector::resize`, exceeds `vector::max_size`, and throws.

Smaller-vocab models (≤ ~128K vocab) and shorter context (≤ 8K) don't hit it. Qwen3 family at 16K is the trigger.

## Reproducer (before fix)

Hardware: Apple M5 Max, 128 GB unified memory.
Model: `Qwen3.6-35B-A3B-Q8_0.gguf` (architecture `qwen35moe`).
Build: pre-fix HEAD of `feature/turboquant-kv-cache` (e69af784a).

```bash
llama-perplexity \
  -m Qwen3.6-35B-A3B-Q8_0.gguf \
  -f wiki.test.raw \
  -ctk f16 -ctv f16 \
  -ngl 99 -fa 1 \
  --threads 6 \
  -c 16384 \
  --kl-divergence-base /tmp/baseline.dat
```

Output:
```
perplexity: saving all logits to /tmp/baseline.dat
perplexity: tokenizing the input ..
perplexity: tokenization took 316.362 ms
perplexity: calculating perplexity over 18 chunks, n_ctx=16384, batch_size=2048, n_seq=1
WARNING: Using native backtrace. Set GGML_BACKTRACE_LLDB for more info.
...
libc++abi: terminating due to uncaught exception of type
  std::length_error: vector
```

Stack frame 7 in the backtrace points at `perplexity(llama_context*, common_params const&, int) + 9748`, with `__throw_length_error` two frames above. That offset corresponds to the `log_probs.resize` call at line 527.

## Validation (after fix)

Same command runs to completion; KL divergence and top-token agreement collected for f16, q8_0, and turbo3 KV cache types against wikitext-2-raw at 16K context:

| Cache | PPL              | KL divergence vs f16 | Top-1 agreement |
|-------|------------------|----------------------|-----------------|
| f16   | 5.3513 ± 0.032   | (baseline)           | —               |
| q8_0  | 5.3508 ± 0.032   | 0.001362 ± 2.3e-5    | **98.708%**     |
| turbo3| 5.3907 ± 0.032   | 0.012050 ± 1.4e-4    | **95.293%**     |

Per-test wall: ~190 seconds. Three runs total ~10 minutes.

## Notes

- Mac/Metal build verified end-to-end (compile + run).
- Behavior change is limited to the KL-save code path; non-KL `llama-perplexity` runs are unaffected.
- This is upstream-relevant: the same overflow exists in `ggml-org/llama.cpp:master` since the perplexity tool was synced from upstream. Happy to also push a mirror PR there if useful.

## Demo context

Validating TurboQuant turbo3 KV at 256K context for an enterprise pitch next week. Walked into this bug while running the standard llama.cpp suite-B perplexity bench against Qwen3.6 to quantify the turbo3 quality cost. Without the fix, the KL-save path was unusable on Qwen3 family at any meaningful PPL bench depth.