### PR TITLE
Add turboquant KV cache support with tensor parallelism

### DIFF
--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -1002,6 +1002,9 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
             case GGML_OP_GLU: {
                 split_state = handle_generic(src_ss, /*scalar_only =*/ false);
             } break;
+            case GGML_OP_TURBO_WHT: {
+            	split_state = handle_generic(src_ss, /*scalar_only =*/ false);
+            } break;
             default: {
                 GGML_ABORT("ggml op not implemented: %s", ggml_op_name(tensor->op));
                 split_state = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};


### PR DESCRIPTION
## Overview

Add turboquant KV cache support with tensor parallelism.

## Additional information

Add `GGML_OP_TURBO_WHT` processing branch in `ggml/src/ggml-backend-meta.cpp`. Fixes Issue #188 .

Tested on Qwen-3.6 27B and 35B-A3B, 2 x RTX 2080 Ti 22 GiB.

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO<!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
