### PR TITLE
cuda: carve sm_60 out of FAST_FP16 paths (fp32 arithmetic like sm_61)

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -258,7 +258,7 @@ static const char * cu_get_error_str(CUresult err) {
 #define FP16_AVAILABLE
 #endif // defined(GGML_USE_HIP) || defined(GGML_USE_MUSA) || __CUDA_ARCH__ >= GGML_CUDA_CC_PASCAL
 
-#if defined(FP16_AVAILABLE) && __CUDA_ARCH__ != 610
+#if defined(FP16_AVAILABLE) && __CUDA_ARCH__ != 610 && __CUDA_ARCH__ != 600
 #define FAST_FP16_AVAILABLE
 #endif // defined(FP16_AVAILABLE) && __CUDA_ARCH__ != 610
 
@@ -302,13 +302,13 @@ static bool fp16_available(const int cc) {
 
 static bool fast_fp16_available(const int cc) {
     return GGML_CUDA_CC_IS_AMD(cc) ||
-        (GGML_CUDA_CC_IS_NVIDIA(cc) && fp16_available(cc) && ggml_cuda_highest_compiled_arch(cc) != 610) ||
+        (GGML_CUDA_CC_IS_NVIDIA(cc) && fp16_available(cc) && ggml_cuda_highest_compiled_arch(cc) != 610 && ggml_cuda_highest_compiled_arch(cc) != 600) ||
         (GGML_CUDA_CC_IS_MTHREADS(cc) && fp16_available(cc));
 }
 
 // To be used for feature selection of external libraries, e.g. cuBLAS.
 static bool fast_fp16_hardware_available(const int cc) {
-    return (GGML_CUDA_CC_IS_NVIDIA(cc) && cc >= GGML_CUDA_CC_PASCAL && cc != 610) || GGML_CUDA_CC_IS_AMD(cc) ||
+    return (GGML_CUDA_CC_IS_NVIDIA(cc) && cc >= GGML_CUDA_CC_PASCAL && cc != 610 && cc != 600) || GGML_CUDA_CC_IS_AMD(cc) ||
         (GGML_CUDA_CC_IS_MTHREADS(cc) && cc >= GGML_CUDA_CC_QY2);
 }
 


### PR DESCRIPTION
## Overview

Extends the existing sm_61 exemption idiom to sm_60 across all three FAST_FP16 gates in
`ggml/src/ggml-cuda/common.cuh`: the device macro, `fast_fp16_available()`, and
`fast_fp16_hardware_available()` (the cuBLAS compute-type selector). 3 lines, sm_60 only.

**Why:** GP100's fp16 "fast path" (vec2 arithmetic in the FA tile kernel, mmvf, and
cuBLAS F16 compute type) costs measurable quality on P100 while buying zero real-world
throughput. Measured on Qwen3.6-27B Q6_K, wikitext-2, 2048 ctx, 32 chunks, vs an
fp32-arithmetic truth base:

| config | median KLD | same-top |
|---|---|---|
| unpatched (fp16 arithmetic) | 0.002298 | 96.53% |
| patched (fp32 arithmetic) | **0.000001** | **99.89%** |

**Performance impact negligible:** pp8192@d8192 within noise on three model classes (hybrid 27B
318.5→318.6 t/s; dense 4B 357.9→358.0; hybrid-MoE 36B 304.4→304.1); tg +1.4% patched
on the hybrid. Real workloads are dominated by the int8 DP4A mmq path, which this
doesn't touch.

**Validated against the same truth base:** FA-on quantized-KV cells differ from stock in the fifth decimal due to this fork's modified FA stack. Anchor: this build's f16-KV run vs the stock-patched f32 truth base scores median 0.000001 / same-top 99.86% — the two trees are interchangeable post-patch.

## Additional information

**Scope:** sm_60 only. sm_61 was already exempt (this mirrors it). sm_62 (Jetson TX2)
shares the gate and silicon but is unmeasured, so it's left untouched. Ampere+ FA
dispatches to the MMA kernels, which aren't gated by this macro — no behavior change
expected there (the 3090 mirror panel will confirm).

Worth investigating if other architectures experience any degradation in quality due to this gate.

## Requirements

Nothing new. Just the patch.

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <Yes. Claude Fable 5. Bug discovery, root cause analysis, test methodology, benchmarking, writeup assistance. I monitored, supervised and guided the entire process.>