### PR TITLE
fattn-vec: restore turbo4 V-cache (re-add GGML_TYPE_TURBO4_0 to V_rows_per_thread==4)

### DIFF
--- a/ggml/src/ggml-cuda/fattn-vec.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec.cuh
@@ -105,7 +105,7 @@ static __global__ void flash_attn_ext_vec(
     static_assert(WARP_SIZE % nthreads_KQ == 0, "bad nthreads_K");
     static_assert(WARP_SIZE % nthreads_V  == 0, "bad nthreads_V");
 
-    constexpr int V_rows_per_thread = V_is_unquantized ? ((type_V == GGML_TYPE_TURBO3_0 || type_V == GGML_TYPE_TURBO2_0) ? 4 : 2*cpy_ne) : 4;
+    constexpr int V_rows_per_thread = V_is_unquantized ? ((type_V == GGML_TYPE_TURBO3_0 || type_V == GGML_TYPE_TURBO2_0 || type_V == GGML_TYPE_TURBO4_0) ? 4 : 2*cpy_ne) : 4;
     constexpr int V_cols_per_iter   = WARP_SIZE / nthreads_V;
 
     constexpr vec_dot_KQ_t vec_dot_KQ = get_vec_dot_KQ<type_K, D, nthreads_KQ>();


### PR DESCRIPTION
Fixes #252.

`turbo4` V-cache produced corrupted / incoherent output (garbled from the very first token) while `turbo3` and `turbo2` worked on the same build.

**Root cause:** `GGML_TYPE_TURBO4_0` was dropped from the `V_rows_per_thread == 4` branch in `ggml/src/ggml-cuda/fattn-vec.cuh`, so turbo4 strided for `2*cpy_ne` (8) rows/thread while its inline V-reconstruction body still decodes only 4 elements per iteration — leaving half of each thread's V rows undecoded and corrupting the P·V accumulation. `turbo3`/`turbo2` stayed in the list (4 rows/thread, matching their decode bodies) and were unaffected — exactly why turbo3 works and turbo4 doesn't on the same build.

This one-line change re-adds `GGML_TYPE_TURBO4_0` to that list, restoring the pre-regression behavior (broke between `2cbfdc62` and `c26cbdffc`). Verified on gfx1100 / ROCm: turbo4 produces clean, correct output again with the fix.

Full analysis in #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
