### PR TITLE
vulkan: submit more frequently on integrated GPUs to fix #185 device-lost (gfx1151/RADV)

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -15862,7 +15862,21 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
     // Estimate the amount of matmul work by looking at the weight matrix size, and submit every 100MB
     // (and scaled down based on model size, so smaller models submit earlier).
     // Also submit at least every 100 nodes, in case there are workloads without as much matmul.
-    int nodes_per_submit = 100;
+    // On integrated GPUs / APUs, batching too much work into a single vkQueueSubmit
+    // can exceed the GPU job watchdog (e.g. amdgpu.lockup_timeout default 2000ms on
+    // RADV) and trigger a device-lost at deep context / heavy graphs (issue #185; cf.
+    // upstream ggml-org/llama.cpp#21724, where lowering this resolves the same
+    // ErrorDeviceLost with no measurable regression). The byte-based submit heuristic
+    // below only accounts for matmul work, so flash-attention-heavy graphs (e.g. the
+    // dense MTP head doing full attention over deep KV) can otherwise accumulate far
+    // past the timeout. Submit frequently on uma devices; allow an env override.
+    int nodes_per_submit = ctx->device->uma ? 1 : 100;
+    if (const char * env_nps = getenv("GGML_VK_NODES_PER_SUBMIT")) {
+        const int v = atoi(env_nps);
+        if (v > 0) {
+            nodes_per_submit = v;
+        }
+    }
     int submitted_nodes = 0;
     int submit_count = 0;
     uint64_t mul_mat_bytes = 0;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -10185,6 +10185,18 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
                                               mask_n_head_log2, m0, m1,
                                               gqa_ratio, split_kv, split_k };
 
+    // Diagnostic: per-FLASH_ATTN_EXT dispatch parameters (GGML_VK_FA_LOG=1). The
+    // last line before a device-lost identifies the crashing dispatch (issue #185):
+    // KV/N/gqa drive the single-submit GPU runtime vs the amdgpu watchdog, and
+    // split_k/split_kv/wg show whether/how it is being chunked.
+    if (getenv("GGML_VK_FA_LOG")) {
+        fprintf(stderr, "[FA] N=%u KV=%u gqa=%u K=%s V=%s mask=%d mask_opt=%d uma=%d "
+                        "split_k=%u split_kv=%u wg=[%u,%u,%u]\n",
+                N, KV, gqa_ratio, ggml_type_name(k->type), ggml_type_name(v->type),
+                mask != nullptr, (int) use_mask_opt, (int) ctx->device->uma,
+                split_k, split_kv, workgroups_x, workgroups_y, workgroups_z);
+    }
+
     if (split_k > 1) {
         ggml_pipeline_request_descriptor_sets(ctx, ctx->device->pipeline_flash_attn_split_k_reduce, 1);
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -10185,18 +10185,6 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
                                               mask_n_head_log2, m0, m1,
                                               gqa_ratio, split_kv, split_k };
 
-    // Diagnostic: per-FLASH_ATTN_EXT dispatch parameters (GGML_VK_FA_LOG=1). The
-    // last line before a device-lost identifies the crashing dispatch (issue #185):
-    // KV/N/gqa drive the single-submit GPU runtime vs the amdgpu watchdog, and
-    // split_k/split_kv/wg show whether/how it is being chunked.
-    if (getenv("GGML_VK_FA_LOG")) {
-        fprintf(stderr, "[FA] N=%u KV=%u gqa=%u K=%s V=%s mask=%d mask_opt=%d uma=%d "
-                        "split_k=%u split_kv=%u wg=[%u,%u,%u]\n",
-                N, KV, gqa_ratio, ggml_type_name(k->type), ggml_type_name(v->type),
-                mask != nullptr, (int) use_mask_opt, (int) ctx->device->uma,
-                split_k, split_kv, workgroups_x, workgroups_y, workgroups_z);
-    }
-
     if (split_k > 1) {
         ggml_pipeline_request_descriptor_sets(ctx, ctx->device->pipeline_flash_attn_split_k_reduce, 1);
 


### PR DESCRIPTION
## Fix for #185: draft-mtp device-lost at deep context on gfx1151 / Vulkan RADV

### Root cause
On hybrid Qwen3.5/3.6 the dense MTP head is the only full-KV attention path (the main model is SWA + DeltaNet). At deep context the Vulkan graph batches a large amount of work, including that full-attention MTP dispatch, into a single `vkQueueSubmit`. On integrated GPUs / APUs that can exceed the amdgpu job watchdog (default `lockup_timeout` ~2000ms on RADV) and trigger an `ErrorDeviceLost`. The byte-based submit heuristic only accounts for matmul work, so flash-attention-heavy graphs slip past it.

### Fix
Submit more frequently on uma devices:

```cpp
int nodes_per_submit = ctx->device->uma ? 1 : 100;
```

with a `GGML_VK_NODES_PER_SUBMIT` env override for tuning. Discrete GPUs are unaffected (`uma == false` keeps the existing 100). Mirrors upstream ggml-org/llama.cpp#21724, which resolves the same `ErrorDeviceLost` with no measurable regression.

### Validation
- **gfx1151 / RADV (Strix Halo, Radeon 8060S), the exact repro hardware:** prefilled to **70,020 tokens** with `--spec-type draft-mtp` and finished normally, 0 device-lost (previously crashed every run at ~43k to 47k). Confirmed by @Defilan.
- **gfx1201 (RX 9070 XT) and Blackwell (5090):** no regression; both are discrete (`uma == false`), so behavior is unchanged.

### Notes
- The investigation-time `GGML_VK_FA_LOG` diagnostic was removed before merge now that the fix is validated.
- The earlier per-workgroup-KV `split_k` approach (this PR's original title) was dropped: on the repro box `split_k` stayed 1 all the way to 70k with no crash, confirming the submit frequency, not FA chunking, is the operative fix.
