### PR TITLE
vulkan: fuse TurboQuant K/V dequant into flash attention

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -16873,14 +16873,13 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                     case GGML_TYPE_Q4_1:
                     case GGML_TYPE_Q4_0:
                         return true;
-                    // TurboQuant K/V flash-attention is not supported on Vulkan: the
-                    // turbo FA dequant path was dropped in the upstream catch-up and the
-                    // turbo3 FA SPIR-V variant is not generated (no pipeline), so report
-                    // these as unsupported rather than dispatching to a missing kernel.
+                    // TurboQuant K/V flash attention: dequant is fused into the
+                    // scalar/coopmat1 FA shaders via dequantize4() (flash_attn_dequant.glsl),
+                    // so the standard f16 FA pipeline handles turbo K/V.
                     case GGML_TYPE_TURBO2_0:
                     case GGML_TYPE_TURBO3_0:
                     case GGML_TYPE_TURBO4_0:
-                        return false;
+                        return true;
                     case GGML_TYPE_Q1_0:
                         return coopmat2;
                     default:

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_base.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_base.glsl
@@ -99,6 +99,9 @@ layout (binding = 6) readonly buffer MO {uint32_t data_mask_opt[];};
 #define FA_TYPE_Q8_0  8u
 #define FA_TYPE_BF16 30u
 #define FA_TYPE_Q1_0 41u
+#define FA_TYPE_TURBO2_0 42u
+#define FA_TYPE_TURBO3_0 43u
+#define FA_TYPE_TURBO4_0 44u
 
 #if defined(BFLOAT16)
 #define O_TYPE float

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_dequant.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_dequant.glsl
@@ -33,6 +33,18 @@ layout (binding = 2) readonly buffer V_PACKED_Q8_0 { block_q8_0_packed16 data[];
 layout (binding = 1) readonly buffer K_PACKED_BF16 { u16vec4 data[]; } k_packed_bf16;
 layout (binding = 2) readonly buffer V_PACKED_BF16 { u16vec4 data[]; } v_packed_bf16;
 
+// TurboQuant K/V views. Explicit std430 + restrict because the turbo blocks have
+// a different (larger) stride than the q4/q5/q8 views aliased at the same binding
+// (turbo3 is a 50-byte block), so the driver must not assume a uniform stride.
+// Graph applies forward WHT to Q pre-attention and inverse WHT to FA output, so
+// dequant just returns centroid * norm.
+layout (binding = 1, std430) restrict readonly buffer K_PACKED_TURBO2_0 { block_turbo2_0 data[]; } k_packed_turbo2_0;
+layout (binding = 2, std430) restrict readonly buffer V_PACKED_TURBO2_0 { block_turbo2_0 data[]; } v_packed_turbo2_0;
+layout (binding = 1, std430) restrict readonly buffer K_PACKED_TURBO3_0 { block_turbo3_0 data[]; } k_packed_turbo3_0;
+layout (binding = 2, std430) restrict readonly buffer V_PACKED_TURBO3_0 { block_turbo3_0 data[]; } v_packed_turbo3_0;
+layout (binding = 1, std430) restrict readonly buffer K_PACKED_TURBO4_0 { block_turbo4_0 data[]; } k_packed_turbo4_0;
+layout (binding = 2, std430) restrict readonly buffer V_PACKED_TURBO4_0 { block_turbo4_0 data[]; } v_packed_turbo4_0;
+
 // Q4_1 and Q5_1 packed32 views: aliased to the same memory as the packed16
 // views, used by the MMQ K-side hot path for fast 4-uint loads.
 layout (binding = 1) readonly buffer K_PACKED_Q4_1_P32 { block_q4_1_packed32 data[]; } k_packed_q4_1_p32;
@@ -107,6 +119,55 @@ layout (binding = 1) readonly buffer K_PACKED_Q5_1_P32 { block_q5_1_packed32 dat
 #define FA_DEQUANT4_BF16(BUF) \
     return FLOAT_TYPEV4(bf16_to_fp32(uvec4(BUF.data[(a_offset + ib) / 4])));
 
+// TurboQuant2 dequant: 2-bit centroids, no signs byte. All 4 elements share
+// qs byte (iqs/4) at iqs%4==0.
+#define FA_DEQUANT4_TURBO2_0(BUF) {                                                               \
+    const float c[4] = float[4](-0.133462, -0.039994, 0.039994, 0.133462);                        \
+    const float norm = float(BUF.data[a_offset + ib].norm);                                       \
+    const uint qs_byte = uint(BUF.data[a_offset + ib].qs[iqs / 4]);                               \
+    const uint i0 = (qs_byte     ) & 0x3u;                                                         \
+    const uint i1 = (qs_byte >> 2) & 0x3u;                                                         \
+    const uint i2 = (qs_byte >> 4) & 0x3u;                                                         \
+    const uint i3 = (qs_byte >> 6) & 0x3u;                                                         \
+    return FLOAT_TYPE(norm) * FLOAT_TYPEV4(c[i0], c[i1], c[i2], c[i3]);                           \
+}
+
+// TurboQuant3 dequant: per-element centroid lookup. iqs is in [0, 128) at vec4
+// alignment (iqs%4 == 0), so all 4 elements share qs byte (iqs/4) and signs
+// byte (iqs/8). No iWHT here, the graph handles rotation outside FA.
+#define FA_DEQUANT4_TURBO3_0(BUF) {                                                               \
+    const float c[8] = float[8](                                                                  \
+        -0.190685, -0.117832, -0.065717, -0.021460,                                               \
+         0.021460,  0.065717,  0.117832,  0.190685);                                              \
+    const float norm = float(BUF.data[a_offset + ib].norm);                                       \
+    const uint qs_byte  = uint(BUF.data[a_offset + ib].qs[iqs / 4]);                              \
+    const uint sgn_byte = uint(BUF.data[a_offset + ib].signs[iqs / 8]);                           \
+    const uint base = iqs & 0x7u;                                                                 \
+    const uint i0 = ((qs_byte     ) & 0x3) | (((sgn_byte >> (base    )) & 0x1u) << 2);            \
+    const uint i1 = ((qs_byte >> 2) & 0x3) | (((sgn_byte >> (base + 1)) & 0x1u) << 2);            \
+    const uint i2 = ((qs_byte >> 4) & 0x3) | (((sgn_byte >> (base + 2)) & 0x1u) << 2);            \
+    const uint i3 = ((qs_byte >> 6) & 0x3) | (((sgn_byte >> (base + 3)) & 0x1u) << 2);            \
+    return FLOAT_TYPE(norm) * FLOAT_TYPEV4(c[i0], c[i1], c[i2], c[i3]);                           \
+}
+
+// TurboQuant4 dequant: 4-bit indices, 2 per byte. iqs%4==0 means the 4
+// elements span 2 consecutive qs bytes (each holds 2 nibbles).
+#define FA_DEQUANT4_TURBO4_0(BUF) {                                                               \
+    const float c[16] = float[16](                                                                \
+        -0.173926, -0.117195, -0.089527, -0.068756,                                               \
+        -0.051262, -0.035597, -0.020989, -0.006938,                                               \
+         0.006938,  0.020989,  0.035597,  0.051262,                                               \
+         0.068756,  0.089527,  0.117195,  0.173926);                                              \
+    const float norm = float(BUF.data[a_offset + ib].norm);                                       \
+    const uint b0 = uint(BUF.data[a_offset + ib].qs[iqs / 2    ]);                                \
+    const uint b1 = uint(BUF.data[a_offset + ib].qs[iqs / 2 + 1]);                                \
+    const uint i0 = (b0     ) & 0xFu;                                                              \
+    const uint i1 = (b0 >> 4) & 0xFu;                                                              \
+    const uint i2 = (b1     ) & 0xFu;                                                              \
+    const uint i3 = (b1 >> 4) & 0xFu;                                                              \
+    return FLOAT_TYPE(norm) * FLOAT_TYPEV4(c[i0], c[i1], c[i2], c[i3]);                           \
+}
+
 FLOAT_TYPEV4 dequantize4(uint ib, uint iqs, uint a_offset, uint binding_idx) {
     if (binding_idx == BINDING_IDX_K) {
         switch (FaTypeK) {
@@ -117,6 +178,9 @@ FLOAT_TYPEV4 dequantize4(uint ib, uint iqs, uint a_offset, uint binding_idx) {
             case FA_TYPE_Q5_1: FA_DEQUANT4_Q5_1(k_packed_q5_1)
             case FA_TYPE_Q8_0: FA_DEQUANT4_Q8_0(k_packed_q8_0)
             case FA_TYPE_BF16: FA_DEQUANT4_BF16(k_packed_bf16)
+            case FA_TYPE_TURBO2_0: FA_DEQUANT4_TURBO2_0(k_packed_turbo2_0)
+            case FA_TYPE_TURBO3_0: FA_DEQUANT4_TURBO3_0(k_packed_turbo3_0)
+            case FA_TYPE_TURBO4_0: FA_DEQUANT4_TURBO4_0(k_packed_turbo4_0)
         }
     } else {
         switch (FaTypeV) {
@@ -127,6 +191,9 @@ FLOAT_TYPEV4 dequantize4(uint ib, uint iqs, uint a_offset, uint binding_idx) {
             case FA_TYPE_Q5_1: FA_DEQUANT4_Q5_1(v_packed_q5_1)
             case FA_TYPE_Q8_0: FA_DEQUANT4_Q8_0(v_packed_q8_0)
             case FA_TYPE_BF16: FA_DEQUANT4_BF16(v_packed_bf16)
+            case FA_TYPE_TURBO2_0: FA_DEQUANT4_TURBO2_0(v_packed_turbo2_0)
+            case FA_TYPE_TURBO3_0: FA_DEQUANT4_TURBO3_0(v_packed_turbo3_0)
+            case FA_TYPE_TURBO4_0: FA_DEQUANT4_TURBO4_0(v_packed_turbo4_0)
         }
     }
     return FLOAT_TYPEV4(0);


### PR DESCRIPTION
## Fuse TurboQuant K/V dequant into Vulkan flash attention

Fixes the turbo V-cache flash-attention regression on Vulkan reported on a Strix Halo (gfx1151) box and reproduced on RDNA4 (gfx1201).

### Problem
`-fa on -ctk q8_0 -ctv turbo3` (or `turbo4`) regressed 2-6x vs `-ctk f16 -ctv f16 -fa on`, GPU pegged the whole time (not a CPU fallback). The upstream catch-up adopted upstream's evolved FA shaders, which dropped the fork's turbo dequant out of `flash_attn_dequant.glsl`. So turbo K/V no longer had a fused decode path inside the FA shader, while CUDA/Metal keep their fused turbo FA kernels. Every decode step paid a per-token turbo dequant cost.

### Fix
Restore the fused path the same way q8_0 works:
- Add turbo2/3/4 SSBO views and `FA_DEQUANT4_TURBO2/3/4_0` decode macros to `flash_attn_dequant.glsl`.
- Wire them into the `dequantize4()` `FaTypeK`/`FaTypeV` switch.
- Add `FA_TYPE_TURBO2_0/3_0/4_0` constants to `flash_attn_base.glsl`.
- Report turbo K/V as supported for `FLASH_ATTN_EXT` again in `ggml-vulkan.cpp`.

This uses the per-element switch path, not a separate `DATA_A_TURBO3_0` shader variant (that variant cannot be compiled by glslc against the current upstream FA base). It covers the asymmetric `K=q8_0 / V=turbo3|turbo4` configuration used in practice.

### Validation (RX 9070 XT, gfx1201, Vulkan KHR_coopmat)
- `test-backend-ops -o FLASH_ATTN_EXT`: 528 turbo cases, 0 failures (matches CPU reference).
- qwen2.5-7b decode, `-fa on`:

| KV config | before | after |
|---|---:|---:|
| f16 / f16 | 42.6 | 42.6 |
| q8_0 / turbo3 | 17.8 | 42.5 |
| q8_0 / turbo4 | 19.0 | 42.5 |

Turbo KV flash attention now runs at f16 speed, the per-token dequant cost is gone.

### Notes
- Symmetric K=V=turbo3 uses the same aliased switch path here. If RADV/gfx1151 shows SSBO alias stride issues for the symmetric case, the follow-up is the separate-binding turbo3 FA variant (currently disabled because it hangs glslc against the new FA base).
