### PR TITLE
server: fix abort on exact prompt-cache match with hybrid/recurrent models

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2701,10 +2701,13 @@ private:
 
                             llama_pos pos_next = slot.prompt.tokens.pos_next(n_past);
 
-                            // the largest pos_min required for a checkpoint to be useful
-                            const auto pos_min_thold = std::max(0, pos_next - n_swa);
+                            // ref: https://github.com/ggml-org/llama.cpp/pull/24110
+                            const bool has_new_tokens = (n_past < slot.task->n_tokens());
 
-                            if (n_past > 0 && n_past < slot.prompt.n_tokens()) {
+                            // the largest pos_min required for a checkpoint to be useful
+                            const auto pos_min_thold = std::max(0, pos_next - n_swa - (has_new_tokens ? 0 : 1));
+
+                            if (n_past > 0 && n_past <= slot.prompt.n_tokens()) {
                                 const auto pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot.id);
                                 if (pos_min == -1) {
                                     SLT_ERR(slot, "n_past = %d, slot.prompt.tokens.size() = %d, seq_id = %d, pos_min = %d\n", n_past, (int) slot.prompt.tokens.size(), slot.id, pos_min);


### PR DESCRIPTION
## Problem

When an incoming prompt **exactly matches** a slot's cached tokens, the server backs off one token (`n_past--`) to guarantee at least one token is decoded for logits. The subsequent truncation calls `seq_rm` with `p0 = n_past > 0`, which **recurrent memory cannot satisfy** (the state can't be rewound to a mid-sequence position when the rollback exceeds `n_rs_seq`), so `common_context_seq_rm` hits `GGML_ABORT` and the whole server dies:

```
common/common.cpp:1472: failed to remove sequence 0 with p0=490, p1=-1
```

Observed in production with Qwen3.6-35B-A3B (hybrid attention + GatedDeltaNet): any client re-sending an identical prompt with `cache_prompt` enabled (regenerate, retry, `n_predict: 0` scoring) crashes the server.

## Reproduction

Any recurrent model, e.g. mamba-130m Q8_0 on CPU:

```bash
llama-server -m mamba-130m.q8_0.gguf --port 8199 -c 2048 -np 1
# POST /completion {"prompt": "<~500-token text>", "n_predict": 0, "cache_prompt": true}  — twice, identical
```

Unpatched, the second request aborts the server:

```
W slot update_slots: ... need to evaluate at least 1 token for each active slot (n_past = 491, task.n_tokens() = 491)
W slot update_slots: ... n_past was set to 490
common/common.cpp:1472: failed to remove sequence 0 with p0=490, p1=-1
```

## Fix

Include the exact-match case (`n_past == slot.prompt.n_tokens()`) in the **existing** checkpoint-restore / full-reprocess branch by relaxing its condition to `n_past <= slot.prompt.n_tokens()` and extending `pos_min_thold` by 1 when there are no new tokens, so the upcoming one-token back-off is accounted for. Recurrent/hybrid models now restore a context checkpoint (or fall back to full re-processing) instead of aborting; attention models are unaffected.

This is a faithful backport of upstream ggml-org/llama.cpp **#23280** (ccee42642) and **#24110** (6f3a9f3de); this fork's merge-base predates both.

## Verification

Patched, same repro sequence (×3): HTTP 200 every time, server stays alive —

```
W ... restored context checkpoint (pos_min = 486, pos_max = 486, n_tokens = 487, n_past = 487, ...)
```

- exact resend: `prompt_n=4` (checkpoint restore; falls back to `n_past = 0` full reprocess when no checkpoint exists)
- grown (appended) prompt: `prompt_n=21` — prefix cache reuse unchanged
- attention-model regression check (stories15M): exact resend `prompt_n=1` (unchanged one-token back-off), grown prompt `prompt_n=8`, no checkpoint restores — no behavior change for non-recurrent models