### PR TITLE
HIP/MUSA: fix build break from unguarded 3D peer memcpy and bare cudaEventCreate

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1873,7 +1873,7 @@ struct ggml_cuda_host_staging_pool {
             return cudaSuccess;
         }
         if (buf) {
-            cudaFreeHost(buf);
+            CUDA_CHECK(cudaFreeHost(buf));
         }
         cudaError_t err = cudaMallocHost(&buf, needed);
         if (err != cudaSuccess) {
@@ -1934,6 +1934,7 @@ static cudaError_t ggml_cuda_copy2d_across_devices(
 
     const auto & info = ggml_cuda_info();
     if (info.peer_access[src_device][dst_device]) {
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
         cudaMemcpy3DPeerParms p = {};
         p.dstDevice = dst_device;
         p.dstPtr = make_cudaPitchedPtr(dst, dpitch, dpitch, height);
@@ -1941,6 +1942,12 @@ static cudaError_t ggml_cuda_copy2d_across_devices(
         p.srcPtr = make_cudaPitchedPtr(const_cast<void *>(src), spitch, spitch, height);
         p.extent = make_cudaExtent(width, height, 1);
         return cudaMemcpy3DPeerAsync(&p, dst_stream);
+#else
+        // HIP/MUSA do not provide cudaMemcpy3DPeerAsync; with peer access
+        // enabled a plain device-to-device 2D copy works across devices
+        // (same approach as ggml_cuda_Memcpy2DPeerAsync above).
+        return cudaMemcpy2DAsync(dst, dpitch, src, spitch, width, height, cudaMemcpyDeviceToDevice, dst_stream);
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
     }
 
     // Fallback: stage all rows through a single contiguous pinned buffer

--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -82,6 +82,7 @@
 #define cudaErrorMemoryAllocation hipErrorOutOfMemory
 #define cudaErrorPeerAccessAlreadyEnabled hipErrorPeerAccessAlreadyEnabled
 #define cudaErrorPeerAccessNotEnabled hipErrorPeerAccessNotEnabled
+#define cudaEventCreate hipEventCreate
 #define cudaEventCreateWithFlags hipEventCreateWithFlags
 #define cudaEventDisableTiming hipEventDisableTiming
 #define cudaEventRecord hipEventRecord

--- a/ggml/src/ggml-cuda/vendors/musa.h
+++ b/ggml/src/ggml-cuda/vendors/musa.h
@@ -47,6 +47,7 @@
 #define cudaErrorMemoryAllocation musaErrorMemoryAllocation
 #define cudaErrorPeerAccessAlreadyEnabled musaErrorPeerAccessAlreadyEnabled
 #define cudaErrorPeerAccessNotEnabled musaErrorPeerAccessNotEnabled
+#define cudaEventCreate musaEventCreate
 #define cudaEventCreateWithFlags musaEventCreateWithFlags
 #define cudaEventDisableTiming musaEventDisableTiming
 #define cudaEventRecord musaEventRecord


### PR DESCRIPTION
## What

Fixes `-DGGML_HIP=ON` and `-DGGML_MUSA=ON` builds, broken on `feature/turboquant-kv-cache` since #164.

1. **Guard the 3D peer copy in `ggml_cuda_copy2d_across_devices()`** — the function (added in #164) uses `cudaMemcpy3DPeerParms` / `make_cudaPitchedPtr` / `make_cudaExtent` / `cudaMemcpy3DPeerAsync` outside the `!GGML_USE_HIP && !GGML_USE_MUSA` guard that protects the older `ggml_cuda_Memcpy2DPeerAsync()` path. On HIP/MUSA with peer access enabled, fall back to a plain device-to-device `cudaMemcpy2DAsync` (same approach as the upstream `Memcpy2DPeerAsync` HIP path).
2. **Alias `cudaEventCreate`** in `vendors/hip.h` and `vendors/musa.h` — `ggml_backend_cuda_device_event_new()` calls it bare (upstream uses `cudaEventCreateWithFlags`, which was already aliased).

## Why not aliases for the 3D peer API?

The first revision of this PR aliased `cudaMemcpy3DPeerAsync → hipMemcpy3DPeerAsync` etc. (that compiles on recent ROCm 7.x). CI's ROCm rejected it — `error: unknown type name 'hipMemcpy3DPeerParms'; did you mean 'hipMemcpy3DParms'?` — the peer variant of the 3D API isn't available there, so the call-site guard is the portable fix.

## Notes

- The remaining `ubuntu-latest-cuda` failure is pre-existing on the base branch (`set-rows.cu(355): warning #177-D: variable "warp_id" declared but never referenced` + `-Werror all-warnings` in the turbo3 set-rows kernel — untouched by this PR), as is the `macOS-latest-arm64-webgpu` test flake.
- Behavior on CUDA is unchanged; single-GPU HIP behavior is unchanged (the peer path only runs when `info.peer_access` is enabled).