### PR TITLE
vocab: add minicpm5 pre-tokenizer

### DIFF
--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -511,6 +511,13 @@ struct llm_tokenizer_bpe : llm_tokenizer {
                 };
                 byte_encode = false;
                 break;
+            case LLAMA_VOCAB_PRE_TYPE_MINICPM5:
+                regex_exprs = {
+                    // original regex from tokenizer.json (openbmb/MiniCPM5-1B)
+                    "\\p{N}{1,3}",
+                    "(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])|[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}+| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+",
+                };
+                break;
             default:
                 // default regex for BPE tokenization pre-processing
                 regex_exprs = {
@@ -2018,6 +2025,10 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
                 pre_type = LLAMA_VOCAB_PRE_TYPE_SARVAM_MOE;
                 escape_whitespaces = true;
                 clean_spaces = false;
+            } else if (
+                    tokenizer_pre == "minicpm5") {
+                pre_type = LLAMA_VOCAB_PRE_TYPE_MINICPM5;
+                ignore_merges = true;
             } else if (
                     tokenizer_pre == "jina-v1-en" ||
                     tokenizer_pre == "jina-v2-code" ||

--- a/src/llama-vocab.h
+++ b/src/llama-vocab.h
@@ -60,6 +60,7 @@ enum llama_vocab_pre_type {
     LLAMA_VOCAB_PRE_TYPE_JAIS2           = 49,
     LLAMA_VOCAB_PRE_TYPE_GEMMA4          = 50,
     LLAMA_VOCAB_PRE_TYPE_SARVAM_MOE      = 51,
+    LLAMA_VOCAB_PRE_TYPE_MINICPM5        = 52,
 };
 
 struct LLM_KV;


### PR DESCRIPTION
## Problem

Loading an `openbmb/MiniCPM5-1B` GGUF (e.g. the TurboQuant `TQ4_1S` quant published at [rpopreapovle/MiniCPM5-1B-TQx_1S-GGUF](https://huggingface.co/rpopreapovle/MiniCPM5-1B-TQx_1S-GGUF), whose model card points users at this fork) fails at vocab load:

```
error loading model vocabulary: unknown pre-tokenizer type: 'minicpm5'
```

This fork is synced to upstream around build b9190; the `minicpm5` pre-tokenizer was added upstream in **b9354**, so it isn't present on any branch here yet.

## Fix

Port the `minicpm5` BPE pre-tokenizer from upstream llama.cpp, following the same pattern as the other pre-tokenizers:

- `src/llama-vocab.h` — add `LLAMA_VOCAB_PRE_TYPE_MINICPM5` enum value
- `src/llama-vocab.cpp` — map `tokenizer_pre == "minicpm5"` → `LLAMA_VOCAB_PRE_TYPE_MINICPM5` (`ignore_merges = true`)
- `src/llama-vocab.cpp` — add the `regex_exprs` case (regex taken verbatim from the MiniCPM5 `tokenizer.json`)

Architecture loading already works; this was purely the missing vocab pre-type. With this patch a MiniCPM5 GGUF loads and runs (`llama-server -m minicpm5-TQ4_1S.gguf ...`).

## Reference

Upstream implementation: ggml-org/llama.cpp release [b9354](https://github.com/ggml-org/llama.cpp/releases/tag/b9354).

🤖 Generated with [Claude Code](https://claude.com/claude-code)