### PR TITLE
dflash: fix zero-draft on cache-hit by flushing encoder KV before checkpoint save

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3615,6 +3615,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
     add_opt(common_arg(
+        {"--dflash-defer-injection"}, "<0|1>",
+        "DFlash deferred encoder KV injection (default: 1, 0 = per-chunk injection for higher acceptance on some models)",
+        [](common_params & params, int value) {
+            params.speculative.draft.dflash_defer_injection = value;
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_DFLASH_DEFER_INJECTION"));
+    add_opt(common_arg(
         {"-cd", "--ctx-size-draft"}, "N",
         string_format("size of the prompt context for the draft model (default: %d, 0 = loaded from model)", params.speculative.draft.n_ctx),
         [](common_params & params, int value) {

--- a/common/common.h
+++ b/common/common.h
@@ -326,9 +326,10 @@ struct common_params_speculative_draft {
 
     std::vector<llama_model_tensor_buft_override> tensor_buft_overrides;
 
-    bool    eagle3       = false; // use EAGLE3 speculative decoding
-    bool    dflash       = false; // use DFlash speculative decoding
-    int32_t n_ctx        = 0;  // draft context size
+    bool    eagle3                = false; // use EAGLE3 speculative decoding
+    bool    dflash                = false; // use DFlash speculative decoding
+    bool    dflash_defer_injection = true;  // defer encoder KV injection to draft time (set false for higher acceptance on some models)
+    int32_t n_ctx                 = 0;     // draft context size
 
 };
 

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -877,16 +877,22 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         LOG_INF("%s: - n_max=%d, n_min=%d, p_min=%.2f\n", __func__, this->params.n_max, this->params.n_min, this->params.p_min);
         LOG_INF("%s: - block_size=%d, mask_token_id=%d, n_extract=%u\n", __func__, block_size, mask_token_id, target_layer_ids_n);
 
-        // Detect target model type: Gemma4 models regress with deferred injection (low acceptance rate)
-        {
+        // Deferred KV injection policy:
+        //  - --dflash-defer-injection=0 → always off
+        //  - --dflash-defer-injection=1 → use model heuristic (Gemma = off, others = on)
+        if (this->params.dflash_defer_injection) {
             char model_desc[128] = {};
             llama_model_desc(model_tgt, model_desc, sizeof(model_desc));
             if (strstr(model_desc, "gemma")) {
                 m_use_deferred = false;
                 LOG_INF("%s: - deferred_kv_injection=0 (disabled for %s)\n", __func__, model_desc);
             } else {
+                m_use_deferred = true;
                 LOG_INF("%s: - deferred_kv_injection=1 (enabled for %s)\n", __func__, model_desc);
             }
+        } else {
+            m_use_deferred = false;
+            LOG_INF("%s: - deferred_kv_injection=0 (disabled by --dflash-defer-injection=0)\n", __func__);
         }
         if (this->params.n_max > block_size - 1 || this->params.n_min > block_size - 1) {
             LOG_WRN("%s: requested draft size (n_max=%d, n_min=%d) exceeds the trained DFlash block size %d -- clamping to %d\n",
@@ -1045,6 +1051,18 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
             }
         }
 
+        // Flush any remaining stashed encoder outputs for deferred mode.
+        // Doing this at the end of process() (rather than in draft()) ensures the
+        // encoder KV is in the decoder before the server saves its checkpoint.
+        // This prevents the checkpoint/restore cycle from losing encoder context,
+        // which was the root cause of both zero-draft on cache-hit and degraded
+        // acceptance over multiple generation iterations.
+        if (m_use_deferred) {
+            for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+                flush_injection(seq_id);
+            }
+        }
+
         return true;
     }
 
@@ -1077,14 +1095,9 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
     void draft(common_speculative_draft_params_vec & dparams) override {
         auto & ctx_dft = params.ctx_dft;
 
-        if (m_use_deferred) {
-            // flush all stashed KV injections before drafting
-            for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
-                if (dparams[seq_id].drafting) {
-                    flush_injection(seq_id);
-                }
-            }
-        }
+        // Note: encoder KV injection is now done at the end of process(),
+        // so by the time draft() runs the decoder already has all encoder
+        // KV entries. This ensures they survive the checkpoint/restore cycle.
 
         common_batch_clear(batch);
 


### PR DESCRIPTION
## Summary

Fixes the zero-draft on cache-hit bug reported in #231. The root cause was that `flush_injection()` ran inside `draft()`, which is **after** the server saves its checkpoint. On checkpoint restore the encoder KV was lost, and on cache-hit requests `process()` never ran for cached tokens so the stash was empty.

## Fix

Move `flush_injection()` from `draft()` to the end of `process()` for deferred mode. This ensures encoder KV is in the decoder **before** the checkpoint save, so it survives checkpoint/restore across both generation iterations and cache-hit requests.

## Verification

Tested on RTX 5090 with `Qwen3-Coder-30B-A3B` + DFlash Q8_0:

**Before fix** — zero-draft on cache-hit:
| Request | Draft gen | Draft acc |
|---|---|---|
| Cold | 93 | 50 |
| Cache hit | **0** | **0** |

**After fix** — both requests draft normally:
| Request | Draft gen | Draft acc |
|---|---|---|
| Cold | 125 | 57 |
| Cache hit | **125** | **56** |

## Also

- Added `--dflash-defer-injection <0|1>` CLI flag as a debug escape hatch for A/B testing

Fixes #231