### PR TITLE
fix: missing required asset loading.html make validate complete asset set in HF download before proceeding

### DIFF
--- a/scripts/ui-assets.cmake
+++ b/scripts/ui-assets.cmake
@@ -260,7 +260,13 @@ function(hf_download version out_var out_resolved)
 
         file(ARCHIVE_EXTRACT INPUT "${archive}" DESTINATION "${DIST_DIR}")
 
-        if(NOT EXISTS "${DIST_DIR}/index.html")
+        # The archive must hold the COMPLETE asset set, not just index.html: a
+        # bucket that is older than llama-ui-embed's required-asset list (e.g.
+        # published before loading.html was added) extracts fine but then kills
+        # the whole build in emit_files. Reject it here so we can try the next
+        # candidate, and ultimately degrade to a no-embedded-UI build.
+        dist_is_complete("${DIST_DIR}" archive_ok)
+        if(NOT archive_ok)
             message(STATUS "UI: archive from ${resolved} is missing required assets")
             continue()
         endif()


### PR DESCRIPTION
ALL detail in #235,   


 Closes #235,     the  PR #225 wire dist_is_complete()  3 point but not into hf_download()  make it complete 4

  that make case If npm not found -> . HF download()  [broke]


 
 - [x] `dist_is_complete()` against the HF `latest` archive that triggers the bug
      (76 files, every required asset present except `loading.html`) -> returns FALSE
- [x] `dist_is_complete()` against a complete dist -> returns TRUE, so builds that
      already work are unaffected