### PR TITLE
fix: NixOS: Remove duplicate spirv-headers entry

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -20,7 +20,6 @@
   spirv-headers,
   openssl,
   shaderc,
-  spirv-headers,
   nodejs,
   importNpmLock,
   useBlas ?


### PR DESCRIPTION
## Overview

This PR removes the duplicate spirv-headers entry, to fix #194 

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO, AI was not used to produce this commit.<!-- mention: YES / NO - if yes, describe how AI was used -->
<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->