### PR TITLE
fix(cuda): MTP + sm_89 compatibility for GCC 12 host compiler

### DIFF
--- a/ggml/src/ggml-cuda/CMakeLists.txt
+++ b/ggml/src/ggml-cuda/CMakeLists.txt
@@ -227,7 +227,8 @@ if (CUDAToolkit_FOUND)
         # - speed (nvcc's default)
         # - balance
         # - size
-        list(APPEND CUDA_FLAGS -compress-mode=${GGML_CUDA_COMPRESSION_MODE})
+        # Disabled: -compress-mode causes issues with GCC 12 host compiler
+        # list(APPEND CUDA_FLAGS -compress-mode=${GGML_CUDA_COMPRESSION_MODE})
     endif()
 
     if (GGML_FATAL_WARNINGS)

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -809,7 +809,7 @@ static __device__ __forceinline__ float ggml_cuda_ue4m3_to_fp32(uint8_t x) {
     const __hip_fp8_e4m3_fnuz xf = *reinterpret_cast<const __hip_fp8_e4m3_fnuz *>(&bits);
     return static_cast<float>(xf) / 2;
 #else
-#if defined(FP8_AVAILABLE) && !defined(GGML_USE_HIP)
+#if defined(FP8_AVAILABLE) && !defined(GGML_USE_HIP) && __CUDA_ARCH__ >= 900
     const uint32_t bits = x * (x != 0x7F && x != 0xFF); // Convert NaN to 0.0f to match CPU implementation.
     const __nv_fp8_e4m3 xf = *reinterpret_cast<const __nv_fp8_e4m3 *>(&bits);
     return static_cast<float>(xf) / 2;


### PR DESCRIPTION
## Summary

- **Disable `-compress-mode` flag** — incompatible with GCC 12 host compiler (passed to GCC instead of nvcc)
- **Guard FP8 `__nv_fp8_e4m3` conversion behind `__CUDA_ARCH__ >= 900`** — FP8 PTX instructions require sm_90+, causing build failure on RTX 4060 Ti / Ada Lovelace (sm_89)

## Why

Without these fixes, building with `-DGGML_CUDA=ON` fails on sm_89 GPUs (RTX 4060 Ti, 4070, 4080, 4090) when using GCC 12 as the CUDA host compiler:

1. `gcc-12: error: unrecognized command-line option '-compress-mode=...'`
2. `ptxas: Feature 'cvt with .e4m3x2/.e5m2x2' requires .target sm_90 or higher`

These changes allow llama-server to build successfully with CUDA support on Ada Lovelace GPUs while retaining full MTP (Multi-Token Prediction) support from upstream.