### PR TITLE
Metal: stop writing removed `rnorm` field in turbo4_0 (fixes Apple Silicon startup crash)

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -654,7 +654,6 @@ void quantize_turbo4_0(device const float * src, device block_turbo4_0 & dst) {
         recon_norm_sq += turbo_centroids_4bit[idx] * turbo_centroids_4bit[idx];
     }
 
-    dst.rnorm = half(0.0f);
     float recon_norm = sqrt(recon_norm_sq);
     dst.norm = half((recon_norm > 1e-10f) ? grp_norm / recon_norm : grp_norm);
 }
@@ -11495,8 +11494,6 @@ kernel void kernel_set_rows_turbo4(
             float c = turbo_centroids_4bit[idx];
             recon_norm_sq += c * c;
         }
-
-        blk.rnorm = half(0.0f);  // reserved field, unused in 4-bit mode
 
         // Norm correction
         float recon_norm = sqrt(recon_norm_sq);


### PR DESCRIPTION
**Changes**:

- Deleted two lines in `ggml-metal.metal` that write a `rnorm` field which PR #197 removed from the 4-bit block_turbo4_0 struct.

**Reason**: 

The embedded Metal library compiles at runtime, the build passes, but `llama-server` crashes on startup on Apple Silicon with no member named `rnorm`. 

The CUDA and CPU changes made recently already omit that write in 4-bit mode... This just matches those other changes.