### PR TITLE
fix(mtmd): guard clip d_head/kq_scale against n_head==0 (Gemma 4 12B SIGFPE)

### DIFF
--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -240,11 +240,11 @@ clip_graph::clip_graph(clip_ctx * ctx, const clip_image_f32 & img) :
         n_patches(n_patches_x * n_patches_y),
         n_embd(hparams.n_embd),
         n_head(hparams.n_head),
-        d_head(n_embd / n_head),
+        d_head(n_head > 0 ? n_embd / n_head : 0),
         n_layer(hparams.n_layer),
         n_mmproj_embd(clip_n_mmproj_embd(ctx)),
         eps(hparams.eps),
-        kq_scale(1.0f / sqrtf((float)d_head)),
+        kq_scale(d_head > 0 ? 1.0f / sqrtf((float)d_head) : 0.0f),
         flash_attn_type(ctx->flash_attn_type) {
     struct ggml_init_params params = {
         /*.mem_size   =*/ ctx->buf_compute_meta.size(),


### PR DESCRIPTION
## Summary

Fixes #163. Loading the Gemma 4 12B mmproj crashes with `SIGFPE, Arithmetic exception` at `clip.cpp:250`.

Root cause: Gemma 4 12B's vision tower has no attention encoder, so `hparams.n_head == 0`. The `clip_graph` constructor's init list does:

```cpp
d_head(n_embd / n_head),                  // integer divide-by-zero -> SIGFPE
...
kq_scale(1.0f / sqrtf((float)d_head)),    // 1/sqrt(0) once d_head is fixed
```

## Fix

Guard both, identical to the upstream fix for ggml-org/llama.cpp#24085 (closed):

```cpp
d_head(n_head > 0 ? n_embd / n_head : 0),
kq_scale(d_head > 0 ? 1.0f / sqrtf((float)d_head) : 0.0f),
```

When the tower has no encoder, `d_head`/`kq_scale` are unused, so 0 is safe.

## Testing

- `mtmd` target builds clean (Metal, clip.cpp.o compiles).
- Matches the canonical upstream patch already merged in ggml-org/llama.cpp.
- Did not repro locally (no Gemma 4 12B mmproj on hand); the guard is a strict superset of the crashing path.

Thanks to @guarismo for the clear report and backtrace.