### PR TITLE
Remove duplicated spirv-headers from package.nix

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -17,7 +17,6 @@
   rocmPackages,
   vulkan-headers,
   vulkan-loader,
-  spirv-headers,
   openssl,
   shaderc,
   spirv-headers,


### PR DESCRIPTION
- Remove redundant `spirv-headers` from package.nix
- Package now builds using Nix

## Overview

- Remove redundant `spirv-headers` from package.nix
- To test the changes, run `nix build .\#packages.<YOUR_SYSTEM_ARCH>.default` or any output you want (I've only tested the build for the CUDA output)

## Additional information

Trying to build this package with Nix. The build failed due to a duplicated `spirv-headers` input.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

