### PR TITLE
Fix server checkpoints with parallel restore

### DIFF
--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -166,8 +166,7 @@ llama_kv_cache::llama_kv_cache(
     // #24060/MTP fix: iterate ALL layers (incl. nextn) so an all-nextn draft
     // (gemma4-assistant: n_layer()==0) registers its KV layers; has_kv() still
     // gates per-layer. Upstream loops the full hparams.n_layer member here.
-    const uint32_t n_layer    = hparams.n_layer_all;
-    const uint32_t n_layer_kv = hparams.n_layer_kv();
+    const uint32_t n_layer = hparams.n_layer_all;
 
     // define a comparator for the buft -> ctx map to ensure that the order is well-defined:
     struct ggml_backend_buft_comparator {
@@ -183,7 +182,10 @@ llama_kv_cache::llama_kv_cache(
         if (it == ctx_map.end()) {
             ggml_init_params params = {
                 // +3 for turbo rotation matrices (turbo_rotation + turbo_rotation_inv + turbo_innerq_scale_inv)
-                /*.mem_size   =*/ size_t((2u*(1 + n_stream)*n_layer_kv + 3)*ggml_tensor_overhead()),
+                // Size this for the actual layer loop below. Some models expose extra
+                // KV-bearing layers through n_layer_all, and under-reserving tensor
+                // metadata corrupts later KV/checkpoint operations.
+                /*.mem_size   =*/ size_t((2u*(1 + n_stream)*n_layer + 3)*ggml_tensor_overhead()),
                 /*.mem_buffer =*/ NULL,
                 /*.no_alloc   =*/ true,
             };

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -121,6 +121,10 @@ struct server_slot {
     bool has_next_token = true;
     bool has_new_line   = false;
     bool truncated      = false;
+    // A restored checkpoint leaves a short prompt suffix to evaluate. Keep that
+    // suffix out of mixed decode batches; the CUDA path is not stable when it is
+    // evaluated concurrently with other active slots.
+    bool prompt_checkpoint_restored = false;
 
     stop_type stop;
 
@@ -218,6 +222,7 @@ struct server_slot {
         generated_text = "";
         has_new_line   = false;
         truncated      = false;
+        prompt_checkpoint_restored = false;
         stop           = STOP_TYPE_NONE;
         stopping_word  = "";
         n_sent_text    = 0;
@@ -2669,9 +2674,17 @@ private:
         std::vector<server_slot *> generating;
         std::vector<server_slot *> drafting;
 
+        const bool has_checkpoint_restored_prompt = std::any_of(slots.begin(), slots.end(), [](const server_slot & slot) {
+            return slot.prompt_checkpoint_restored && slot.state == SLOT_STATE_PROCESSING_PROMPT;
+        });
+
         // determine which slots are generating and drafting
         for (auto & slot : slots) {
             if (slot.state != SLOT_STATE_GENERATING) {
+                continue;
+            }
+
+            if (has_checkpoint_restored_prompt) {
                 continue;
             }
 
@@ -3061,6 +3074,7 @@ private:
 
                                         pos_next = std::min(pos_next, std::max(it->pos_min + 1, it->pos_max));
                                         n_past   = std::min(slot.prompt.tokens.size_up_to_pos(pos_next), (size_t) it->n_tokens);
+                                        slot.prompt_checkpoint_restored = true;
                                         SLT_WRN(slot, "restored context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_past = %d, size = %.3f MiB)\n", it->pos_min, it->pos_max, it->n_tokens, n_past, (float) it->size() / 1024 / 1024);
                                     }
 
@@ -3110,6 +3124,10 @@ private:
                             }
                         }
                     } // end of SLOT_STATE_STARTED
+
+                    if (slot.prompt_checkpoint_restored && n_tokens_prev > 0) {
+                        continue;
+                    }
 
                     if (!slot.can_split()) {
                         // cannot fit the prompt in the current batch - will try next iter
@@ -3281,6 +3299,7 @@ private:
 
                         slot.n_decoded = 0;
                         slot.i_batch   = batch.n_tokens - 1;
+                        slot.prompt_checkpoint_restored = false;
 
                         slot.init_sampler();
                     } else {
@@ -3327,12 +3346,17 @@ private:
 
                     // no need to create checkpoints that are too close together
                     do_checkpoint = do_checkpoint && (slot.prompt.checkpoints.empty() || n_tokens_start > slot.prompt.checkpoints.back().n_tokens + params_base.checkpoint_min_step);
+
                     SLT_DBG(slot, "main/do_checkpoint = %s, pos_min = %d, pos_max = %d\n", do_checkpoint ? "yes" : "no", pos_min, pos_max);
 
                     // note: we create the checkpoint before calling llama_decode(), so the current batch is not
                     //       yet processed and therefore it is not part of the checkpoint.
                     if (do_checkpoint) {
                         create_checkpoint(slot, n_tokens_cur, pos_min, pos_max);
+                    }
+
+                    if (slot.prompt_checkpoint_restored || (!slot.prompt.checkpoints.empty() && near_prompt_end)) {
+                        break;
                     }
                 }
 


### PR DESCRIPTION
## Summary

This fixes the CUDA failure seen when server context checkpoints are used together with multi-slot parallel decode in the TurboQuant fork.

The patch has two parts:

- size the KV metadata ggml context with `hparams.n_layer_all`, matching the actual layer loop used when registering KV tensors
- isolate prompt suffix evaluation after restoring a context checkpoint, so restored suffix tokens are not mixed into a decode batch with other active slots

## Root cause

The crash reproduced when a slot restored a context checkpoint and then evaluated the remaining prompt suffix while other slots were generating or processing prompt chunks. The failure showed up as a CUDA `invalid argument` in the following small mixed decode batch.

The server now marks slots that restored a checkpoint and keeps that short suffix out of mixed multi-slot decode batches. Checkpoint creation/restoration remains enabled; only the fragile post-restore suffix is isolated.

The KV metadata change fixes a separate correctness issue in the fork: the code iterates over `hparams.n_layer_all`, but the tensor metadata arena was sized with `hparams.n_layer_kv()`. For models with extra KV-bearing layers, that can under-reserve ggml tensor metadata and corrupt later KV/checkpoint operations.

## Validation

Built with:

```bash
cmake --build /home/jake-k/TheTom-llama-cpp-turboquant/build-cuda --target llama-server -j 8
```

Runtime validation on RTX 3090 Ti with Nex-N2-mini UD-Q3_K_XL, `-ctk q8_0 -ctv turbo3`, prompt RAM cache, and context checkpoints enabled:

- q8/q8 p2 checkpoint smoke: passed, no CUDA error
- q8/turbo3 p4 checkpoint smoke: passed, no CUDA error
- production overlap restore test: 7/7 requests passed, 3 restores logged, no CUDA error
- production-shaped soak: `-c 600000 --parallel 4`, about 120K prompt tokens per request, 32 restore requests plus 2 long concurrent decode requests: 34/34 requests passed, 30 restores logged, 4 checkpoints created, no CUDA error/OOM

Production flags used for the soak included:

```bash
-c 600000 -b 2048 -ub 512 -ngl 99 -fa on -ctk q8_0 -ctv turbo3 \
--parallel 4 --jinja --reasoning off --cache-prompt --cache-ram 4096 \
--ctx-checkpoints 6 --checkpoint-min-step 4096 --cache-idle-slots
```
