### PR TITLE
fix: tolerate leading whitespace before <think> tags in PEG parsers

### DIFF
--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -158,7 +158,9 @@ common_peg_parser analyze_reasoning::build_parser(parser_build_context & ctx) co
         if (!end.empty()) {
             if (!start.empty()) {
                 // Standard tag-based: optional(<think>reasoning</think>)
-                return p.optional(p.optspace(start) + p.reasoning(p.until(trim_whitespace(end))) + p.optspace(end));
+                // Allow optional whitespace before the start tag — some models
+                // emit a newline before reasoning begins.
+                return p.optional(p.space() + p.optspace(start) + p.reasoning(p.until(trim_whitespace(end))) + p.optspace(end));
             }
             // Delimiter-style (empty start)
             return p.optional(p.reasoning(p.until(trim_whitespace(end))) + p.optspace(end));

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1540,7 +1540,7 @@ static common_chat_params common_chat_params_init_kimi_k2(const common_chat_temp
 
         // Note: this model is CRAZY. It can diverge from its supposed tool calling pattern in so many ways it's not funny.
         // For example, it can call tools at the end of reasoning without closing reasoning...
-        auto reasoning = extract_reasoning ? p.optional(THINK_START + p.reasoning(
+        auto reasoning = extract_reasoning ? p.optional(p.space() + THINK_START + p.reasoning(
             p.until_one_of({ THINK_END, "<|tool_calls_section_begin|>", "<|tool_call_begin|>" })) +
             p.optional(p.literal(THINK_END))) : p.eps();
         auto generation_prompt = p.literal(GEN_PROMPT);
@@ -1671,7 +1671,9 @@ static common_chat_params common_chat_params_init_lfm2(const common_chat_templat
 
         auto reasoning = p.eps();
         if (extract_reasoning) {
-            reasoning = p.optional(THINK_START + p.reasoning(p.until(THINK_END)) + THINK_END);
+            // Allow optional whitespace before <think> — some models emit a
+            // newline between the generation prompt and the thinking tag.
+            reasoning = p.optional(p.space() + THINK_START + p.reasoning(p.until(THINK_END)) + THINK_END);
         }
 
         if (!has_tools || inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_NONE) {
@@ -1848,11 +1850,13 @@ static common_chat_params common_chat_params_init_deepseek_v3_2(const common_cha
 
         auto reasoning = p.eps();
         if (extract_reasoning && inputs.enable_thinking) {
-            reasoning = p.optional(THINK_START + p.reasoning(p.until(THINK_END)) + THINK_END);
+            // Allow optional whitespace before <think> — some models emit a
+            // newline between the generation prompt and the thinking tag.
+            reasoning = p.optional(p.space() + THINK_START + p.reasoning(p.until(THINK_END)) + THINK_END);
         } else if (extract_reasoning) {
             // Thinking disabled but reasoning extraction requested: the generation prompt
             // contains an empty <think></think> pair that must still be consumed.
-            reasoning = p.optional(p.literal(THINK_START) + p.until(THINK_END) + p.literal(THINK_END));
+            reasoning = p.optional(p.space() + p.literal(THINK_START) + p.until(THINK_END) + p.literal(THINK_END));
         }
 
         if (has_response_format) {


### PR DESCRIPTION
## Summary

Several specialized PEG parsers (Kimi K2, LFM2, DeepSeek v3.2) and the auto-parser require `<think>` to appear **immediately** after the generation prompt. When the model emits a leading newline (or any whitespace) before `<think>`, the PEG parser silently skips the optional reasoning block inside `p.optional(...)` and the entire think-tag content falls through to `p.content(p.rest())` — no `reasoning_content` is produced.

## Root cause

The model template renders `add_generation_prompt` as something like `<|im_start|>assistant\n`, and the model frequently emits an extra `\n` before the `<think>` tag:

```
<|im_start|>assistant\n\n<think>reasoning content</think>final answer
```

All five affected sites use a pattern like `p.optional(THINK_START + ...)` with no tolerance for whitespace before the tag literal.

## Fix

Insert `p.space()` (zero-or-more whitespace: space, tab, newline) before each start-tag match. `p.space()` is defined in `common/peg-parser.h:420-422` and is safe when no whitespace precedes the tag (matches zero characters).

### Affected locations

| Handler | File | Line | Pattern |
|---------|------|------|---------|
| Kimi K2 | `common/chat.cpp` | 1543 | `p.optional(THINK_START + ...)` |
| LFM2 | `common/chat.cpp` | 1674 | `p.optional(THINK_START + ...)` |
| DeepSeek v3.2 (thinking on) | `common/chat.cpp` | 1851 | `p.optional(THINK_START + ...)` |
| DeepSeek v3.2 (thinking off) | `common/chat.cpp` | 1855 | `p.optional(p.literal(THINK_START) + ...)` |
| Auto-parser catch-all | `common/chat-auto-parser-generator.cpp` | 161 | `p.optional(p.optspace(start) + ...)` |

All five get the same fix: `p.optional(p.space() + <start-tag-match> + ...)`.

## Testing

- Load an LFM2.5 model (e.g. `LFM2.5-1.2B-Thinking-Q8_0.gguf`)
- Enable `--reasoning on` with `--reasoning-format auto`
- Send a chat request — before fix, `<think>` content appears in `output_text` / `message.content` instead of `reasoning_content`
- After fix, reasoning correctly populates `reasoning_content` / `response.reasoning_text.delta`
