### PR TITLE
vulkan: fix turbo3 signs ballot packing on wave64 subgroups

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/copy_to_quant.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/copy_to_quant.comp
@@ -450,11 +450,19 @@ void main() {
         data_q[db].qs[t / 4u] = uint8_t(qs_byte);
     }
 
-    // Pack signs: 8 elements per byte via subgroup ballot
+    // Pack signs: 8 elements per byte via subgroup ballot.
+    // The ballot result is a uvec4 with one bit per subgroup lane, 32 lanes per
+    // component. On wave32 every lane's bit is in ballot.x, but on wave64
+    // (GCN/Polaris) lanes 32-63 land in ballot.y — indexing .x with a shift of
+    // (sg_lane/8)*8 >= 32 is UB and reads the wrong lanes' bits, corrupting
+    // half of every signs byte at write time (#241). Select the component by
+    // lane/32 and the byte within it by (lane%32)/8, valid for any subgroup
+    // size that is a multiple of 8.
     uvec4 ballot = subgroupBallot(((idx >> 2u) & 1u) != 0u);
     if (sg_lane % 8u == 0u) {
-        uint local_byte = sg_lane / 8u;
-        data_q[db].signs[t / 8u] = uint8_t((ballot.x >> (local_byte * 8u)) & 0xFFu);
+        uint ballot_word   = sg_lane / 32u;
+        uint byte_in_word  = (sg_lane % 32u) / 8u;
+        data_q[db].signs[t / 8u] = uint8_t((ballot[ballot_word] >> (byte_in_word * 8u)) & 0xFFu);
     }
 
     // Step 7: reconstruction norm via subgroup reduction


### PR DESCRIPTION
Fixes #241.

The turbo3 SET_ROWS quantizer in copy_to_quant.comp packed the signs bytes from `ballot.x` with a `(lane/8)*8` shift. On 64-wide subgroups (GCN/Polaris via RADV) lanes 32-63 report in `ballot.y` and the shift on `.x` is >= 32 (UB), so half of every signs byte was written from the wrong lanes' bits — corruption baked into the cache at write time. Reads were never at fault (FLASH_ATTN_EXT passes on Polaris before and after).

Fix selects the ballot component by `lane/32` and the byte within it by `(lane%32)/8`, valid for any subgroup size that is a multiple of 8.

Verified by @apollo-mg on RX 580 (wave64): all four turbo3-containing cells recover from gzip-ratio 0.18-0.43 to the healthy 0.49-0.53 band with coherent output; all three non-turbo3 cells are byte-identical to the unpatched build, as a signs-only fix requires. Wave32 is a no-op by construction: for lane < 32, `ballot_word == 0` and `byte_in_word == lane/8`, which is bit-for-bit the old expression.

Test-coverage gap that let this ship (SET_ROWS_TURBO3 skipping 0/0 with a green summary on Vulkan) is tracked separately in #242.