### PR TITLE
llama: fix NaN device-split crash when all devices report zero free memory (fixes #209)

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1266,8 +1266,18 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
         split_sum += splits[i];
         splits[i] = split_sum;
     }
-    for (size_t i = 0; i < n_devices(); ++i) {
-        splits[i] /= split_sum;
+    if (split_sum <= 0.0f) {
+        // all devices reported zero free memory (e.g. a fitted primary model packed
+        // the GPU before a draft model load) - normalizing would produce NaN split
+        // points and an out-of-range device index below. fall back to a uniform split.
+        LLAMA_LOG_WARN("%s: all device split weights are zero, falling back to a uniform split\n", __func__);
+        for (size_t i = 0; i < n_devices(); ++i) {
+            splits[i] = float(i + 1) / n_devices();
+        }
+    } else {
+        for (size_t i = 0; i < n_devices(); ++i) {
+            splits[i] /= split_sum;
+        }
     }
 
     const int i_gpu_start = std::max(n_layer_all + 1 - n_gpu_layers, 0);
@@ -1278,7 +1288,9 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
             LLAMA_LOG_DEBUG("load_tensors: layer %3d assigned to device %s, is_swa = %d\n", il, ggml_backend_dev_name(cpu_dev), is_swa);
             return {cpu_dev, &pimpl->cpu_buft_list};
         }
-        const int layer_gpu = std::upper_bound(splits.begin(), splits.begin() + n_devices(), float(il - i_gpu_start)/act_gpu_layers) - splits.begin();
+        const int layer_gpu = std::min<int>(
+            std::upper_bound(splits.begin(), splits.begin() + n_devices(), float(il - i_gpu_start)/act_gpu_layers) - splits.begin(),
+            (int) n_devices() - 1);
         auto * dev = devices.at(layer_gpu).dev;
         LLAMA_LOG_DEBUG("load_tensors: layer %3d assigned to device %s, is_swa = %d\n", il, ggml_backend_dev_name(dev), is_swa);
         return {dev, &pimpl->gpu_buft_list.at(dev)};


### PR DESCRIPTION
Fixes #209.

## Root cause (instrumented on a 5090)

When a separate draft model (`-md`) loads after the memory fitter has packed the primary model into VRAM, `ggml_backend_dev_memory` reports **0 bytes free** on every device. The default split-by-free-memory path in `llama-model.cpp` then normalizes by a zero sum:

```
splits[0] = free = 0  ->  split_sum = 0  ->  0/0 = -nan
```

`std::upper_bound` over a NaN split point returns one past the end, so `layer_gpu == n_devices()` and `devices.at(layer_gpu)` throws `vector::_M_range_check`, aborting the draft load. Confirmed with instrumentation: `layer_gpu=1 n_devices=1 splits[0]=-nan`.

## Fix

- Fall back to a **uniform split** (with a warning) when the split weights sum to zero, instead of dividing by zero.
- Clamp `layer_gpu` to `n_devices() - 1` defensively.

## Validation (5090, Llama-3.1-8B target + Llama-3.2-1B draft, `--spec-type draft-simple`)

- Before: server exits at startup with the range-check error (reproduced identically back to the June 17 build; this is not from the recent merges).
- After: guard fires once, the draft loads (CUDA's "0 free" is pessimistic; the VMM pool has slack), and spec decoding runs with **0.70 draft acceptance**.
- Losslessness: greedy spec output is **token-identical** to plain decode on the same build/config.

## Remaining observation (not addressed here)

The fitter had a ~6.5 GB reserve for the draft (`fit_params_target` += the `[spec]` estimate) yet free memory at draft-load time was still 0, and the `[spec]` estimate itself (5.5 GB for a 1.3 GB Q8 draft) looks inflated. The guard makes this survivable; the reserve accounting deserves its own look. Noted on #209.
