### PR TITLE
cuda: fix abort on mixed f16/bf16 + q8_0 KV cache (default build)

### DIFF
--- a/ggml/src/ggml-cuda/CMakeLists.txt
+++ b/ggml/src/ggml-cuda/CMakeLists.txt
@@ -121,6 +121,10 @@ if (CUDAToolkit_FOUND)
             template-instances/fattn-vec-instance-f16-f16.cu
             template-instances/fattn-vec-instance-q4_0-q4_0.cu
             template-instances/fattn-vec-instance-q8_0-q8_0.cu
+            template-instances/fattn-vec-instance-f16-q8_0.cu
+            template-instances/fattn-vec-instance-q8_0-f16.cu
+            template-instances/fattn-vec-instance-bf16-q8_0.cu
+            template-instances/fattn-vec-instance-q8_0-bf16.cu
             template-instances/fattn-vec-instance-bf16-bf16.cu
             template-instances/fattn-vec-instance-turbo3_0-turbo3_0.cu
             template-instances/fattn-vec-instance-turbo3_0-q8_0.cu

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -419,6 +419,12 @@ static void ggml_cuda_flash_attn_ext_vec(ggml_backend_cuda_context & ctx, ggml_t
     FATTN_VEC_CASES_ALL_D(GGML_TYPE_Q4_0, GGML_TYPE_Q4_0)
     FATTN_VEC_CASES_ALL_D(GGML_TYPE_Q8_0, GGML_TYPE_Q8_0)
     FATTN_VEC_CASES_ALL_D(GGML_TYPE_BF16, GGML_TYPE_BF16)
+
+    // Mixed f16/bf16 + q8_0 KV cache types (default build)
+    FATTN_VEC_CASES_ALL_D(GGML_TYPE_F16,  GGML_TYPE_Q8_0)
+    FATTN_VEC_CASES_ALL_D(GGML_TYPE_Q8_0, GGML_TYPE_F16)
+    FATTN_VEC_CASES_ALL_D(GGML_TYPE_BF16, GGML_TYPE_Q8_0)
+    FATTN_VEC_CASES_ALL_D(GGML_TYPE_Q8_0, GGML_TYPE_BF16)
 #endif // GGML_CUDA_FA_ALL_QUANTS
 
     // TurboQuant3 KV cache types (always enabled)


### PR DESCRIPTION
## Overview
The runtime kernel selector allows mixed f16/bf16 and q8_0 KV pairs, but in the default build (GGML_CUDA_FA_ALL_QUANTS=OFF) the four vec instances are not compiled and the dispatch list does not list them. The selector picks the vec kernel, dispatch finds no case, and it hits GGML_ABORT at fattn.cu:469 on the first decode token. Prefill runs fine, so pp-only testing misses it.

Reproduce with -fa 1 -ctk f16 -ctv q8_0 (or reversed): prefill runs, crash on the first decode token. RTX 4090 (sm_89), CUDA 12.8, base 471fb4ec8. A print before the abort showed D_Q=256 K=f16 V=q8_0.

Fix: add the four instance files to the default CMake else() list and the four cases to the non-ALL_QUANTS #else block. ALL_QUANTS=ON already had them. 

Same missing-instance abort described in #21526 for the (turbo*, f16) pairs; this PR covers the f16/bf16 + q8_0 pairs in the default build, which were still missing.

## Additional information
After the fix, both combos decode instead of aborting (base 471fb4ec8, commit 53cd9f4e4):

```
=== DECODE K=f16 V=q8_0 ===
| model                          |       size |     params | backend    | ngl | type_v |  fa |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -----: | --: | --------------: | -------------------: |
| qwen35 27B Q4_K - Medium       |  16.67 GiB |    27.32 B | CUDA       |  99 |   q8_0 |   1 |           tg128 |         38.51 ± 0.15 |
| qwen35 27B Q4_K - Medium       |  16.67 GiB |    27.32 B | CUDA       |  99 |   q8_0 |   1 |  tg128 @ d32768 |         33.60 ± 0.01 |
=== DECODE K=q8_0 V=f16 ===
| model                          |       size |     params | backend    | ngl | type_k |  fa |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -----: | --: | --------------: | -------------------: |
| qwen35 27B Q4_K - Medium       |  16.67 GiB |    27.32 B | CUDA       |  99 |   q8_0 |   1 |           tg128 |         38.74 ± 0.17 |
| qwen35 27B Q4_K - Medium       |  16.67 GiB |    27.32 B | CUDA       |  99 |   q8_0 |   1 |  tg128 @ d32768 |         35.05 ± 0.01 |
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI helped locate the missing instances and helped me write this description clearly (not a native speaker). I ran all builds and tests myself, verified the results and take responsibility for the change.
