### PR TITLE
vulkan: restore turbo_wht op + turbo3/4 FA dispatch (regression from b9190 upstream sync)

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -847,6 +847,7 @@ struct vk_device_struct {
     vk_pipeline pipeline_timestep_embedding_f32;
     vk_pipeline pipeline_conv_transpose_1d_f32;
     vk_pipeline pipeline_pool2d_f32;
+    vk_pipeline pipeline_turbo_wht;
     vk_pipeline pipeline_rwkv_wkv6_f32;
     vk_pipeline pipeline_rwkv_wkv7_f32;
     // [size_idx][kda] where size_idx: 0=d32, 1=d64, 2=d128
@@ -3654,9 +3655,20 @@ static void ggml_vk_load_shaders(vk_device& device) {
         const bool fa_ds = fa.first.subgroup_size == 0;
 
         const bool use_mmq = ggml_vk_fa_scalar_uses_mmq(device, fa.first.k_type);
+        const bool is_turbo3 = (fa.first.k_type == GGML_TYPE_TURBO3_0);
         const void * spv_data = nullptr;
         size_t spv_size = 0;
-        if (use_mmq) {
+        if (is_turbo3) {
+            // Dedicated SPIR-V built with DATA_A_TURBO3_0: turbo3-only K/V
+            // bindings and per-element centroid dequant. fp32 variant only.
+            if (device->fp16) {
+                if (f32acc) { spv_data = flash_attn_f32_f16_turbo3_0_data;        spv_size = flash_attn_f32_f16_turbo3_0_len; }
+                else        { spv_data = flash_attn_f32_f16_turbo3_0_f16acc_data; spv_size = flash_attn_f32_f16_turbo3_0_f16acc_len; }
+            } else {
+                spv_data = flash_attn_f32_f16_turbo3_0_fp32_data;
+                spv_size = flash_attn_f32_f16_turbo3_0_fp32_len;
+            }
+        } else if (use_mmq) {
 #if defined(GGML_VULKAN_INTEGER_DOT_GLSLC_SUPPORT)
             if (device->fp16) {
                 if (f32acc) { spv_data = flash_attn_f32_f16_int8_data;        spv_size = flash_attn_f32_f16_int8_len; }
@@ -3692,9 +3704,14 @@ static void ggml_vk_load_shaders(vk_device& device) {
             const bool f32acc = fa.first.f32acc;
             const uint32_t fa_sgs = fa.first.subgroup_size;
             const bool fa_ds = fa.first.subgroup_size == 0;
+            const bool is_turbo3 = (fa.first.k_type == GGML_TYPE_TURBO3_0);
 
             const void * spv_data;
             size_t spv_size;
+            if (is_turbo3) {
+                if (f32acc) { spv_data = flash_attn_f32_f16_turbo3_0_cm1_data;        spv_size = flash_attn_f32_f16_turbo3_0_cm1_len; }
+                else        { spv_data = flash_attn_f32_f16_turbo3_0_f16acc_cm1_data; spv_size = flash_attn_f32_f16_turbo3_0_f16acc_cm1_len; }
+            } else
             if (f32acc) { spv_data = flash_attn_f32_f16_cm1_data;        spv_size = flash_attn_f32_f16_cm1_len; }
             else        { spv_data = flash_attn_f32_f16_f16acc_cm1_data; spv_size = flash_attn_f32_f16_f16acc_cm1_len; }
             const char *name = aligned ? "flash_attn_f32_f16_aligned_cm1" : "flash_attn_f32_f16_cm1";
@@ -4600,7 +4617,10 @@ static void ggml_vk_load_shaders(vk_device& device) {
         ggml_vk_create_pipeline(device, device->pipeline_set_rows ## itype [GGML_TYPE_Q5_0], "set_rows_q5_0" #itype, set_rows_q5_0 ## itype ## _len, set_rows_q5_0 ## itype ## _data, "main", 3, sizeof(vk_op_binary_push_constants), {1, 1, 1}, {1}, 1, true); \
         ggml_vk_create_pipeline(device, device->pipeline_set_rows ## itype [GGML_TYPE_Q5_1], "set_rows_q5_1" #itype, set_rows_q5_1 ## itype ## _len, set_rows_q5_1 ## itype ## _data, "main", 3, sizeof(vk_op_binary_push_constants), {1, 1, 1}, {1}, 1, true); \
         ggml_vk_create_pipeline(device, device->pipeline_set_rows ## itype [GGML_TYPE_Q8_0], "set_rows_q8_0" #itype, set_rows_q8_0 ## itype ## _len, set_rows_q8_0 ## itype ## _data, "main", 3, sizeof(vk_op_binary_push_constants), {1, 1, 1}, {1}, 1, true); \
-        ggml_vk_create_pipeline(device, device->pipeline_set_rows ## itype [GGML_TYPE_IQ4_NL], "set_rows_iq4_nl" #itype, set_rows_iq4_nl ## itype ## _len, set_rows_iq4_nl ## itype ## _data, "main", 3, sizeof(vk_op_binary_push_constants), {1, 1, 1}, {1}, 1, true);
+        ggml_vk_create_pipeline(device, device->pipeline_set_rows ## itype [GGML_TYPE_IQ4_NL], "set_rows_iq4_nl" #itype, set_rows_iq4_nl ## itype ## _len, set_rows_iq4_nl ## itype ## _data, "main", 3, sizeof(vk_op_binary_push_constants), {1, 1, 1}, {1}, 1, true); \
+        ggml_vk_create_pipeline(device, device->pipeline_set_rows ## itype [GGML_TYPE_TURBO2_0], "set_rows_turbo2_0" #itype, set_rows_turbo2_0 ## itype ## _len, set_rows_turbo2_0 ## itype ## _data, "main", 3, sizeof(vk_op_binary_push_constants), {1, 1, 1}, {1}, 1, true, true, 32u); \
+        ggml_vk_create_pipeline(device, device->pipeline_set_rows ## itype [GGML_TYPE_TURBO3_0], "set_rows_turbo3_0" #itype, set_rows_turbo3_0 ## itype ## _len, set_rows_turbo3_0 ## itype ## _data, "main", 3, sizeof(vk_op_binary_push_constants), {1, 1, 1}, {1}, 1, true, true, 32u); \
+        ggml_vk_create_pipeline(device, device->pipeline_set_rows ## itype [GGML_TYPE_TURBO4_0], "set_rows_turbo4_0" #itype, set_rows_turbo4_0 ## itype ## _len, set_rows_turbo4_0 ## itype ## _data, "main", 3, sizeof(vk_op_binary_push_constants), {1, 1, 1}, {1}, 1, true, true, 32u);
 
     SET_ROWS(_i32)
     SET_ROWS(_i64)
@@ -4840,6 +4860,9 @@ static void ggml_vk_load_shaders(vk_device& device) {
     ggml_vk_create_pipeline(device, device->pipeline_conv_transpose_1d_f32, "conv_transpose_1d_f32", conv_transpose_1d_f32_len, conv_transpose_1d_f32_data, "main", 3, sizeof(vk_op_conv_transpose_1d_push_constants), {1, 1, 1}, {}, 1);
 
     ggml_vk_create_pipeline(device, device->pipeline_pool2d_f32, "pool2d_f32", pool2d_f32_len, pool2d_f32_data, "main", 2, sizeof(vk_op_pool2d_push_constants), {512, 1, 1}, {}, 1);
+
+    // TurboQuant WHT (forward / inverse rotation, 128-element block)
+    ggml_vk_create_pipeline(device, device->pipeline_turbo_wht, "turbo_wht", turbo_wht_len, turbo_wht_data, "main", 2, 3 * sizeof(uint32_t), {128, 1, 1}, {}, 1);
 
     ggml_vk_create_pipeline(device, device->pipeline_rwkv_wkv6_f32, "rwkv_wkv6_f32", rwkv_wkv6_f32_len, rwkv_wkv6_f32_data, "main", 7, sizeof(vk_op_rwkv_wkv6_push_constants), {1, 1, 1}, {device->subgroup_size}, 1);
 
@@ -10393,7 +10416,10 @@ static void ggml_vk_op_f32(ggml_backend_vk_context * ctx, vk_context& subctx, co
     case GGML_OP_SET_ROWS:
         {
             uint32_t ne = ggml_nelements(src0);
-            if (ggml_is_quantized(dst->type)) {
+            if (dst->type == GGML_TYPE_TURBO2_0 || dst->type == GGML_TYPE_TURBO3_0 || dst->type == GGML_TYPE_TURBO4_0) {
+                // turbo set_rows shaders: 128 threads per WG, one full QK=128 block per WG
+                ne = ne / 128;
+            } else if (ggml_is_quantized(dst->type)) {
                 // quants run 32 threads each doing QUANT_K elements
                 ne = CEIL_DIV(ne, 32 * ggml_blck_size(dst->type));
             } else {
@@ -11167,6 +11193,34 @@ static void ggml_vk_set_rows(ggml_backend_vk_context * ctx, vk_context& subctx, 
         0,
         0.0f, 0.0f, 0,
     });
+}
+
+static void ggml_vk_turbo_wht(ggml_backend_vk_context * ctx, vk_context& subctx, const ggml_tensor * src0, ggml_tensor * dst) {
+    int direction, group_size;
+    memcpy(&direction, dst->op_params + 0, sizeof(int));
+    memcpy(&group_size, dst->op_params + sizeof(int), sizeof(int));
+    struct { uint32_t ne; uint32_t direction; uint32_t group_size; } pc = {
+        (uint32_t)ggml_nelements(src0), (uint32_t)direction, (uint32_t)group_size,
+    };
+    vk_pipeline pipeline = ctx->device->pipeline_turbo_wht;
+    GGML_ASSERT(pipeline != nullptr);
+    ggml_pipeline_request_descriptor_sets(ctx, pipeline, 1);
+    vk_subbuffer src_buf = ggml_vk_tensor_subbuffer(ctx, src0, false);
+    vk_subbuffer dst_buf = ggml_vk_tensor_subbuffer(ctx, dst, false);
+    // Spread workgroups across Y/Z to stay within maxComputeWorkGroupCount[0].
+    const uint32_t n_groups = pc.ne / (uint32_t)group_size;
+    std::array<uint32_t, 3> elements;
+    if (n_groups > 262144) {
+        elements = { 512 * (uint32_t)group_size, 512, CEIL_DIV(n_groups, 262144) };
+    } else if (n_groups > 512) {
+        elements = { 512 * (uint32_t)group_size, CEIL_DIV(n_groups, 512), 1 };
+    } else {
+        elements = { pc.ne, 1, 1 };
+    }
+    // Compute-to-compute RAW/WAW ordering must be explicit on Vulkan.
+    ggml_vk_sync_buffers(ctx, subctx);
+    ggml_vk_dispatch_pipeline(ctx, subctx, pipeline, { src_buf, dst_buf }, pc, elements);
+    ggml_vk_sync_buffers(ctx, subctx);
 }
 
 static void ggml_vk_silu_back(ggml_backend_vk_context * ctx, vk_context& subctx, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
@@ -13349,6 +13403,10 @@ static bool ggml_vk_build_graph(ggml_backend_vk_context * ctx, ggml_cgraph * cgr
         break;
     case GGML_OP_SET_ROWS:
         ggml_vk_set_rows(ctx, compute_ctx, src0, src1, node);
+
+        break;
+    case GGML_OP_TURBO_WHT:
+        ggml_vk_turbo_wht(ctx, compute_ctx, src0, node);
 
         break;
     case GGML_OP_SILU_BACK:
@@ -15753,6 +15811,10 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                     case GGML_TYPE_Q4_1:
                     case GGML_TYPE_Q4_0:
                         return true;
+                    case GGML_TYPE_TURBO2_0:
+                    case GGML_TYPE_TURBO3_0:
+                    case GGML_TYPE_TURBO4_0:
+                        return true;
                     case GGML_TYPE_Q1_0:
                         return coopmat2;
                     default:
@@ -15804,6 +15866,11 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
             }
         case GGML_OP_SET_ROWS:
             {
+                // turbo shaders use a 128-element block: head_dim must be divisible by 128
+                if ((op->type == GGML_TYPE_TURBO2_0 || op->type == GGML_TYPE_TURBO3_0 || op->type == GGML_TYPE_TURBO4_0)
+                    && (op->src[0]->ne[0] % 128 != 0)) {
+                    return false;
+                }
                 switch (op->type) {
                     case GGML_TYPE_F32:
                     case GGML_TYPE_F16:
@@ -15815,6 +15882,9 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                     case GGML_TYPE_Q5_1:
                     case GGML_TYPE_Q8_0:
                     case GGML_TYPE_IQ4_NL:
+                    case GGML_TYPE_TURBO2_0:
+                    case GGML_TYPE_TURBO3_0:
+                    case GGML_TYPE_TURBO4_0:
                         return true;
                     default:
                         return false;
@@ -16039,6 +16109,8 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                 && op->src[1]->type == GGML_TYPE_F32;
         case GGML_OP_POOL_2D:
             return ggml_is_contiguous(op->src[0]) && op->src[0]->type == GGML_TYPE_F32;
+        case GGML_OP_TURBO_WHT:
+            return op->src[0]->type == GGML_TYPE_F32 && op->src[0]->ne[0] % 128 == 0;
         case GGML_OP_RWKV_WKV6:
         case GGML_OP_RWKV_WKV7:
             return true; // all inputs are contiguous, see ggml.c

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn.comp
@@ -2,8 +2,10 @@
 
 #extension GL_EXT_control_flow_attributes : enable
 #extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_8bit_storage : require
 
 #extension GL_EXT_shader_explicit_arithmetic_types_int32 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 
 #ifdef FLOAT16
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
@@ -264,7 +266,9 @@ void main() {
                             uint iqs = (coord % BLOCK_SIZE_K);
                             K_Tf = dequantize4(ib, iqs, k_offset, BINDING_IDX_K);
                         } else {
+#if !defined(DATA_A_TURBO3_0)
                             K_Tf = FLOAT_TYPEV4(data_kv4[k_offset / 4 + (j * Bc + c) * k_stride / 4 + d]);
+#endif
                         }
                     }
 
@@ -317,7 +321,9 @@ void main() {
                         uint iqs = (coord % BLOCK_SIZE_K);
                         K_Tf = dequantize4(ib, iqs, k_offset, BINDING_IDX_K);
                     } else {
+#if !defined(DATA_A_TURBO3_0)
                         K_Tf = FLOAT_TYPEV4(data_kv4[k_offset / 4 + (j * Bc + c * cols_per_iter + col_tid) * k_stride / 4 + d * D_split + d_tid]);
+#endif
                     }
                     [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
                         Sf[r][c] += dot(ACC_TYPEV4(Q_cache[r]), ACC_TYPEV4(K_Tf));
@@ -340,7 +346,9 @@ void main() {
                         uint iqs = (coord % BLOCK_SIZE_K);
                         K_Tf = dequantize4(ib, iqs, k_offset, BINDING_IDX_K);
                     } else {
+#if !defined(DATA_A_TURBO3_0)
                         K_Tf = FLOAT_TYPEV4(data_kv4[k_offset / 4 + (j * Bc + c * cols_per_iter + col_tid) * k_stride / 4 + d * D_split + d_tid]);
+#endif
                     }
                     [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
                         Sf[r][c] += dot(ACC_TYPEV4(Qf[tile_row(r) * qf_stride + d * D_split + d_tid]), ACC_TYPEV4(K_Tf));
@@ -494,7 +502,9 @@ void main() {
                             uint iqs = (coord % BLOCK_SIZE_V);
                             V_Tf = dequantize4(ib, iqs, v_offset, BINDING_IDX_V);
                         } else {
+#if !defined(DATA_A_TURBO3_0)
                             V_Tf = FLOAT_TYPEV4(data_vv4[v_offset / 4 + (j * Bc + c) * v_stride / 4 + d]);
+#endif
                         }
                     }
 
@@ -525,7 +535,9 @@ void main() {
                     uint iqs = (coord % BLOCK_SIZE_V);
                     Vf = dequantize4(ib, iqs, v_offset, BINDING_IDX_V);
                 } else {
+#if !defined(DATA_A_TURBO3_0)
                     Vf = FLOAT_TYPEV4(data_vv4[v_offset / 4 + (j * Bc + c * cols_per_iter + col_tid) * v_stride / 4 + d * D_split + d_tid]);
+#endif
                 }
                 [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
                     Of[r][d] += FLOAT_TYPEV4(Pf[r] * Vf);

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_base.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_base.glsl
@@ -112,6 +112,9 @@ uint fa_block_elems(uint ty) {
         case FA_TYPE_Q5_1: return uint(QUANT_K_Q5_1);
         case FA_TYPE_Q8_0: return uint(QUANT_K_Q8_0);
         case FA_TYPE_Q1_0: return uint(QUANT_K_Q1_0); // cm2-only, harmless elsewhere
+        case 42u:          return uint(QUANT_K_TURBO2_0); // GGML_TYPE_TURBO2_0
+        case 43u:          return uint(QUANT_K_TURBO3_0); // GGML_TYPE_TURBO3_0
+        case 44u:          return uint(QUANT_K_TURBO4_0); // GGML_TYPE_TURBO4_0
         default:           return 1u;
     }
 }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -2,9 +2,11 @@
 
 #extension GL_EXT_control_flow_attributes : enable
 #extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_8bit_storage : require
 
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int32 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 
 #extension GL_KHR_shader_subgroup_basic : enable
 #extension GL_KHR_shader_subgroup_arithmetic : enable
@@ -27,10 +29,12 @@ const uint32_t cols_per_thread = Bc / cols_per_iter;
 
 layout (binding = 0) readonly buffer Q {float data_q[];};
 layout (binding = 0) readonly buffer QV4 {vec4 data_qv4[];};
+#if !defined(DATA_A_TURBO3_0)
 layout (binding = 1) readonly buffer K {float16_t data_k[];};
 layout (binding = 1) readonly buffer KV4 {f16vec4 data_kv4[];};
 layout (binding = 2) readonly buffer V {float16_t data_v[];};
 layout (binding = 2) readonly buffer VV4 {f16vec4 data_vv4[];};
+#endif
 layout (binding = 3) readonly buffer M {float16_t data_m[];};
 
 shared float tmpsh[row_split];
@@ -230,7 +234,9 @@ void main() {
                             uint iqs = (coord % BLOCK_SIZE_K);
                             K_Tf = dequantize4(ib, iqs, k_offset, BINDING_IDX_K);
                         } else {
+#if !defined(DATA_A_TURBO3_0)
                             K_Tf = f16vec4(data_kv4[k_offset / 4 + (j * Bc + c) * k_stride / 4 + d]);
+#endif
                         }
                     }
 
@@ -270,7 +276,9 @@ void main() {
                                 uint iqs = (coord % BLOCK_SIZE_K);
                                 K_Tf = dequantize4(ib, iqs, k_offset, BINDING_IDX_K);
                             } else {
+#if !defined(DATA_A_TURBO3_0)
                                 K_Tf = f16vec4(data_kv4[k_offset / 4 + (j * Bc + row) * k_stride / 4 + d * 16 / 4 + col_vec]);
+#endif
                             }
                         }
 
@@ -281,13 +289,17 @@ void main() {
             }
 
             if (stage_k) {
+                memoryBarrierShared();
                 uint coord = (gl_SubgroupID * MatBc) * kvsh_stride;
                 coopMatLoad(KMat, kvsh, coord, kvsh_stride, gl_CooperativeMatrixLayoutRowMajor);
             } else {
+#if !defined(DATA_A_TURBO3_0)
                 const uint coord = k_offset / 4 + (j * Bc + gl_SubgroupID * MatBc) * k_stride / 4 + d * 16 / 4;
                 coopMatLoad(KMat, data_kv4, coord, k_stride / 4, gl_CooperativeMatrixLayoutRowMajor);
+#endif
             }
             } else {
+                memoryBarrierShared();
                 uint coord = (gl_SubgroupID * MatBc) * kvsh_stride + d * 16 / 4;
                 coopMatLoad(KMat, kvsh, coord, kvsh_stride, gl_CooperativeMatrixLayoutRowMajor);
             }
@@ -393,7 +405,9 @@ void main() {
                             uint iqs = (coord % BLOCK_SIZE_V);
                             V_Tf = dequantize4(ib, iqs, v_offset, BINDING_IDX_V);
                         } else {
+#if !defined(DATA_A_TURBO3_0)
                             V_Tf = f16vec4(data_vv4[v_offset / 4 + (j * Bc + c) * v_stride / 4 + d]);
+#endif
                         }
                     }
 
@@ -441,7 +455,9 @@ void main() {
                         if (USE_DECODE_V) {
                             kvsh[row * vsh_stride + col] = dequantize4(ib, iqs, v_offset, BINDING_IDX_V);
                         } else {
+#if !defined(DATA_A_TURBO3_0)
                             kvsh[row * vsh_stride + col] = data_vv4[(v_offset + v_row * v_stride + v_col) / 4];
+#endif
                         }
                     } else {
                         kvsh[row * vsh_stride + col] = f16vec4(0.0f);
@@ -459,15 +475,19 @@ void main() {
 
                     if (SHMEM_STAGING == 0) {
                     if (!USE_DECODE_V && !KV_bounds_check) {
+#if !defined(DATA_A_TURBO3_0)
                         // F16 values can be loaded directly from global memory
                         const uint v_tile_row = j * Bc + bc_chunk * MatBc;
                         const uint v_tile_offset = v_offset / 4 + v_tile_row * v_stride / 4 + hsv_offset / 4;
                         coopMatLoad(QMat, data_vv4, v_tile_offset, v_stride / 4, gl_CooperativeMatrixLayoutRowMajor);
+#endif
                     } else {
+                        memoryBarrierShared();
                         const uint v_tile_offset = bc_chunk * MatBr * v_cols + gl_SubgroupID * (MatBc / 4);
                         coopMatLoad(QMat, kvsh, v_tile_offset, vsh_stride, gl_CooperativeMatrixLayoutRowMajor);
                     }
                     } else {
+                        memoryBarrierShared();
                         const uint v_tile_offset = bc_chunk * MatBc * kvsh_stride + (hsv_tile * row_split + gl_SubgroupID) * (MatBc / 4);
                         coopMatLoad(QMat, kvsh, v_tile_offset, kvsh_stride, gl_CooperativeMatrixLayoutRowMajor);
                     }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_dequant.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_dequant.glsl
@@ -12,6 +12,7 @@
 // illegal to return from / pass to functions. Macros expand inline where the
 // float16 stays in storage and is converted to FLOAT_TYPE at use.
 
+#if !defined(DATA_A_TURBO3_0)
 // F32 is fed as a vec4 "block" (4 floats), matching what dequant_funcs_cm2.glsl
 // does for F32 in the cm2 shader. FaBlockBytesK/V == 16 for F32.
 layout (binding = 1) readonly buffer K_PACKED_F32  { vec4 data[]; }                k_packed_f32;
@@ -27,11 +28,29 @@ layout (binding = 1) readonly buffer K_PACKED_Q5_1 { block_q5_1_packed16 data[];
 layout (binding = 2) readonly buffer V_PACKED_Q5_1 { block_q5_1_packed16 data[]; } v_packed_q5_1;
 layout (binding = 1) readonly buffer K_PACKED_Q8_0 { block_q8_0_packed16 data[]; } k_packed_q8_0;
 layout (binding = 2) readonly buffer V_PACKED_Q8_0 { block_q8_0_packed16 data[]; } v_packed_q8_0;
+#endif  // !DATA_A_TURBO3_0
 
+// TurboQuant3 K/V (50-byte blocks) — used for asymmetric K=q8_0 V=turbo3
+// or symmetric K=V=turbo3 dispatched via the generic FA SPIR-V (selected by
+// FaTypeK/FaTypeV spec constants). Graph applies forward WHT to Q pre-attention
+// (when K is turbo) and inverse WHT to FA output post-attention (when V is
+// turbo), so dequant returns centroid*norm — orthogonal Q·K_rot = Q_rot·K_rot.
+// `restrict` + explicit `std430` keeps the driver from assuming a uniform stride
+// across aliased SSBO views at the same binding (the existing 16-bit-aligned
+// q4/q5/q8 views have ~18-34 byte strides; turbo3 needs a 50-byte stride).
+layout (binding = 1, std430) restrict readonly buffer K_PACKED_TURBO2_0 { block_turbo2_0 data[]; } k_packed_turbo2_0;
+layout (binding = 2, std430) restrict readonly buffer V_PACKED_TURBO2_0 { block_turbo2_0 data[]; } v_packed_turbo2_0;
+layout (binding = 1, std430) restrict readonly buffer K_PACKED_TURBO3_0 { block_turbo3_0 data[]; } k_packed_turbo3_0;
+layout (binding = 2, std430) restrict readonly buffer V_PACKED_TURBO3_0 { block_turbo3_0 data[]; } v_packed_turbo3_0;
+layout (binding = 1, std430) restrict readonly buffer K_PACKED_TURBO4_0 { block_turbo4_0 data[]; } k_packed_turbo4_0;
+layout (binding = 2, std430) restrict readonly buffer V_PACKED_TURBO4_0 { block_turbo4_0 data[]; } v_packed_turbo4_0;
+
+#if !defined(DATA_A_TURBO3_0)
 // Q4_1 and Q5_1 packed32 views: aliased to the same memory as the packed16
 // views, used by the MMQ K-side hot path for fast 4-uint loads.
 layout (binding = 1) readonly buffer K_PACKED_Q4_1_P32 { block_q4_1_packed32 data[]; } k_packed_q4_1_p32;
 layout (binding = 1) readonly buffer K_PACKED_Q5_1_P32 { block_q5_1_packed32 data[]; } k_packed_q5_1_p32;
+#endif  // !DATA_A_TURBO3_0
 
 // Per-quant decode bodies are expanded once for the K view set and once for
 // the V view set. The macros take the buffer name as a parameter.
@@ -99,6 +118,68 @@ layout (binding = 1) readonly buffer K_PACKED_Q5_1_P32 { block_q5_1_packed32 dat
     return FLOAT_TYPE(BUF.data[a_offset + ib].d) * FLOAT_TYPEV4(v0.x, v0.y, v1.x, v1.y);          \
 }
 
+// TurboQuant2 dequant: 2-bit centroids, no signs byte. All 4 elements share
+// qs byte (iqs/4) at iqs%4==0.
+#define FA_DEQUANT4_TURBO2_0(BUF) {                                                               \
+    const float c[4] = float[4](-0.133462, -0.039994, 0.039994, 0.133462);                        \
+    const float norm = float(BUF.data[a_offset + ib].norm);                                        \
+    const uint qs_byte = uint(BUF.data[a_offset + ib].qs[iqs / 4]);                                \
+    const uint i0 = (qs_byte     ) & 0x3u;                                                          \
+    const uint i1 = (qs_byte >> 2) & 0x3u;                                                          \
+    const uint i2 = (qs_byte >> 4) & 0x3u;                                                          \
+    const uint i3 = (qs_byte >> 6) & 0x3u;                                                          \
+    return FLOAT_TYPE(norm) * FLOAT_TYPEV4(c[i0], c[i1], c[i2], c[i3]);                            \
+}
+
+// TurboQuant3 dequant: per-element centroid lookup. iqs is in [0, 128) at vec4
+// alignment (iqs%4 == 0), so all 4 elements share qs byte (iqs/4) and signs
+// byte (iqs/8). No iWHT here — graph handles rotation outside FA.
+#define FA_DEQUANT4_TURBO3_0(BUF) {                                                               \
+    const float c[8] = float[8](                                                                   \
+        -0.190685, -0.117832, -0.065717, -0.021460,                                                \
+         0.021460,  0.065717,  0.117832,  0.190685);                                               \
+    const float norm = float(BUF.data[a_offset + ib].norm);                                        \
+    const uint qs_byte  = uint(BUF.data[a_offset + ib].qs[iqs / 4]);                               \
+    const uint sgn_byte = uint(BUF.data[a_offset + ib].signs[iqs / 8]);                            \
+    const uint base = iqs & 0x7u;                                                                   \
+    const uint i0 = ((qs_byte     ) & 0x3) | (((sgn_byte >> (base    )) & 0x1u) << 2);             \
+    const uint i1 = ((qs_byte >> 2) & 0x3) | (((sgn_byte >> (base + 1)) & 0x1u) << 2);             \
+    const uint i2 = ((qs_byte >> 4) & 0x3) | (((sgn_byte >> (base + 2)) & 0x1u) << 2);             \
+    const uint i3 = ((qs_byte >> 6) & 0x3) | (((sgn_byte >> (base + 3)) & 0x1u) << 2);             \
+    return FLOAT_TYPE(norm) * FLOAT_TYPEV4(c[i0], c[i1], c[i2], c[i3]);                            \
+}
+
+// TurboQuant4 dequant: 4-bit indices, 2 per byte. iqs%4==0 means the 4
+// elements span 2 consecutive qs bytes (each holds 2 nibbles).
+#define FA_DEQUANT4_TURBO4_0(BUF) {                                                               \
+    const float c[16] = float[16](                                                                 \
+        -0.173926, -0.117195, -0.089527, -0.068756,                                                \
+        -0.051262, -0.035597, -0.020989, -0.006938,                                                \
+         0.006938,  0.020989,  0.035597,  0.051262,                                                \
+         0.068756,  0.089527,  0.117195,  0.173926);                                               \
+    const float norm = float(BUF.data[a_offset + ib].norm);                                        \
+    const uint b0 = uint(BUF.data[a_offset + ib].qs[iqs / 2    ]);                                 \
+    const uint b1 = uint(BUF.data[a_offset + ib].qs[iqs / 2 + 1]);                                 \
+    const uint i0 = (b0     ) & 0xFu;                                                               \
+    const uint i1 = (b0 >> 4) & 0xFu;                                                               \
+    const uint i2 = (b1     ) & 0xFu;                                                               \
+    const uint i3 = (b1 >> 4) & 0xFu;                                                               \
+    return FLOAT_TYPE(norm) * FLOAT_TYPEV4(c[i0], c[i1], c[i2], c[i3]);                            \
+}
+
+#if defined(DATA_A_TURBO3_0)
+// Per-shader-compilation turbo3 variant: only turbo3 K/V bindings exist at
+// bindings 1/2 (no f16/q4/q5/q8 aliases) — eliminates SSBO alias collisions
+// for the symmetric K=V=turbo3 dispatch on RDNA where mismatched stride aliases
+// at the same binding caused driver-side mis-strided loads.
+FLOAT_TYPEV4 dequantize4(uint ib, uint iqs, uint a_offset, uint binding_idx) {
+    if (binding_idx == BINDING_IDX_K) {
+        FA_DEQUANT4_TURBO3_0(k_packed_turbo3_0)
+    } else {
+        FA_DEQUANT4_TURBO3_0(v_packed_turbo3_0)
+    }
+}
+#else
 FLOAT_TYPEV4 dequantize4(uint ib, uint iqs, uint a_offset, uint binding_idx) {
     if (binding_idx == BINDING_IDX_K) {
         switch (FaTypeK) {
@@ -108,6 +189,9 @@ FLOAT_TYPEV4 dequantize4(uint ib, uint iqs, uint a_offset, uint binding_idx) {
             case FA_TYPE_Q5_0: FA_DEQUANT4_Q5_0(k_packed_q5_0)
             case FA_TYPE_Q5_1: FA_DEQUANT4_Q5_1(k_packed_q5_1)
             case FA_TYPE_Q8_0: FA_DEQUANT4_Q8_0(k_packed_q8_0)
+            case 42u:          FA_DEQUANT4_TURBO2_0(k_packed_turbo2_0)  // GGML_TYPE_TURBO2_0
+            case 43u:          FA_DEQUANT4_TURBO3_0(k_packed_turbo3_0)  // GGML_TYPE_TURBO3_0
+            case 44u:          FA_DEQUANT4_TURBO4_0(k_packed_turbo4_0)  // GGML_TYPE_TURBO4_0
         }
     } else {
         switch (FaTypeV) {
@@ -117,7 +201,11 @@ FLOAT_TYPEV4 dequantize4(uint ib, uint iqs, uint a_offset, uint binding_idx) {
             case FA_TYPE_Q5_0: FA_DEQUANT4_Q5_0(v_packed_q5_0)
             case FA_TYPE_Q5_1: FA_DEQUANT4_Q5_1(v_packed_q5_1)
             case FA_TYPE_Q8_0: FA_DEQUANT4_Q8_0(v_packed_q8_0)
+            case 42u:          FA_DEQUANT4_TURBO2_0(v_packed_turbo2_0)  // GGML_TYPE_TURBO2_0
+            case 43u:          FA_DEQUANT4_TURBO3_0(v_packed_turbo3_0)  // GGML_TYPE_TURBO3_0
+            case 44u:          FA_DEQUANT4_TURBO4_0(v_packed_turbo4_0)  // GGML_TYPE_TURBO4_0
         }
     }
     return FLOAT_TYPEV4(0);
 }
+#endif  // DATA_A_TURBO3_0

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -659,6 +659,16 @@ void process_shaders() {
             string_to_spv("flash_attn_f32_f16", "flash_attn.comp",
                 merge_maps(fa_base_dict, {{"Q_TYPE", "float"}, {"D_TYPE", "float"}, {"D_TYPEV4", "vec4"}, {"MMQ", "1"}, {"FA_MMQ_MIXED", "1"}}), fp16, false, false, f16acc, "_int8");
 #endif
+            // TurboQuant3 FA: separate SPIR-V variants with DATA_A_TURBO3_0 so the
+            // shader gets turbo3-only K/V bindings (no f16 alias) and the dequant
+            // path runs the per-element centroid lookup (graph applies WHT to Q
+            // pre-attention and inverse WHT to output post-attention).
+            string_to_spv("flash_attn_f32_f16_turbo3_0", "flash_attn.comp",
+                merge_maps(fa_base_dict, {{"DATA_A_TURBO3_0", "1"}, {"Q_TYPE", "float"}, {"D_TYPE", "float"}, {"D_TYPEV4", "vec4"}}), fp16, false, false, f16acc);
+#if defined(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+            string_to_spv("flash_attn_f32_f16_turbo3_0", "flash_attn_cm1.comp",
+                merge_maps(fa_base_dict, {{"DATA_A_TURBO3_0", "1"}, {"Q_TYPE", "float"}, {"D_TYPE", "float"}, {"D_TYPEV4", "vec4"}, {"COOPMAT", "1"}}), fp16, true, false, f16acc);
+#endif
         }
     }
 
@@ -749,10 +759,13 @@ void process_shaders() {
         string_to_spv("cpy_" + t + "_f32", "copy_from_quant.comp", {{"DATA_A_" + to_uppercase(t), "1"}, {"D_TYPE", "float"}, {"FLOAT_TYPE", "float"}});
     }
 
-    for (std::string t : {"f32", "f16", "bf16", "q1_0", "q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "iq4_nl"}) {
+    for (std::string t : {"f32", "f16", "bf16", "q1_0", "q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "iq4_nl", "turbo2_0", "turbo3_0", "turbo4_0"}) {
         string_to_spv("set_rows_" + t + "_i32", "copy_to_quant.comp", {{"SET_ROWS", "1"}, {"DATA_A_" + to_uppercase(t), "1"}, {"B_TYPE", "uint"}, {"B_SIZE", "32"}, {"D_TYPE", "float"}, {"FLOAT_TYPE", "float"}});
         string_to_spv("set_rows_" + t + "_i64", "copy_to_quant.comp", {{"SET_ROWS", "1"}, {"DATA_A_" + to_uppercase(t), "1"}, {"B_TYPE", "uvec2"}, {"B_SIZE", "64"}, {"D_TYPE", "float"}, {"FLOAT_TYPE", "float"}});
     }
+
+    // TurboQuant Walsh-Hadamard Transform op (Q forward + kqv inverse rotation)
+    string_to_spv("turbo_wht", "turbo_wht.comp", {});
 
     auto get_type_str = [](bool f16) {
         return f16 ? "float16_t" : "float";


### PR DESCRIPTION
## Summary

Restores Vulkan turbo3/4 KV cache support that was clobbered during the b9190 upstream-sync merge (`e30bbcfe5`). Brings back the wiring originally landed in PR #62 (`ff8bb7394`), adapts it to the post-sync Vulkan API, and adds turbo2/turbo4 FA dispatch + the `requiredSubgroupSize=32` constraint that's required on RDNA4.

Tracking: #159 (regression discovery). Closes: #88, #89.

## What was broken on current main

- `pipeline_turbo_wht` member, `ggml_vk_turbo_wht` dispatch fn, and `GGML_OP_TURBO_WHT` case handler all missing — graph-level WHT rotation for Q (and inverse rotation post-FA) silently fell back or failed
- `CREATE_FA(GGML_TYPE_TURBO3_0, ...)` SPIR-V variants not built — FA dispatch had no turbo pipeline to find
- `fa_kv_ok` rejected turbo types in `supports_op(FLASH_ATTN_EXT)`
- `flash_attn_dequant.glsl` had no turbo cases in `dequantize4()`
- SET_ROWS pipelines never registered for turbo2/turbo3/turbo4 → hard assert at cache allocation

Net effect: `--cache-type-k turbo3 --cache-type-v turbo3` on Vulkan failed at startup, and asymmetric configs produced incoherent output.

## Fix

Three commits:

**1. SET_ROWS pipeline registration for turbo2/3/4**
- Adds turbo types to `vulkan-shaders-gen.cpp` set_rows generation loop
- Registers `set_rows_turbo*_0_{i32,i64}` pipelines in `ggml-vulkan.cpp`
- Adds `head_dim % 128 == 0` guard in `supports_op(SET_ROWS)` matching the 128-element block constraint
- Special-cases the dispatch math: turbo set_rows shaders run 128 threads per WG handling one full QK=128 block, so `ne = ne / 128` rather than the generic `CEIL_DIV(ne, 32 * blck_size)`
- **`requiredSubgroupSize = 32`** on the three turbo set_rows pipelines. Without this the RDNA4 driver picked wave64 by default, breaking the `subgroupBallot.x` 32-lane sign-packing inside the turbo set_rows shader. This is THE root cause of the incoherent decode in #88

**2. `ggml_turbo_wht` Vulkan op**
- `pipeline_turbo_wht` member + creation reusing the existing `turbo_wht.comp` shader
- `ggml_vk_turbo_wht` dispatch function (reads `direction`, `group_size` from `op_params`, dispatches with explicit `ggml_vk_sync_buffers` barriers around for compute-to-compute RAW/WAW ordering)
- `GGML_OP_TURBO_WHT` case in the build-graph dispatch switch
- `supports_op(GGML_OP_TURBO_WHT)` returns true for F32 src with `ne[0] % 128 == 0`

**3. Flash Attention dispatch for turbo3 K/V**
- Adds `fa_kv_ok` cases for turbo2/3/4 in `supports_op(FLASH_ATTN_EXT)`
- Adds turbo K/V SSBO bindings to `flash_attn_dequant.glsl` (`restrict std430` to avoid alias-stride issues on RDNA when the same binding has mismatched-stride aliases)
- Adds `FA_DEQUANT4_TURBO{2,3,4}_0` macros: per-element centroid lookup, no iWHT in the kernel because the graph applies WHT to Q pre-attention and inverse WHT to output post-attention (orthogonality: `Q · K_rot = Q_rot · K_rot`)
- Adds `fa_block_elems` cases for turbo2/3/4 → `QUANT_K_TURBO*_0`
- Dedicated `DATA_A_TURBO3_0` SPIR-V variant (scalar + cm1 coopmat paths) that gates away the generic f16/q4/q5/q8 binding aliases — eliminates the SSBO alias collision on RDNA where mismatched stride aliases at the same binding caused mis-strided loads
- `memoryBarrierShared()` added in `flash_attn_cm1.comp` at the shared-memory load sites for kvsh to fix the cm1 coopmat read-before-write race
- `flash_attn.comp` and `flash_attn_cm1.comp` gate the f16 K/V aliases under `#if !defined(DATA_A_TURBO3_0)` so the turbo3 variant only has turbo bindings at slots 1/2

Note: cm2 (NV cooperative matrix v2) FA path is intentionally skipped in this PR — turbo3 is f32-accumulator only. NV users get the cm1 KHR-coopmat path. cm2 specialization can be a follow-up.

## Two real root causes (out of ~8 hypotheses)

1. **`requiredSubgroupSize = 32` on turbo set_rows** — RDNA4 driver picks wave64 by default for compute pipelines unless explicitly constrained. The turbo set_rows shader uses `subgroupBallot` to pack 32 sign bits into a single uvec4.x word; on wave64 the ballot covered 64 lanes and the sign packing was off by 32. This silently produced garbage in the cache writes. Pinning to wave32 via `VkPipelineShaderStageRequiredSubgroupSizeCreateInfo` makes the ballot semantics deterministic.

2. **`ne = ne / 128` dispatch math** — turbo set_rows runs one full QK=128 block per workgroup with 128 threads. The generic quant path uses 32 threads per WG with `CEIL_DIV(ne, 32 * blck_size)`. Without the special case, the turbo path was under-dispatched by 32×, leaving most of the cache uninitialized.

The second was the missing piece from the original April implementation — present in `ff8bb7394`, dropped during the b9190 sync. The first is RDNA4-new: didn't matter on the hardware the April PR was developed on, surfaces on wave-flexible hardware.

## Verification

All on RX 9070 XT (RDNA4, gfx1201), Qwen2.5-7B Q4_K_M, current branch HEAD:

| Config | pp512 | tg128 | Status |
|---|---|---|---|
| `--cache-type-k f16 --cache-type-v f16` (baseline) | 2636 t/s | 48.4 t/s | no regression |
| `--cache-type-k q8_0 --cache-type-v turbo4` (recommended) | 1951 t/s | 49.2 t/s | coherent |
| `--cache-type-k q8_0 --cache-type-v turbo3` | ~446 t/s | ~45.6 t/s | coherent |
| `--cache-type-k q8_0 --cache-type-v turbo2` | ~453 t/s | ~45.2 t/s | coherent |

All decode against HIP turbo3 baseline produces coherent output. Prefill on Vulkan now lands at ~3.3× the previously-measured HIP throughput on the same hardware. Decode is ~56% of HIP; there's headroom for follow-up tuning (workgroup-size sweep, possibly turbo3-specific FA pipeline tuning).

#137 (RDNA 3.5 GFX1151 case) not retested here — requires Strix Halo hardware. Likely fixed by the same `requiredSubgroupSize=32` mechanism since RDNA 3.5 has the same wave-flexible scheduling, but unverified.

## Files touched

- `ggml/src/ggml-vulkan/ggml-vulkan.cpp` (host-side wiring)
- `ggml/src/ggml-vulkan/vulkan-shaders/flash_attn.comp` (turbo3 binding guards)
- `ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_base.glsl` (fa_block_elems cases)
- `ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp` (turbo3 binding guards + memoryBarrierShared)
- `ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_dequant.glsl` (turbo K/V bindings + dequant macros + DATA_A_TURBO3_0 specialization)
- `ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp` (turbo3 FA SPIR-V variants + set_rows turbo + turbo_wht)

212 insertions / 4 deletions across 6 files.

## Follow-ups

- `vulkan: turbo3/4 decode perf vs HIP gap (~44% headroom on RX 9070 XT)` — workgroup-size sweep, possibly cm2 path
- `vulkan: cm2 (NV cooperative matrix v2) path for turbo3 FA` — NV users currently on cm1, optimal would be cm2
- `vulkan: extend DATA_A_TURBO2_0 / DATA_A_TURBO4_0 SPIR-V specialization` — turbo2/4 currently use the generic FA SPIR-V which has all binding aliases declared; if RDNA alias issues surface there, dedicated variants would be the fix
- #137 RDNA 3.5 verification on Strix Halo hardware
