### PR TITLE
server : fix false speculative warning when not enabled

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1141,27 +1141,30 @@ private:
 
         slots.clear();
 
-        ctx_tgt_seq_rm_type = common_context_can_seq_rm(ctx_tgt);
-        if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_NO) {
-            SRV_WRN("%s", "speculative decoding not supported by this context\n");
-        }
+        // try speculative decoding
+        const bool is_speculative_enabled = std::any_of(params_base.speculative.types.begin(), params_base.speculative.types.end(), [](auto t) { return t != COMMON_SPECULATIVE_TYPE_NONE; });
+        if (is_speculative_enabled) {
+            ctx_tgt_seq_rm_type = common_context_can_seq_rm(ctx_tgt);
+            if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_NO) {
+                SRV_WRN("%s", "speculative decoding not supported by this context\n");
+            }
 
-        if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL) {
-            SRV_WRN("%s", "speculative decoding will use checkpoints\n");
+            if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL) {
+                SRV_WRN("%s", "speculative decoding will use checkpoints\n");
+            }
+
+            if (ctx_tgt_seq_rm_type != COMMON_CONTEXT_SEQ_RM_TYPE_NO) {
+                try {
+                    spec.reset(common_speculative_init(params_base.speculative, params_base.n_parallel));
+                } catch (const std::exception & e) {
+                    SRV_ERR("failed to initialize speculative decoding context: %s\n", e.what());
+                }
+            }
         }
 
         // initialize slots
         for (int i = 0; i < params_base.n_parallel; i++) {
             slots.emplace_back();
-        }
-
-        // try speculative decoding
-        if (ctx_tgt_seq_rm_type != COMMON_CONTEXT_SEQ_RM_TYPE_NO) {
-            try {
-                spec.reset(common_speculative_init(params_base.speculative, params_base.n_parallel));
-            } catch (const std::exception & e) {
-                SRV_ERR("failed to initialize speculative decoding context: %s\n", e.what());
-            }
         }
 
         if (ctx_dft) {


### PR DESCRIPTION
  ### Overview of the Change

  1. The Issue:
  Whenever you started  llama-server , it checked if the context could remove tokens (sequence removal) and tried to set up speculative decoding. Because speculative decoding is disabled
  by default, it would print these warnings during startup:
      •  "speculative decoding will use checkpoints" 
      •  "no implementations specified for speculative decoding" 
  2. The Fix:
  We added a check  is_speculative_enabled  in  tools/server/server-context.cpp . It checks if the speculative types configured actually contain a speculative method (i.e. anything other
  than  NONE ).
  3. The Result:
  If speculative decoding is not enabled, the server skips the check and initialization, keeping the startup logs clean of these false-positive warnings.

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES -->
- the AI helped  
<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
