### PR TITLE
cuda: backport upstream revert of "reset cuda context after reading memory size" (#24715)

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -635,21 +635,6 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {
 
 // cuda buffer
 
-struct ggml_backend_cuda_device_context {
-    int device;
-    std::string name;
-    std::string description;
-    std::string pci_bus_id;
-    int op_offload_min_batch_size;
-#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-    std::mutex device_mutex;
-    int active_count = 0;
-    // set once the device has ever been used; a reset after that would invalidate
-    // host state that caches per-context data (e.g. raised shared memory limits)
-    bool ever_active = false;
-#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-};
-
 struct ggml_backend_cuda_buffer_context {
     int device;
     void * dev_ptr = nullptr;
@@ -667,13 +652,6 @@ struct ggml_backend_cuda_buffer_context {
 
 static void ggml_backend_cuda_buffer_free_buffer(ggml_backend_buffer_t buffer) {
     ggml_backend_cuda_buffer_context * ctx = (ggml_backend_cuda_buffer_context *)buffer->context;
-
-#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-    ggml_backend_cuda_device_context * dev_ctx = (ggml_backend_cuda_device_context *) buffer->buft->device->context;
-    std::lock_guard<std::mutex> lock(dev_ctx->device_mutex);
-    dev_ctx->active_count--;
-#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-
     delete ctx;
 }
 
@@ -868,13 +846,6 @@ static ggml_backend_buffer_t ggml_backend_cuda_buffer_type_alloc_buffer(ggml_bac
     }
 
     ggml_backend_cuda_buffer_context * ctx = new ggml_backend_cuda_buffer_context(buft_ctx->device, dev_ptr);
-
-#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-    ggml_backend_cuda_device_context * dev_ctx = (ggml_backend_cuda_device_context *) buft->device->context;
-    std::lock_guard<std::mutex> lock(dev_ctx->device_mutex);
-    dev_ctx->active_count++;
-    dev_ctx->ever_active = true;
-#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
 
     return ggml_backend_buffer_init(buft, ggml_backend_cuda_buffer_interface, ctx, size);
 }
@@ -1582,12 +1553,6 @@ static bool ggml_backend_buft_is_cuda_host(ggml_backend_buffer_type_t buft) {
 }
 
 static void ggml_backend_cuda_host_buffer_free_buffer(ggml_backend_buffer_t buffer) {
-#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-    ggml_backend_cuda_device_context * dev_ctx = (ggml_backend_cuda_device_context *) buffer->buft->device->context;
-    std::lock_guard<std::mutex> lock(dev_ctx->device_mutex);
-    dev_ctx->active_count--;
-#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-
     CUDA_CHECK(cudaFreeHost(buffer->context));
 }
 
@@ -1595,8 +1560,6 @@ static void * ggml_cuda_host_malloc(size_t size) {
     if (getenv("GGML_CUDA_NO_PINNED") != nullptr) {
         return nullptr;
     }
-
-    ggml_cuda_set_device(0); // cudaMallocHost can create the implicit CUDA device context, make sure that this is consistently done on device 0.
 
     void * ptr = nullptr;
     cudaError_t err = cudaMallocHost((void **) &ptr, size);
@@ -1622,13 +1585,6 @@ static ggml_backend_buffer_t ggml_backend_cuda_host_buffer_type_alloc_buffer(ggm
     ggml_backend_buffer_t buffer = ggml_backend_cpu_buffer_from_ptr(ptr, size);
     buffer->buft = buft;
     buffer->iface.free_buffer = ggml_backend_cuda_host_buffer_free_buffer;
-
-#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-    ggml_backend_cuda_device_context * dev_ctx = (ggml_backend_cuda_device_context *) buft->device->context;
-    std::lock_guard<std::mutex> lock(dev_ctx->device_mutex);
-    dev_ctx->active_count++;
-    dev_ctx->ever_active = true;
-#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
 
     return buffer;
 }
@@ -3429,12 +3385,6 @@ static const char * ggml_backend_cuda_get_name(ggml_backend_t backend) {
 static void ggml_backend_cuda_free(ggml_backend_t backend) {
     ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
 
-#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-    ggml_backend_cuda_device_context * dev_ctx = (ggml_backend_cuda_device_context *) backend->device->context;
-    std::lock_guard<std::mutex> lock(dev_ctx->device_mutex);
-    dev_ctx->active_count--;
-#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-
     delete cuda_ctx;
     delete backend;
 }
@@ -5172,6 +5122,14 @@ void ggml_backend_cuda_unregister_host_buffer(void * buffer) {
 
 // backend device
 
+struct ggml_backend_cuda_device_context {
+    int device;
+    std::string name;
+    std::string description;
+    std::string pci_bus_id;
+    int op_offload_min_batch_size;
+};
+
 static const char * ggml_backend_cuda_device_get_name(ggml_backend_dev_t dev) {
     ggml_backend_cuda_device_context * ctx = (ggml_backend_cuda_device_context *)dev->context;
     return ctx->name.c_str();
@@ -5260,11 +5218,6 @@ static bool ggml_backend_cuda_get_available_uma_memory(long * available_memory_k
 
 static void ggml_backend_cuda_device_get_memory(ggml_backend_dev_t dev, size_t * free, size_t * total) {
     ggml_backend_cuda_device_context * ctx = (ggml_backend_cuda_device_context *)dev->context;
-
-#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-    std::lock_guard<std::mutex> lock(ctx->device_mutex);
-#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-
     ggml_cuda_set_device(ctx->device);
     CUDA_CHECK(cudaMemGetInfo(free, total));
 
@@ -5291,16 +5244,6 @@ static void ggml_backend_cuda_device_get_memory(ggml_backend_dev_t dev, size_t *
     }
 #endif // defined(__linux__)
 
-#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-    // If no backends or buffers are active, the cudaMemGetInfo call above lazily created a CUDA
-    // context that permanently consumes VRAM. Reset the device to free it.
-    // Only safe before the device has ever been used: a reset destroys the primary context,
-    // while host state caching per-context data (raised shared memory limits, cuBLAS handles)
-    // survives and would then refer to a context that no longer exists.
-    if (ctx->active_count == 0 && !ctx->ever_active) {
-        CUDA_CHECK(cudaDeviceReset());
-    }
-#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
 }
 
 static enum ggml_backend_dev_type ggml_backend_cuda_device_get_type(ggml_backend_dev_t dev) {
@@ -6020,21 +5963,12 @@ ggml_backend_t ggml_backend_cuda_init(int device) {
         return nullptr;
     }
 
-    ggml_backend_dev_t dev = ggml_backend_reg_dev_get(ggml_backend_cuda_reg(), device);
-
     ggml_backend_t cuda_backend = new ggml_backend {
         /* .guid    = */ ggml_backend_cuda_guid(),
         /* .iface   = */ ggml_backend_cuda_interface,
-        /* .device  = */ dev,
+        /* .device  = */ ggml_backend_reg_dev_get(ggml_backend_cuda_reg(), device),
         /* .context = */ ctx,
     };
-
-#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-    ggml_backend_cuda_device_context * dev_ctx = (ggml_backend_cuda_device_context *) dev->context;
-    std::lock_guard<std::mutex> lock(dev_ctx->device_mutex);
-    dev_ctx->active_count++;
-    dev_ctx->ever_active = true;
-#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
 
     return cuda_backend;
 }

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -644,6 +644,9 @@ struct ggml_backend_cuda_device_context {
 #if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
     std::mutex device_mutex;
     int active_count = 0;
+    // set once the device has ever been used; a reset after that would invalidate
+    // host state that caches per-context data (e.g. raised shared memory limits)
+    bool ever_active = false;
 #endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
 };
 
@@ -870,6 +873,7 @@ static ggml_backend_buffer_t ggml_backend_cuda_buffer_type_alloc_buffer(ggml_bac
     ggml_backend_cuda_device_context * dev_ctx = (ggml_backend_cuda_device_context *) buft->device->context;
     std::lock_guard<std::mutex> lock(dev_ctx->device_mutex);
     dev_ctx->active_count++;
+    dev_ctx->ever_active = true;
 #endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
 
     return ggml_backend_buffer_init(buft, ggml_backend_cuda_buffer_interface, ctx, size);
@@ -1623,6 +1627,7 @@ static ggml_backend_buffer_t ggml_backend_cuda_host_buffer_type_alloc_buffer(ggm
     ggml_backend_cuda_device_context * dev_ctx = (ggml_backend_cuda_device_context *) buft->device->context;
     std::lock_guard<std::mutex> lock(dev_ctx->device_mutex);
     dev_ctx->active_count++;
+    dev_ctx->ever_active = true;
 #endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
 
     return buffer;
@@ -5289,7 +5294,10 @@ static void ggml_backend_cuda_device_get_memory(ggml_backend_dev_t dev, size_t *
 #if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
     // If no backends or buffers are active, the cudaMemGetInfo call above lazily created a CUDA
     // context that permanently consumes VRAM. Reset the device to free it.
-    if (ctx->active_count == 0) {
+    // Only safe before the device has ever been used: a reset destroys the primary context,
+    // while host state caching per-context data (raised shared memory limits, cuBLAS handles)
+    // survives and would then refer to a context that no longer exists.
+    if (ctx->active_count == 0 && !ctx->ever_active) {
         CUDA_CHECK(cudaDeviceReset());
     }
 #endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
@@ -6025,6 +6033,7 @@ ggml_backend_t ggml_backend_cuda_init(int device) {
     ggml_backend_cuda_device_context * dev_ctx = (ggml_backend_cuda_device_context *) dev->context;
     std::lock_guard<std::mutex> lock(dev_ctx->device_mutex);
     dev_ctx->active_count++;
+    dev_ctx->ever_active = true;
 #endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
 
     return cuda_backend;


### PR DESCRIPTION
Close  #237

~~### Suggested fix~~ 

~~Only reset a device that has never been used. Add an ever_active flag to~~
~~ggml_backend_cuda_device_context , set it at the three sites that do active_count++~~
~~(buffer alloc, host buffer alloc, backend init), and gate the reset on it:~~
 
   ~~if (ctx->active_count == 0 && !ctx->ever_active) {~~
      ~~CUDA_CHECK(cudaDeviceReset());~~
   ~~}~~
 
~~This preserves the original intent -- avoiding a lazily created context that permanently~~
~~holds VRAM when memory is queried before anything has been allocated -- while never~~
~~resetting a context whose kernel state other code still assumes is live.~~

~~- [x] Before the fix, llama-bench --n-cpu-moe 32,34,36,38,40,42,44 (6 model reloads)~~
 ~~aborts with CUDA error: invalid argument right after the first configuration~~
~~- [x] With the fix, the same sweep completes all 14 rows with no abort~~
 
 
 
 
 
 
 
 
 ## Why a revert rather than a targeted fix

The first commit in this PR (`f3c29b7`) gated the reset behind an `ever_active` flag so a
device that had already been used would never be reset. It works, but upstream has
already settled this differently:

- upstream reverted `0f7fada56` entirely in `ea21e0395` (#24715), authored by the same
  person who wrote the original commit
- upstream considered and **closed without merging** #24682, which kept the reset and
  re-applied kernel attributes via a context generation counter -- the same class of fix
  as `ever_active`
- the reset caused three separate problems upstream, all now closed:
  - #24328 `CUDA: ggml_cuda_compute_forward: MUL_MAT failed` (the crash reported here)
  - #24374 multi-GPU split buffer crash during model load
  - #24608 `--fit` model load taking 20x longer

This branch has diverged from upstream at this point: it carries `0f7fada56` but not the
revert. The second commit (`af8ac64`) cherry-picks `ea21e0395`, which supersedes the
first commit and brings this file back in line with upstream.
 
 
- [x] Before: `llama-bench --n-cpu-moe 32,34,36,38,40,42,44 -ngl 99 -ctk turbo4
      -ctv turbo3 -b 4096 -ub 2048` aborts with `CUDA error: invalid argument`
      immediately after the first configuration
- [x] After: the same sweep (7 configurations, 6 model reloads) completes all 14 rows
      with no abort
- [x] Release build with `-DGGML_CUDA=ON`, no errors