### PR TITLE
HIP: fix turbo KV decode crash under graph capture; batch-aware VEC/TILE FA routing

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -1315,6 +1315,13 @@ void launch_fattn(
     //
     // Small batches (Q->ne[1] <= 8) always route through the pool so the warmup run
     // populates it; these match the decode/speculative cases that get captured.
+    //
+    // Caveat (memory, not correctness): when a captured decode cannot use VEC
+    // (head_dim == 192, or K->ne[1] not a multiple of FATTN_KQ_STRIDE) it falls
+    // through to this TILE/MMA path and pool-allocs the full f16 dequant buffer.
+    // The legacy pool then retains that buffer permanently -- these configs trade
+    // VRAM for graph compatibility. VEC-eligible head dims (e.g. Gemma) never hit
+    // this: their decode uses the VEC kernel, which does not call launch_fattn.
     cudaStreamCaptureStatus fa_capture_status = cudaStreamCaptureStatusNone;
     CUDA_CHECK(cudaStreamIsCapturing(main_stream, &fa_capture_status));
     const bool fa_use_pool = (fa_capture_status != cudaStreamCaptureStatusNone) || (Q->ne[1] <= 8);

--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -1298,17 +1298,41 @@ void launch_fattn(
     const int nsm = ggml_cuda_info().devices[id].nsm;
 
 #ifdef GGML_USE_HIP
-    // HIP/ROCm: bypass the memory pool for f16 temp buffers.
-    // The legacy pool (ggml_cuda_pool_leg) retains peak-sized allocations permanently.
-    // For quantized KV dequant, this means the f16 temp buffer stays allocated,
-    // consuming more VRAM than the quantized KV compression saves — causing OOM.
-    // Using raw alloc+free ensures the memory is released after the kernel completes.
+    // HIP/ROCm: the f16 dequant temp buffers for quantized KV need two strategies
+    // depending on whether the current launch is being captured into a HIP graph:
+    //
+    //  * NOT capturing (large prefill batches run eagerly): use raw cudaMalloc/cudaFree
+    //    so the (potentially multi-GB) f16 dequant buffer is released immediately. The
+    //    legacy pool (no VMM on gfx1201) would otherwise retain it at peak size and
+    //    negate the quantized-KV VRAM savings -> OOM.
+    //
+    //  * Capturing (small decode batches captured into a graph): raw cudaMalloc/cudaFree/
+    //    cudaStreamSynchronize are forbidden during capture ("operation not permitted
+    //    when stream is capturing"). Use the memory pool instead. ggml resets graph
+    //    warmup and runs eagerly whenever tensor sizes change, so the pool buffer is
+    //    always warmed at the right size before capture and alloc() reuses it without
+    //    calling cudaMalloc during capture.
+    //
+    // Small batches (Q->ne[1] <= 8) always route through the pool so the warmup run
+    // populates it; these match the decode/speculative cases that get captured.
+    cudaStreamCaptureStatus fa_capture_status = cudaStreamCaptureStatusNone;
+    CUDA_CHECK(cudaStreamIsCapturing(main_stream, &fa_capture_status));
+    const bool fa_use_pool = (fa_capture_status != cudaStreamCaptureStatusNone) || (Q->ne[1] <= 8);
+
     struct hip_f16_alloc {
-        half * ptr = nullptr;
-        cudaStream_t stream;
-        hip_f16_alloc(cudaStream_t s) : stream(s) {}
+        half           * ptr  = nullptr;
+        ggml_cuda_pool * mem_pool = nullptr;  // non-null => allocate from the pool (graph-safe)
+        size_t           pool_size = 0;
+        cudaStream_t     stream;
+        hip_f16_alloc(cudaStream_t s, ggml_cuda_pool * p) : mem_pool(p), stream(s) {}
         ~hip_f16_alloc() {
-            if (ptr) {
+            if (!ptr) {
+                return;
+            }
+            if (mem_pool) {
+                // Pool free is plain bookkeeping (no CUDA calls) -> safe during capture.
+                mem_pool->free(ptr, pool_size);
+            } else {
                 // Cast to void: hipStreamSynchronize / hipFree are [[nodiscard]] under
                 // HIP's -Werror policy; we're in a destructor and can't propagate errors.
                 (void) cudaStreamSynchronize(stream);
@@ -1316,11 +1340,15 @@ void launch_fattn(
             }
         }
         void alloc(size_t nelements) {
-            CUDA_CHECK(cudaMalloc(&ptr, nelements * sizeof(half)));
+            if (mem_pool) {
+                ptr = (half *) mem_pool->alloc(nelements * sizeof(half), &pool_size);
+            } else {
+                CUDA_CHECK(cudaMalloc(&ptr, nelements * sizeof(half)));
+            }
         }
     };
-    hip_f16_alloc K_f16(main_stream);
-    hip_f16_alloc V_f16(main_stream);
+    hip_f16_alloc K_f16(main_stream, fa_use_pool ? &pool : nullptr);
+    hip_f16_alloc V_f16(main_stream, fa_use_pool ? &pool : nullptr);
 #else
     ggml_cuda_pool_alloc<half>   K_f16(pool);
     ggml_cuda_pool_alloc<half>   V_f16(pool);

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -538,14 +538,17 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
     const bool can_use_vector_kernel = Q->ne[0] <= 256 && Q->ne[0] % 64 == 0 && Q->ne[0] != 192 && K->ne[1] % FATTN_KQ_STRIDE == 0;
 
 #ifdef GGML_USE_HIP
-    // HIP/ROCm: the TILE/MMA/WMMA FA paths allocate unbounded f16 temp buffers
-    // for quantized KV types (K_f16, V_f16 in launch_fattn). The pool retains
-    // peak allocation size, so the temp buffer VRAM exceeds KV compression savings.
-    // This causes quantized KV to OOM before f16 on the same context length.
-    // Force VEC path which does inline dequant with zero temp buffer overhead.
-    // Trade-off: prefill is slower (sequential query processing).
+    // HIP/ROCm: the TILE/MMA/WMMA FA paths allocate large f16 temp buffers for
+    // quantized KV types (K_f16, V_f16 in launch_fattn). For SMALL batches (decode)
+    // the VEC kernel is preferred: it does inline dequant with zero temp buffer
+    // overhead, it natively supports the TurboQuant types, and it produces a
+    // HIP-graph-safe op stream (no per-call cudaMalloc/cudaFree during capture).
+    // For LARGE batches (prefill) the VEC kernel is far slower (sequential query
+    // processing), so we deliberately fall through to the TILE/MMA path which is
+    // ~3.4x faster; prefill runs eagerly (not captured) so its f16 temp buffer is
+    // allocated/freed raw in launch_fattn without violating graph-capture rules.
     // Limitation: head_dim > 256 cannot use VEC (falls through to TILE).
-    if ((ggml_is_quantized(K->type) || ggml_is_quantized(V->type)) && can_use_vector_kernel) {
+    if ((ggml_is_quantized(K->type) || ggml_is_quantized(V->type)) && can_use_vector_kernel && Q->ne[1] <= 8) {
         return BEST_FATTN_KERNEL_VEC;
     }
 #endif // GGML_USE_HIP


### PR DESCRIPTION
With `GGML_HIP_GRAPHS=ON`, any turbo KV cache type crashes on the first decode step on RDNA4:

```
FLASH_ATTN_EXT failed: operation not permitted when stream is capturing
```

Two coupled causes:

1. The force-VEC condition for quantized KV applies to all batch sizes, so large prefill batches also run the sequential VEC kernel (~188 t/s pp2048 on gfx1201).
2. `launch_fattn`'s f16 dequant temp buffers (`K_f16`/`V_f16`) use raw `cudaMalloc`/`cudaFree`/`cudaStreamSynchronize`, which are illegal during graph capture.

The raw alloc exists for a good reason on gfx1201 (no VMM): the legacy pool would retain the multi-GB dequant buffer permanently and negate the quantized-KV VRAM savings. So the fix has to be capture-aware rather than always-pool.

### Changes

- `fattn.cu`: only force VEC for small batches (`Q->ne[1] <= 8`). Decode stays on the graph-safe VEC path (inline dequant, no temp buffer); large prefill batches fall through to the TILE/MMA kernel.
- `fattn-common.cuh`: check `cudaStreamIsCapturing`; allocate `K_f16`/`V_f16` from the ggml pool while capturing (pool alloc/free make no CUDA calls), keep raw alloc + immediate free for large eager prefill. This is safe because ggml resets graph warmup whenever tensor sizes change, so the pool buffer is warmed at the right size before any capture.

### Results

gfx1201 (Radeon AI PRO R9700, 32 GB), Windows 11, HIP SDK 7.1, Gemma-4-31B-it Q4_K_M:

| Config | pp2048 | tg128 | decode crash |
|---|---|---|---|
| HIP_GRAPHS=OFF, turbo4 | 188 t/s | ~22 t/s | no |
| HIP_GRAPHS=ON, unpatched, turbo4 | — | — | yes (first step) |
| HIP_GRAPHS=ON + this patch, turbo4 | 735 t/s | 22.9 t/s | no |

Long context with `-b 2048 -ub 512`: turbo3/turbo3 tg128 @ d131072 = 9.38 ± 0.93 t/s; the full 256K context loads in ~22.9 GB. Quality checked with KLD vs an f16 baseline and needle-in-a-haystack (9/9 for q8_0/turbo4 and turbo3/turbo3). Full methodology, raw data and a one-command repro build for gfx1201: https://github.com/KaiFelixBennett/gemma4-turboquant-rdna4

Possibly related: #12 (turbo3 crash on an RX 9070 XT — same gfx1201 family, closed as stale).

Originally developed and benchmarked at 7d9715f; rebased onto 73eb521 (the fattn files were untouched in between) and built warning-free there. Can re-run any of the benchmarks on this hardware if useful.
