### PR TITLE
server: persist context checkpoints in a sidecar file for slot save/restore

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2207,6 +2207,95 @@ private:
         return true;
     }
 
+    // context checkpoints exist only in process memory and are not part of the
+    // llama_state_seq file format. persist them in a sidecar file so that
+    // action=restore in a fresh process can roll back mid-prompt (e.g. after a
+    // BPE boundary re-tokenization of the prompt tail) instead of re-prefilling.
+    static bool checkpoints_save_sidecar(const std::list<common_prompt_checkpoint> & checkpoints, const std::string & filepath) {
+        FILE * f = fopen(filepath.c_str(), "wb");
+        if (f == nullptr) {
+            return false;
+        }
+
+        bool ok = true;
+
+        const uint32_t magic   = 0x4C434B50; // "PKCL"
+        const uint32_t version = 1;
+        const uint32_t count   = (uint32_t) checkpoints.size();
+
+        ok = ok && fwrite(&magic,   sizeof(magic),   1, f) == 1;
+        ok = ok && fwrite(&version, sizeof(version), 1, f) == 1;
+        ok = ok && fwrite(&count,   sizeof(count),   1, f) == 1;
+
+        for (const auto & cur : checkpoints) {
+            const int64_t  n_tokens = cur.n_tokens;
+            const int32_t  pos_min  = cur.pos_min;
+            const int32_t  pos_max  = cur.pos_max;
+            const uint64_t n_tgt    = cur.data_tgt.size();
+            const uint64_t n_dft    = cur.data_dft.size();
+
+            ok = ok && fwrite(&n_tokens, sizeof(n_tokens), 1, f) == 1;
+            ok = ok && fwrite(&pos_min,  sizeof(pos_min),  1, f) == 1;
+            ok = ok && fwrite(&pos_max,  sizeof(pos_max),  1, f) == 1;
+            ok = ok && fwrite(&n_tgt,    sizeof(n_tgt),    1, f) == 1;
+            ok = ok && fwrite(&n_dft,    sizeof(n_dft),    1, f) == 1;
+            ok = ok && (n_tgt == 0 || fwrite(cur.data_tgt.data(), 1, n_tgt, f) == n_tgt);
+            ok = ok && (n_dft == 0 || fwrite(cur.data_dft.data(), 1, n_dft, f) == n_dft);
+        }
+
+        fclose(f);
+        return ok;
+    }
+
+    static bool checkpoints_load_sidecar(std::list<common_prompt_checkpoint> & checkpoints, const std::string & filepath) {
+        FILE * f = fopen(filepath.c_str(), "rb");
+        if (f == nullptr) {
+            return false;
+        }
+
+        uint32_t magic = 0, version = 0, count = 0;
+
+        bool ok = fread(&magic,   sizeof(magic),   1, f) == 1 &&
+                  fread(&version, sizeof(version), 1, f) == 1 &&
+                  fread(&count,   sizeof(count),   1, f) == 1 &&
+                  magic == 0x4C434B50 && version == 1 && count <= 1024;
+
+        std::list<common_prompt_checkpoint> loaded;
+
+        for (uint32_t i = 0; ok && i < count; ++i) {
+            auto & cur = loaded.emplace_back();
+
+            uint64_t n_tgt = 0;
+            uint64_t n_dft = 0;
+
+            ok = ok && fread(&cur.n_tokens, sizeof(cur.n_tokens), 1, f) == 1;
+            ok = ok && fread(&cur.pos_min,  sizeof(cur.pos_min),  1, f) == 1;
+            ok = ok && fread(&cur.pos_max,  sizeof(cur.pos_max),  1, f) == 1;
+            ok = ok && fread(&n_tgt,        sizeof(n_tgt),        1, f) == 1;
+            ok = ok && fread(&n_dft,        sizeof(n_dft),        1, f) == 1;
+
+            // sanity: refuse absurd blob sizes (16 GiB per blob)
+            ok = ok && n_tgt <= (1ull << 34) && n_dft <= (1ull << 34);
+
+            if (ok) {
+                cur.data_tgt.resize(n_tgt);
+                cur.data_dft.resize(n_dft);
+                ok = ok && (n_tgt == 0 || fread(cur.data_tgt.data(), 1, n_tgt, f) == n_tgt);
+                ok = ok && (n_dft == 0 || fread(cur.data_dft.data(), 1, n_dft, f) == n_dft);
+            }
+        }
+
+        fclose(f);
+
+        if (!ok) {
+            return false;
+        }
+
+        checkpoints = std::move(loaded);
+
+        return true;
+    }
+
     // n_tokens_cur: the number of tokens added to the batch for the current slot
     void create_checkpoint(server_slot & slot, const int64_t n_tokens_cur, llama_pos pos_min, llama_pos pos_max) {
         while (slot.prompt.checkpoints.size() >= (size_t) params_base.n_ctx_checkpoints) {
@@ -2444,6 +2533,16 @@ private:
                     const int64_t t_end = ggml_time_us();
                     const double t_save_ms = (t_end - t_start) / 1000.0;
 
+                    // persist context checkpoints alongside the state file so that a
+                    // restore in a fresh process can roll back mid-prompt (see restore path)
+                    if (!slot->prompt.checkpoints.empty()) {
+                        if (checkpoints_save_sidecar(slot->prompt.checkpoints, filepath + ".ckpt")) {
+                            SLT_INF(*slot, "saved %zu context checkpoints to sidecar\n", slot->prompt.checkpoints.size());
+                        } else {
+                            SLT_WRN(*slot, "failed to write checkpoint sidecar %s\n", (filepath + ".ckpt").c_str());
+                        }
+                    }
+
                     auto res = std::make_unique<server_task_result_slot_save_load>();
                     res->id       = task.id;
                     res->id_slot  = id_slot;
@@ -2487,6 +2586,24 @@ private:
                     tokens.resize(token_count);
                     slot->prompt.tokens.clear();
                     slot->prompt.tokens.insert(tokens);
+
+                    // reload the context checkpoints written at save time; without them the
+                    // next request's rollback finds no usable cache data and forces a full
+                    // re-prefill ("forcing full prompt re-processing due to lack of cache
+                    // data"). if no sidecar exists (state saved by an older build), fall back
+                    // to synthesizing a tip checkpoint from the just-restored state, which at
+                    // least covers exact continuations.
+                    if (params_base.n_ctx_checkpoints > 0 && token_count > 0) {
+                        if (checkpoints_load_sidecar(slot->prompt.checkpoints, filepath + ".ckpt")) {
+                            SLT_INF(*slot, "restored %zu context checkpoints from sidecar\n", slot->prompt.checkpoints.size());
+                        } else {
+                            const llama_pos p_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot->id);
+                            const llama_pos p_max = llama_memory_seq_pos_max(llama_get_memory(ctx_tgt), slot->id);
+                            if (p_min >= 0 && p_max >= p_min) {
+                                create_checkpoint(*slot, 0, p_min, p_max);
+                            }
+                        }
+                    }
 
                     const int64_t t_end = ggml_time_us();
                     const double t_restore_ms = (t_end - t_start) / 1000.0;


### PR DESCRIPTION
## Overview

`/slots/{id}?action=restore` currently loses its performance benefit across server restarts: the KV state rehydrates from disk correctly, but the first `/completion` request discards it and runs a full re-prefill.

**Mechanism:** `llama_state_seq_save_file` serializes tokens + KV cells but not `slot.prompt.checkpoints`, which exist only in process memory. After a cold restart, the first request must roll back a few positions (BPE re-tokenization of the prompt tail), finds no covering checkpoint, and hits `forcing full prompt re-processing due to lack of cache data` — discarding the entire restored state.

**Fix:** persist the checkpoint list to a versioned sidecar file (`<state>.ckpt`, magic `PKCL`, version 1) at `SLOT_SAVE`; reload it at `SLOT_RESTORE`. If no sidecar exists (state saved by an older build), synthesize a tip checkpoint from the restored state as a graceful fallback — this covers exact-append resumes, while divergent resumes degrade to pre-patch behavior (full re-prefill, no crash).

Single commit, +117 lines in `tools/server/server-context.cpp`, nothing else touched.

**Measured** (Qwopus3.6-27B Q6_K hybrid, 2× Tesla P100 `-sm layer`, `-ctk turbo4 -ctv turbo4`):

| Scenario | Before | After |
|---|---|---|
| Resume a 100K-token session after restart (delta prefill) | 720.1s | **1.0s** (~720x) |
| End-to-end resume incl. restoring the 2.56 GB state from disk | 722.4s | **4.3s** (~167x) |
| 1K acceptance run | 7,704ms | 807ms |

Canary recall at 5/50/95% depth intact; `n_saved == n_restored` exact (100,043). The "before" number is the **same patched build with the sidecar file removed** — a same-build A/B, so the sidecar is the entire effect.

**Regression checks** (all passed, zero invalidation warnings on patched paths):
- Live prefix reuse unchanged; no files written unless `action=save` is called
- Restore-then-converse: 4-turn conversation on a restored state, every turn cached, correct recall
- Park-and-resume with a divergent continuation: cached at 798ms, rollback served by a sidecar checkpoint
- Missing/old sidecar: graceful degradation to pre-patch behavior (correct output, no crash)
- The dual-slot cache drop on hybrid + `--kv-unified` (`-np 2`) reproduces identically on an unpatched build — pre-existing and unrelated to this PR; happy to file it separately

Sidecar size on hybrid archs is context-independent (~150 MiB per checkpoint of recurrent state; 299 MB at both 1K and 100K here), ~11% of state size at 100K. The format is versioned, so capping the persisted checkpoint count or adding fields later won't break old sidecars.

## Additional information

Follow-up to the Discord discussion (summary posted in the llama.cpp channel). Repro and benchmark scripts (canary-based `slot_benchmark.py`, `live_multiturn_regression.py`) available on request.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — root-cause analysis, patch drafting, and benchmark design were done with AI assistance (Claude Fable+Opus, Gemini Pro 3.1); I directed and supervised the work, and all measurements were run and verified on my own hardware. The commit carries a `Co-Authored-By` trailer. 