### PR TITLE
vulkan : add TQ3_1S and register TQ4_1S weight types

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -5084,15 +5084,15 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
         // TurboQuant weight types are pinned to a 32-thread workgroup with a
         // shared-memory reduction, independent of the device subgroup size.
         //
-        // mul_mat_vec_tq4_1s.comp maps one thread to one element of a
-        // 32-element block: it indexes a 32-entry shared array by
-        // gl_LocalInvocationID.x, pairs lanes as (tid, tid + step) for the WHT
-        // butterfly, and selects the half-block scale with (tid < 16 ? d0 : d1).
+        // mul_mat_vec_tq4_1s.comp and mul_mat_vec_tq3_1s.comp map one thread to
+        // one element of a 32-element block: they index a 32-entry shared array
+        // by gl_LocalInvocationID.x, pair lanes as (tid, tid + step) for the WHT
+        // butterfly, and select the half-block scale with (tid < 16 ? d0 : d1).
         // All three are only correct when the workgroup is exactly 32 threads.
         //
         // The generic wg_size_subgroup above is the device subgroup size (or 4x
-        // it), which on RADV/gfx1151 is 64 -- that would read past tq4_smem and
-        // corrupt the butterfly. A subgroup reduction is wrong for the same
+        // it), which on RADV/gfx1151 is 64 -- that would read past tq{3,4}_smem
+        // and corrupt the butterfly. A subgroup reduction is wrong for the same
         // reason: the 32 threads are only half a wave there, so subgroupAdd
         // would fold in lanes from an unrelated block. Hence SHMEM and no
         // forced subgroup size.
@@ -5127,6 +5127,7 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_IQ4_NL][i],  "mul_mat_vec_iq4_nl_f32_f32",  arr_dmmv_iq4_nl_f32_f32_len[reduc16],  arr_dmmv_iq4_nl_f32_f32_data[reduc16],  "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_MXFP4][i],   "mul_mat_vec_mxfp4_f32_f32",   OCP_DMMV_LEN(arr_dmmv_mxfp4_f32_f32, reduc16), OCP_DMMV_DATA(arr_dmmv_mxfp4_f32_f32, reduc16), "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_NVFP4][i],   "mul_mat_vec_nvfp4_f32_f32",   OCP_DMMV_LEN(arr_dmmv_nvfp4_f32_f32, reduc16), OCP_DMMV_DATA(arr_dmmv_nvfp4_f32_f32, reduc16), "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
+            ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_TQ3_1S][i],  "mul_mat_vec_tq3_1s_f32_f32",  mul_mat_vec_tq3_1s_f32_f32_len, mul_mat_vec_tq3_1s_f32_f32_data, "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {1, 1, 1}, {tq_wg_size, 1, i+1}, 1, true, tq_use_subgroups, tq_force_subgroup_size);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_TQ4_1S][i],  "mul_mat_vec_tq4_1s_f32_f32",  mul_mat_vec_tq4_1s_f32_f32_len, mul_mat_vec_tq4_1s_f32_f32_data, "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {1, 1, 1}, {tq_wg_size, 1, i+1}, 1, true, tq_use_subgroups, tq_force_subgroup_size);
 
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_F32 ][i], "mul_mat_vec_f32_f16_f32",  arr_dmmv_f32_f16_f32_len[reduc],  arr_dmmv_f32_f16_f32_data[reduc],  "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {1, 1, 1}, {wg_size_subgroup, 1, i+1}, 1, false, use_subgroups, force_subgroup_size);
@@ -5155,6 +5156,7 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_IQ4_NL][i],  "mul_mat_vec_iq4_nl_f16_f32",  arr_dmmv_iq4_nl_f16_f32_len[reduc16],  arr_dmmv_iq4_nl_f16_f32_data[reduc16],  "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_MXFP4][i],   "mul_mat_vec_mxfp4_f16_f32",   OCP_DMMV_LEN(arr_dmmv_mxfp4_f16_f32, reduc16), OCP_DMMV_DATA(arr_dmmv_mxfp4_f16_f32, reduc16), "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_NVFP4][i],   "mul_mat_vec_nvfp4_f16_f32",   OCP_DMMV_LEN(arr_dmmv_nvfp4_f16_f32, reduc16), OCP_DMMV_DATA(arr_dmmv_nvfp4_f16_f32, reduc16), "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
+            ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_TQ3_1S][i],  "mul_mat_vec_tq3_1s_f16_f32",  mul_mat_vec_tq3_1s_f16_f32_len, mul_mat_vec_tq3_1s_f16_f32_data, "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {1, 1, 1}, {tq_wg_size, 1, i+1}, 1, true, tq_use_subgroups, tq_force_subgroup_size);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_TQ4_1S][i],  "mul_mat_vec_tq4_1s_f16_f32",  mul_mat_vec_tq4_1s_f16_f32_len, mul_mat_vec_tq4_1s_f16_f32_data, "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {1, 1, 1}, {tq_wg_size, 1, i+1}, 1, true, tq_use_subgroups, tq_force_subgroup_size);
 
 #if defined(GGML_VULKAN_INTEGER_DOT_GLSLC_SUPPORT)
@@ -5271,6 +5273,7 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_IQ4_NL],  "dequant_iq4_nl",  dequant_iq4_nl_len,  dequant_iq4_nl_data,  "main", 2, 5 * sizeof(uint32_t), {256 * 16, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_MXFP4],   "dequant_mxfp4",   dequant_mxfp4_len,   dequant_mxfp4_data,   "main", 2, 5 * sizeof(uint32_t), {256 * 16, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_NVFP4],   "dequant_nvfp4",   dequant_nvfp4_len,   dequant_nvfp4_data,   "main", 2, 5 * sizeof(uint32_t), {256 * 16, 1, 1}, {}, 1);
+    ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_TQ3_1S],  "dequant_tq3_1s",  dequant_tq3_1s_len,  dequant_tq3_1s_data,  "main", 2, 5 * sizeof(uint32_t), {256 * 32, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_TQ4_1S],  "dequant_tq4_1s",  dequant_tq4_1s_len,  dequant_tq4_1s_data,  "main", 2, 5 * sizeof(uint32_t), {256 * 32, 1, 1}, {}, 1);
 
     // get_rows
@@ -7511,6 +7514,7 @@ static vk_pipeline ggml_vk_get_to_fp16(ggml_backend_vk_context * ctx, ggml_type 
         case GGML_TYPE_IQ4_XS:
         case GGML_TYPE_IQ4_NL:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_TQ3_1S:
         case GGML_TYPE_TQ4_1S:
         case GGML_TYPE_NVFP4:
             break;
@@ -7655,6 +7659,7 @@ static vk_pipeline ggml_vk_get_dequantize_mul_mat_vec(ggml_backend_vk_context * 
         case GGML_TYPE_IQ4_XS:
         case GGML_TYPE_IQ4_NL:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_TQ3_1S:
         case GGML_TYPE_TQ4_1S:
         case GGML_TYPE_NVFP4:
             break;
@@ -7683,7 +7688,7 @@ static vk_pipeline ggml_vk_get_dequantize_mul_mat_vec(ggml_backend_vk_context * 
     // every DMMV_WG_SIZE_* class, so the size class cannot change the pipeline
     // today. Pin it anyway: the shader is only correct at 32 threads, and this
     // keeps that intent explicit if tq_wg_size ever becomes w-dependent.
-    if (a_type == GGML_TYPE_TQ4_1S) {
+    if (a_type == GGML_TYPE_TQ3_1S || a_type == GGML_TYPE_TQ4_1S) {
         dmmv_wg = DMMV_WG_SIZE_SUBGROUP;
     }
 
@@ -17839,6 +17844,7 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                     case GGML_TYPE_IQ4_XS:
                     case GGML_TYPE_IQ4_NL:
                     case GGML_TYPE_MXFP4:
+                    case GGML_TYPE_TQ3_1S:
                     case GGML_TYPE_TQ4_1S:
                     case GGML_TYPE_NVFP4:
                         break;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -17813,6 +17813,20 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
             {
                 ggml_type src0_type = op->src[0]->type;
                 if (op->op == GGML_OP_MUL_MAT_ID) {
+                    // TurboQuant weight types have no mul_mat_vec_id pipeline. The
+                    // mul_mat_id_s/m/l check below does not reject them: it is a shared-memory
+                    // heuristic, and ggml_vk_matmul_shmem_support() has no lut_size case for
+                    // TQ3_1S/TQ4_1S, so it computes a trivially-fitting size and leaves those
+                    // flags true on mainstream vendors. Claiming support is only survivable
+                    // while n > 8, where ggml_vk_use_mul_mat_vec_id() routes to mul_mm_id and
+                    // the generic dequant-to-f16 path picks it up. On the decode path
+                    // (src2->ne[1] <= 8) it reaches ggml_vk_get_dequantize_mul_mat_vec_id(),
+                    // whose type switch has no TQ cases, and asserts on a null pipeline. That
+                    // is ordinary MoE decode for a TQ-quantized model, so reject explicitly
+                    // until mul_mat_vec_id_tq{3,4}_1s exists.
+                    if (src0_type == GGML_TYPE_TQ3_1S || src0_type == GGML_TYPE_TQ4_1S) {
+                        return false;
+                    }
                     if (!device->mul_mat_id_s[src0_type] && !device->mul_mat_id_m[src0_type] && !device->mul_mat_id_l[src0_type]) {
                         // If there's not enough shared memory for row_ids and the result tile, fallback to CPU
                         return false;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -5081,6 +5081,25 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
                                               (use_subgroups16 && w == DMMV_WG_SIZE_LARGE) ? SHADER_REDUCTION_MODE_HYBRID :
                                               SHADER_REDUCTION_MODE_SHMEM;
 
+        // TurboQuant weight types are pinned to a 32-thread workgroup with a
+        // shared-memory reduction, independent of the device subgroup size.
+        //
+        // mul_mat_vec_tq4_1s.comp maps one thread to one element of a
+        // 32-element block: it indexes a 32-entry shared array by
+        // gl_LocalInvocationID.x, pairs lanes as (tid, tid + step) for the WHT
+        // butterfly, and selects the half-block scale with (tid < 16 ? d0 : d1).
+        // All three are only correct when the workgroup is exactly 32 threads.
+        //
+        // The generic wg_size_subgroup above is the device subgroup size (or 4x
+        // it), which on RADV/gfx1151 is 64 -- that would read past tq4_smem and
+        // corrupt the butterfly. A subgroup reduction is wrong for the same
+        // reason: the 32 threads are only half a wave there, so subgroupAdd
+        // would fold in lanes from an unrelated block. Hence SHMEM and no
+        // forced subgroup size.
+        const uint32_t tq_wg_size             = 32;
+        const bool     tq_use_subgroups       = false;
+        const uint32_t tq_force_subgroup_size = 0;
+
         for (uint32_t i = 0; i < mul_mat_vec_max_cols; ++i) {
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_F32 ][i], "mul_mat_vec_f32_f32_f32",  arr_dmmv_f32_f32_f32_len[reduc],  arr_dmmv_f32_f32_f32_data[reduc],  "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {1, 1, 1}, {wg_size_subgroup, 1, i+1}, 1, false, use_subgroups, force_subgroup_size);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_F16 ][i], "mul_mat_vec_f16_f32_f32",  arr_dmmv_f16_f32_f32_len[reduc],  arr_dmmv_f16_f32_f32_data[reduc],  "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {2, 1, 1}, {wg_size_subgroup, 2, i+1}, 1, false, use_subgroups, force_subgroup_size);
@@ -5108,6 +5127,7 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_IQ4_NL][i],  "mul_mat_vec_iq4_nl_f32_f32",  arr_dmmv_iq4_nl_f32_f32_len[reduc16],  arr_dmmv_iq4_nl_f32_f32_data[reduc16],  "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_MXFP4][i],   "mul_mat_vec_mxfp4_f32_f32",   OCP_DMMV_LEN(arr_dmmv_mxfp4_f32_f32, reduc16), OCP_DMMV_DATA(arr_dmmv_mxfp4_f32_f32, reduc16), "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_NVFP4][i],   "mul_mat_vec_nvfp4_f32_f32",   OCP_DMMV_LEN(arr_dmmv_nvfp4_f32_f32, reduc16), OCP_DMMV_DATA(arr_dmmv_nvfp4_f32_f32, reduc16), "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
+            ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_TQ4_1S][i],  "mul_mat_vec_tq4_1s_f32_f32",  mul_mat_vec_tq4_1s_f32_f32_len, mul_mat_vec_tq4_1s_f32_f32_data, "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {1, 1, 1}, {tq_wg_size, 1, i+1}, 1, true, tq_use_subgroups, tq_force_subgroup_size);
 
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_F32 ][i], "mul_mat_vec_f32_f16_f32",  arr_dmmv_f32_f16_f32_len[reduc],  arr_dmmv_f32_f16_f32_data[reduc],  "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {1, 1, 1}, {wg_size_subgroup, 1, i+1}, 1, false, use_subgroups, force_subgroup_size);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_F16 ][i], "mul_mat_vec_f16_f16_f32",  arr_dmmv_f16_f16_f32_len[reduc],  arr_dmmv_f16_f16_f32_data[reduc],  "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {2, 1, 1}, {wg_size_subgroup, 2, i+1}, 1, false, use_subgroups, force_subgroup_size);
@@ -5135,6 +5155,7 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_IQ4_NL][i],  "mul_mat_vec_iq4_nl_f16_f32",  arr_dmmv_iq4_nl_f16_f32_len[reduc16],  arr_dmmv_iq4_nl_f16_f32_data[reduc16],  "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_MXFP4][i],   "mul_mat_vec_mxfp4_f16_f32",   OCP_DMMV_LEN(arr_dmmv_mxfp4_f16_f32, reduc16), OCP_DMMV_DATA(arr_dmmv_mxfp4_f16_f32, reduc16), "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_NVFP4][i],   "mul_mat_vec_nvfp4_f16_f32",   OCP_DMMV_LEN(arr_dmmv_nvfp4_f16_f32, reduc16), OCP_DMMV_DATA(arr_dmmv_nvfp4_f16_f32, reduc16), "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
+            ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_TQ4_1S][i],  "mul_mat_vec_tq4_1s_f16_f32",  mul_mat_vec_tq4_1s_f16_f32_len, mul_mat_vec_tq4_1s_f16_f32_data, "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {1, 1, 1}, {tq_wg_size, 1, i+1}, 1, true, tq_use_subgroups, tq_force_subgroup_size);
 
 #if defined(GGML_VULKAN_INTEGER_DOT_GLSLC_SUPPORT)
             if (device->integer_dot_product) {
@@ -5250,6 +5271,7 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_IQ4_NL],  "dequant_iq4_nl",  dequant_iq4_nl_len,  dequant_iq4_nl_data,  "main", 2, 5 * sizeof(uint32_t), {256 * 16, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_MXFP4],   "dequant_mxfp4",   dequant_mxfp4_len,   dequant_mxfp4_data,   "main", 2, 5 * sizeof(uint32_t), {256 * 16, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_NVFP4],   "dequant_nvfp4",   dequant_nvfp4_len,   dequant_nvfp4_data,   "main", 2, 5 * sizeof(uint32_t), {256 * 16, 1, 1}, {}, 1);
+    ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_TQ4_1S],  "dequant_tq4_1s",  dequant_tq4_1s_len,  dequant_tq4_1s_data,  "main", 2, 5 * sizeof(uint32_t), {256 * 32, 1, 1}, {}, 1);
 
     // get_rows
     ggml_vk_create_pipeline(device, device->pipeline_get_rows[GGML_TYPE_F32 ], "get_rows_f32",  get_rows_f32_len,  get_rows_f32_data,  "main", 3, sizeof(vk_op_binary_push_constants), { 512, 1, 1}, {}, 1);
@@ -7489,6 +7511,7 @@ static vk_pipeline ggml_vk_get_to_fp16(ggml_backend_vk_context * ctx, ggml_type 
         case GGML_TYPE_IQ4_XS:
         case GGML_TYPE_IQ4_NL:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_TQ4_1S:
         case GGML_TYPE_NVFP4:
             break;
         default:
@@ -7632,6 +7655,7 @@ static vk_pipeline ggml_vk_get_dequantize_mul_mat_vec(ggml_backend_vk_context * 
         case GGML_TYPE_IQ4_XS:
         case GGML_TYPE_IQ4_NL:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_TQ4_1S:
         case GGML_TYPE_NVFP4:
             break;
         default:
@@ -7653,6 +7677,14 @@ static vk_pipeline ggml_vk_get_dequantize_mul_mat_vec(ggml_backend_vk_context * 
                 dmmv_wg = DMMV_WG_SIZE_LARGE;
             }
         }
+    }
+
+    // TurboQuant weight types are created with a fixed 32-thread workgroup for
+    // every DMMV_WG_SIZE_* class, so the size class cannot change the pipeline
+    // today. Pin it anyway: the shader is only correct at 32 threads, and this
+    // keeps that intent explicit if tq_wg_size ever becomes w-dependent.
+    if (a_type == GGML_TYPE_TQ4_1S) {
+        dmmv_wg = DMMV_WG_SIZE_SUBGROUP;
     }
 
     if (b_type == GGML_TYPE_Q8_1) {
@@ -17807,6 +17839,7 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                     case GGML_TYPE_IQ4_XS:
                     case GGML_TYPE_IQ4_NL:
                     case GGML_TYPE_MXFP4:
+                    case GGML_TYPE_TQ4_1S:
                     case GGML_TYPE_NVFP4:
                         break;
                     default:

--- a/ggml/src/ggml-vulkan/vulkan-shaders/dequant_funcs.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/dequant_funcs.glsl
@@ -762,6 +762,57 @@ vec2 get_dm(uint ib, uint a_offset) {
 }
 #endif
 
+#if defined(DATA_A_TQ3_1S)
+vec2 dequantize(uint ib, uint iqs, uint a_offset) {
+    // TQ3_1S: 8-level Lloyd-Max centroids for N(0,1). ASYMMETRIC -- must match
+    // TQ3_0_CENTROIDS in ggml/src/ggml-turbo-quant.c byte for byte.
+    const float centroids[8] = float[8](
+        -1.996684, -1.291398, -0.740341, -0.247508,
+         0.230106,  0.725222,  1.277503,  1.988943
+    );
+
+    // iqs is the element pair index within the block (0..15)
+    const uint j0 = iqs;
+    const uint j1 = iqs + 1;
+
+    // 8 three-bit indices per 3-byte group, index i at bits [3i, 3i+2] of the
+    // group read as a 24-bit little-endian word (see dequant_tq3_1s.comp).
+    const uint g0 = (j0 >> 3) * 3u;
+    const uint g1 = (j1 >> 3) * 3u;
+    const uint p0 = uint(data_a[a_offset + ib].qs[g0])
+                  | (uint(data_a[a_offset + ib].qs[g0 + 1u]) << 8)
+                  | (uint(data_a[a_offset + ib].qs[g0 + 2u]) << 16);
+    const uint p1 = uint(data_a[a_offset + ib].qs[g1])
+                  | (uint(data_a[a_offset + ib].qs[g1 + 1u]) << 8)
+                  | (uint(data_a[a_offset + ib].qs[g1 + 2u]) << 16);
+    const uint idx0 = (p0 >> ((j0 & 7u) * 3u)) & 7u;
+    const uint idx1 = (p1 >> ((j1 & 7u) * 3u)) & 7u;
+
+    // Scale by d0 (elements 0-15) or d1 (elements 16-31)
+    const float d0 = float(data_a[a_offset + ib].d0);
+    const float d1 = float(data_a[a_offset + ib].d1);
+    const float s0 = (j0 < 16) ? d0 : d1;
+    const float s1 = (j1 < 16) ? d0 : d1;
+
+    // Returns centroid * scale WITHOUT the inverse RHT, exactly like the
+    // TQ4_1S branch below. Any caller that wants true weights must apply the
+    // inverse WHT itself, or pre-rotate the activation instead (which is what
+    // mul_mat_vec_tq3_1s.comp does). Callers that do neither -- notably
+    // get_rows_quant.comp -- would get un-rotated values, which is why
+    // GET_ROWS support is not claimed for this type.
+    return vec2(centroids[idx0] * s0, centroids[idx1] * s1);
+}
+vec4 dequantize4(uint ib, uint iqs, uint a_offset) {
+    vec2 v0 = dequantize(ib, iqs, a_offset);
+    vec2 v1 = dequantize(ib, iqs + 2, a_offset);
+    return vec4(v0.x, v0.y, v1.x, v1.y);
+}
+vec2 get_dm(uint ib, uint a_offset) {
+    // No global scale/min: scales are applied per-element in dequantize()
+    return vec2(1, 0);
+}
+#endif
+
 #if defined(DATA_A_TQ4_1S)
 vec2 dequantize(uint ib, uint iqs, uint a_offset) {
     // TQ4_1S: 16-level Lloyd-Max centroids for N(0,1)

--- a/ggml/src/ggml-vulkan/vulkan-shaders/dequant_tq3_1s.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/dequant_tq3_1s.comp
@@ -1,0 +1,93 @@
+#version 450
+
+#include "dequant_head.glsl"
+
+// 256 threads per workgroup, each thread fully dequants one TQ3_1S block
+// (32 elements, 16 bytes). Workgroups process 256 blocks = 8192 elements each
+// so the x dispatch stays under maxComputeWorkGroupCount[0] for large tensors.
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+layout (binding = 0) readonly buffer A {block_tq3_1s data_a[];};
+layout (binding = 1) writeonly buffer D {D_TYPE data_b[];};
+
+// One WHT butterfly stage, as a flat 16-iteration loop over the 16 disjoint
+// pairs, with a compile-time constant stride supplied by the macro argument.
+//
+// This is deliberately NOT the rolled triple loop of tq3_0_rht_inverse()
+// (ggml/src/ggml-turbo-quant.c) or of dequant_tq4_1s.comp. Those have a
+// non-constant inner increment, so glslang cannot unroll them, buf[] stays a
+// dynamically indexed function-local array, and it is not promotable to
+// registers -- it becomes scratch. This shader runs over the *entire* weight
+// tensor on the prefill path, so that matters. With a literal STEP and a
+// constant trip count every subscript folds: the compiled SPIR-V for this file
+// contains zero loops and no function-local array at all.
+//
+// lo enumerates the same (j, j + step) pairs, in the same order, as the
+// reference triple loop -- verified for all five stages. The pairs within a
+// stage are disjoint, so order is not load-bearing, but keeping it identical
+// makes the floating-point result bit-for-bit equal to the CPU reference.
+#define TQ3_WHT_STAGE(STEP)                                             \
+    [[unroll]] for (uint k = 0u; k < 16u; k++) {                        \
+        const uint lo = ((k / (STEP)) * (2u * (STEP))) + (k % (STEP));  \
+        const float a = buf[lo];                                        \
+        const float b = buf[lo + (STEP)];                               \
+        buf[lo]          = a + b;                                       \
+        buf[lo + (STEP)] = a - b;                                       \
+    }
+
+void main() {
+    // Lloyd-Max centroids for 3-bit normal quantization. ASYMMETRIC -- must
+    // match TQ3_0_CENTROIDS in ggml/src/ggml-turbo-quant.c byte for byte.
+    const float centroids[8] = float[8](
+        -1.996684, -1.291398, -0.740341, -0.247508,
+         0.230106,  0.725222,  1.277503,  1.988943
+    );
+
+    // WHT sign pattern for inverse RHT normalization (shared with TQ4_1S)
+    const float signs[32] = float[32](
+        +1.0, -1.0, +1.0, -1.0, +1.0, +1.0, -1.0, +1.0,
+        -1.0, -1.0, +1.0, -1.0, +1.0, +1.0, -1.0, +1.0,
+        -1.0, -1.0, +1.0, -1.0, +1.0, -1.0, -1.0, +1.0,
+        -1.0, +1.0, +1.0, -1.0, +1.0, -1.0, -1.0, +1.0
+    );
+
+    const float INV_SQRT32 = 0.17677669529663688;
+
+    const uint ib = gl_WorkGroupID.x * gl_WorkGroupSize.x + gl_LocalInvocationID.x;
+    if (ib >= p.nel / 32) return;
+
+    const float d0 = float(data_a[ib].d0);
+    const float d1 = float(data_a[ib].d1);
+
+    // Load centroid*scale into per-thread buffer.
+    // TQ3 packs 8 three-bit indices into each 3-byte group, 4 groups per block.
+    // Reading the group as a 24-bit little-endian word turns the extraction
+    // into a single shift: quantize_row_tq3_1s_ref() lays index i at bits
+    // [3i, 3i+2] of that word, including indices 2 and 5 which straddle a byte.
+    float buf[32];
+    [[unroll]] for (uint g = 0u; g < 4u; g++) {
+        const uint qb = g * 3u;
+        const uint packed = uint(data_a[ib].qs[qb])
+                          | (uint(data_a[ib].qs[qb + 1u]) << 8)
+                          | (uint(data_a[ib].qs[qb + 2u]) << 16);
+        [[unroll]] for (uint i = 0u; i < 8u; i++) {
+            const uint j   = g * 8u + i;
+            const uint idx = (packed >> (i * 3u)) & 7u;
+            const float d  = (j < 16u) ? d0 : d1;
+            buf[j] = centroids[idx] * d;
+        }
+    }
+
+    // Inverse WHT butterfly (5 stages for 32 elements) -- matches CPU reference
+    TQ3_WHT_STAGE(1u)
+    TQ3_WHT_STAGE(2u)
+    TQ3_WHT_STAGE(4u)
+    TQ3_WHT_STAGE(8u)
+    TQ3_WHT_STAGE(16u)
+
+    // Normalize and apply sign pattern
+    const uint out_base = ib * 32u;
+    [[unroll]] for (uint j = 0u; j < 32u; j++) {
+        data_b[out_base + j] = D_TYPE(buf[j] * INV_SQRT32 * signs[j]);
+    }
+}

--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vec_tq3_1s.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vec_tq3_1s.comp
@@ -1,0 +1,162 @@
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types_int32 : require
+
+#include "mul_mat_vec_base.glsl"
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+// Lloyd-Max centroids for TQ3_1S (3-bit, 8 levels) -- N(0, 1) optimal.
+// These are ASYMMETRIC (unlike TQ4's mirrored table); they must match
+// TQ3_0_CENTROIDS in ggml/src/ggml-turbo-quant.c byte for byte.
+const float TQ3_CENTROIDS[8] = float[8](
+    -1.996684, -1.291398, -0.740341, -0.247508,
+     0.230106,  0.725222,  1.277503,  1.988943
+);
+
+// WHT sign pattern for 32-element blocks (shared by TQ3 and TQ4);
+// TQ3_0_SIGNS in ggml-turbo-quant.c, TQ_WEIGHT_SIGNS in turbo-quant.cuh.
+const float TQ3_SIGNS[32] = float[32](
+    +1.0, -1.0, +1.0, -1.0, +1.0, +1.0, -1.0, +1.0,
+    -1.0, -1.0, +1.0, -1.0, +1.0, +1.0, -1.0, +1.0,
+    -1.0, -1.0, +1.0, -1.0, +1.0, -1.0, -1.0, +1.0,
+    -1.0, +1.0, +1.0, -1.0, +1.0, -1.0, -1.0, +1.0
+);
+
+const float TQ3_INV_SQRT32 = 0.17677669529663688;
+
+// ---------------------------------------------------------------------------
+// Why this kernel never dequantizes a weight
+// ---------------------------------------------------------------------------
+//
+// A stored TQ3_1S block holds c[j] = centroid[idx_j] * d_j, i.e. the block
+// *after* the rotation that quantization applied. The true weight is recovered
+// by the inverse RHT in dequantize_row_tq3_1s():
+//
+//     w = k * S * H * c
+//
+// with H the 32x32 natural-ordered (Sylvester) Hadamard matrix realised by the
+// in-place butterfly, S = diag(TQ3_SIGNS), and k = 1/sqrt(32). H is symmetric
+// and S is diagonal, so for any activation block x:
+//
+//     <w, x> = <k*S*H*c, x>
+//            = k * sum_j (H*c)[j] * (S*x)[j]
+//            = k * <H*c, S*x>
+//            = k * <c, H^T*S*x>
+//            = k * <c, H*S*x>          (H symmetric)
+//
+// The rotation can therefore be moved off the weights and onto the activation:
+// sign-flip and butterfly the *activation* block once per workgroup, then dot
+// it against the raw centroid*scale values straight out of memory. That is why
+// there is no inverse WHT anywhere below, and why the loads of data_a are used
+// unmodified. The k factor is folded into the per-row weight term rather than
+// the shared activation, which is equivalent by linearity and saves a pass over
+// shared memory.
+//
+// Cost: one 32-point WHT per (block, column) instead of one per (block, row).
+// For a 5120-row projection that is a ~5000x reduction in butterfly work, and
+// it is what the CUDA (tq_prerotate_activation, ggml-cuda/mmvq-tq.cu) and Metal
+// (kernel_mul_mv_tq3_1s_f32_impl, ggml-metal.metal) kernels both do.
+//
+// Shared memory budget: NUM_COLS * 32 floats (max 1 KiB at NUM_COLS=8)
+// plus whatever tmpsh the reduction helper allocates.
+// ---------------------------------------------------------------------------
+
+shared float tq3_smem[8 * 32];
+
+void compute_outputs(const uint32_t first_row, const uint32_t num_rows) {
+    const uint tid = gl_LocalInvocationID.x;
+
+    uint a_offset, b_offset, d_offset;
+    get_offsets(a_offset, b_offset, d_offset);
+
+    FLOAT_TYPE temp[NUM_COLS][NUM_ROWS];
+    [[unroll]] for (uint j = 0; j < NUM_COLS; ++j) {
+        [[unroll]] for (uint n = 0; n < NUM_ROWS; ++n) {
+            temp[j][n] = FLOAT_TYPE(0);
+        }
+    }
+
+    const uint num_blocks_per_row = p.ncols / 32u;
+
+    // TQ3 packs 8 three-bit indices into each 3-byte group, 4 groups per block.
+    // Loading the group as a 24-bit little-endian word makes the extraction a
+    // single shift: the C packer in quantize_row_tq3_1s_ref() lays index i at
+    // bits [3i, 3i+2] of that word, including the two indices (2 and 5) that
+    // straddle a byte boundary.
+    const uint group  = tid >> 3u;          // 3-byte group, 0..3
+    const uint qs_base = group * 3u;        // byte offset of the group
+    const uint shift  = (tid & 7u) * 3u;    // bit offset within the group
+    const float sign_tid = TQ3_SIGNS[tid];
+
+    for (uint blk = 0; blk < num_blocks_per_row; blk++) {
+        // --- Stage 1: load activation, sign-flip, write to shared memory ---
+        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+            const uint b_base = c * p.batch_stride_b + b_offset + blk * 32u;
+            tq3_smem[c * 32u + tid] = float(data_b[b_base + tid]) * sign_tid;
+        }
+        barrier();
+
+        // --- Stage 2: forward WHT butterfly in shared memory (5 stages) ---
+        // Pairs (tid, tid + step) with (tid & step) == 0, matching the
+        // (j, j + step) pairing of tq3_0_rht_forward() in ggml-turbo-quant.c.
+        [[unroll]] for (uint step = 1u; step < 32u; step <<= 1u) {
+            if ((tid & step) == 0u) {
+                const uint partner = tid + step;
+                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                    const uint base = c * 32u;
+                    const float a = tq3_smem[base + tid];
+                    const float b = tq3_smem[base + partner];
+                    tq3_smem[base + tid]     = a + b;
+                    tq3_smem[base + partner] = a - b;
+                }
+            }
+            barrier();
+        }
+
+        // --- Stage 3: dequant all rows' weights for this block position ---
+        // Pre-computing the weight for every row before touching the column
+        // accumulator lets the compiler treat the smem read in stage 4 as
+        // loop-invariant across rows, which is the Vulkan analogue of the
+        // "hot loop load dedup" optimisation in the CUDA kernel (PR #57).
+        float w_vals[NUM_ROWS];
+        [[unroll]] for (uint n = 0; n < num_rows; ++n) {
+            const uint ib = (first_row + n) * num_blocks_per_row + blk;
+            const uint packed = uint(data_a[a_offset + ib].qs[qs_base])
+                              | (uint(data_a[a_offset + ib].qs[qs_base + 1u]) << 8)
+                              | (uint(data_a[a_offset + ib].qs[qs_base + 2u]) << 16);
+            const uint idx = (packed >> shift) & 7u;
+            const float d  = (tid < 16u)
+                ? float(data_a[a_offset + ib].d0)
+                : float(data_a[a_offset + ib].d1);
+            w_vals[n] = TQ3_CENTROIDS[idx] * d * TQ3_INV_SQRT32;
+        }
+
+        // --- Stage 4: accumulate dot products ---
+        // Read the rotated activation once per column; reuse across all rows.
+        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+            const float b_rotated = tq3_smem[c * 32u + tid];
+            [[unroll]] for (uint n = 0; n < num_rows; ++n) {
+                temp[c][n] += FLOAT_TYPE(w_vals[n] * b_rotated);
+            }
+        }
+
+        // Ensure every thread is done reading before the next block's store.
+        barrier();
+    }
+
+    reduce_result(temp, d_offset, first_row, num_rows, tid);
+}
+
+void main() {
+    const uint first_row = NUM_ROWS * (gl_WorkGroupID.x + gl_NumWorkGroups.x * gl_WorkGroupID.z);
+
+    if (first_row + NUM_ROWS <= p.stride_d) {
+        compute_outputs(first_row, NUM_ROWS);
+    } else {
+        if (first_row >= p.stride_d) {
+            return;
+        }
+        compute_outputs(first_row, p.stride_d - first_row);
+    }
+}

--- a/ggml/src/ggml-vulkan/vulkan-shaders/types.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/types.glsl
@@ -1827,6 +1827,25 @@ struct block_turbo4_0
 #endif
 
 
+#define QUANT_K_TQ3_1S 32
+#define QUANT_R_TQ3_1S 1
+
+// Mirrors block_tq3_1s in ggml/src/ggml-common.h: 2 + 2 + 12 = 16 bytes.
+// The qs array is 4 groups of 3 bytes, each holding 8 three-bit indices.
+struct block_tq3_1s
+{
+    float16_t d0;      // scale for elements 0-15
+    float16_t d1;      // scale for elements 16-31
+    uint8_t qs[12];    // 3-bit centroid indices, 8 packed per 3-byte group
+};
+
+#if defined(DATA_A_TQ3_1S)
+#define QUANT_K QUANT_K_TQ3_1S
+#define QUANT_R QUANT_R_TQ3_1S
+#define QUANT_AUXF 1
+#define A_TYPE block_tq3_1s
+#endif
+
 #define QUANT_K_TQ4_1S 32
 #define QUANT_R_TQ4_1S 1
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -889,6 +889,24 @@ void process_shaders() {
     string_to_spv("dequant_tq4_1s", "dequant_tq4_1s.comp",
         merge_maps(base_dict, {{"DATA_A_TQ4_1S", "1"}, {"D_TYPE", "float16_t"}}));
 
+    // TQ3_1S is the sibling 3-bit type (8 Lloyd-Max levels, 8 indices packed
+    // per 3 bytes, 16 B blocks). Unlike TQ4_1S it had no Vulkan shaders at all,
+    // so dequant_tq3_1s.comp and mul_mat_vec_tq3_1s.comp are new. Everything in
+    // the three-point rationale above applies here verbatim -- the mat-vec maps
+    // one thread to one element of a 32-element block, so it is generated
+    // explicitly and pinned to a 32-thread workgroup host-side rather than
+    // being driven from type_names.
+    //
+    // TQ3_1S is also excluded from the coopmat/coopmat2 matmul paths: it has no
+    // dequant_funcs_cm2.glsl entry, and gfx1151 exposes KHR_coopmat (coopmat1)
+    // only. A stub that returned zeros there would be worse than no support.
+    string_to_spv("mul_mat_vec_tq3_1s_f32_f32", "mul_mat_vec_tq3_1s.comp",
+        merge_maps(base_dict, {{"DATA_A_TQ3_1S", "1"}, {"B_TYPE", "float"}, {"B_TYPEV2", "vec2"}, {"B_TYPEV4", "vec4"}, {"D_TYPE", "float"}}));
+    string_to_spv("mul_mat_vec_tq3_1s_f16_f32", "mul_mat_vec_tq3_1s.comp",
+        merge_maps(base_dict, {{"DATA_A_TQ3_1S", "1"}, {"B_TYPE", "float16_t"}, {"B_TYPEV2", "f16vec2"}, {"B_TYPEV4", "f16vec4"}, {"D_TYPE", "float"}}));
+    string_to_spv("dequant_tq3_1s", "dequant_tq3_1s.comp",
+        merge_maps(base_dict, {{"DATA_A_TQ3_1S", "1"}, {"D_TYPE", "float16_t"}}));
+
     auto get_type_str = [](bool f16) {
         return f16 ? "float16_t" : "float";
     };

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -854,6 +854,41 @@ void process_shaders() {
     // TurboQuant Walsh-Hadamard Transform op (Q forward + kqv inverse rotation)
     string_to_spv("turbo_wht", "turbo_wht.comp", {});
 
+    // TurboQuant WEIGHT types.
+    //
+    // dequant_tq4_1s.comp and mul_mat_vec_tq4_1s.comp have been in the tree
+    // since 2a716ac4 but were never passed to glslc: the Vulkan SPIR-V build is
+    // driven entirely by the explicit string_to_spv() calls here (there is no
+    // glob), and "tq4_1s" appears in neither type_names nor any generation
+    // loop. The shaders were dead files, so every TQ4_1S MUL_MAT fell back to
+    // CPU while test-backend-ops reported OK -- its TQ4_1S cases were silently
+    // skipped rather than run (see ggml-org/llama.cpp#242 for why a fully
+    // skipped op still reports success).
+    //
+    // These are generated here rather than by adding "tq4_1s" to type_names,
+    // because that loop would also emit three things we must not use:
+    //
+    //   1. USE_SUBGROUP_ADD / _NO_SHMEM reduction variants. mul_mat_vec_tq4_1s
+    //      indexes a 32-entry shared array by gl_LocalInvocationID.x and pairs
+    //      lanes as (tid, tid + step) for the butterfly, so it is only correct
+    //      for a 32-thread workgroup. A subgroup reduction over a wave that is
+    //      not exactly the workgroup is wrong, and RADV on gfx1151 (Strix Halo,
+    //      Radeon 8060S) reports "warp size: 64". The host side pins these
+    //      pipelines to a 32-thread workgroup with SHMEM reduction to match.
+    //   2. mul_mat_vec_id_tq4_1s_*, for which no host pipeline is created.
+    //   3. get_rows_tq4_1s via get_rows_quant.comp, which applies no inverse
+    //      WHT and whose get_dm() returns vec2(1,0); it would hand back
+    //      un-rotated centroid*scale values. GET_ROWS support is deliberately
+    //      not claimed for this type.
+    string_to_spv("mul_mat_vec_tq4_1s_f32_f32", "mul_mat_vec_tq4_1s.comp",
+        merge_maps(base_dict, {{"DATA_A_TQ4_1S", "1"}, {"B_TYPE", "float"}, {"B_TYPEV2", "vec2"}, {"B_TYPEV4", "vec4"}, {"D_TYPE", "float"}}));
+    string_to_spv("mul_mat_vec_tq4_1s_f16_f32", "mul_mat_vec_tq4_1s.comp",
+        merge_maps(base_dict, {{"DATA_A_TQ4_1S", "1"}, {"B_TYPE", "float16_t"}, {"B_TYPEV2", "f16vec2"}, {"B_TYPEV4", "f16vec4"}, {"D_TYPE", "float"}}));
+    // Cold path: dequantize the whole tensor to f16 and run the generic matmul.
+    // Used when n > mul_mat_vec_max_cols (prompt processing).
+    string_to_spv("dequant_tq4_1s", "dequant_tq4_1s.comp",
+        merge_maps(base_dict, {{"DATA_A_TQ4_1S", "1"}, {"D_TYPE", "float16_t"}}));
+
     auto get_type_str = [](bool f16) {
         return f16 ? "float16_t" : "float";
     };

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9411,6 +9411,11 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
 
     for (ggml_type type_a : all_types) {
         test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 4, 2, false, 64, 16, 3*ggml_blck_size(type_a)));
+        // n=1 as well as n=16: ggml_vk_use_mul_mat_vec_id() selects the mat-vec path only
+        // when src2->ne[1] <= 8, so the n=16 case above exercises mul_mm_id and never touches
+        // the decode path. A backend that claims MUL_MAT_ID support without a mul_mat_vec_id
+        // pipeline for the type passes at n=16 and asserts on a null pipeline at n=1.
+        test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 4, 2, false, 64, 1, 3*ggml_blck_size(type_a)));
     }
 
     for (ggml_type type_a : base_types) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -2463,9 +2463,10 @@ struct test_set_rows : public test_case {
             err_estimate /= 0.25f*float(ne[0] * r * ne[2]*nr23[0] * ne[3]*nr23[1]);
             return err_estimate;
         }
-        if (type_dst == GGML_TYPE_TQ4_1S) {
-            // Reduction order matters; TQ4_1S has a 32-element WHT inside the
-            // dot product which amplifies fp reduction differences slightly.
+        if (type_dst == GGML_TYPE_TQ3_1S || type_dst == GGML_TYPE_TQ4_1S) {
+            // Reduction order matters; both TurboQuant weight types have a
+            // 32-element WHT inside the dot product which amplifies fp
+            // reduction differences slightly.
             return 0.01;
         }
         return 1e-7;
@@ -9198,6 +9199,31 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         for (int m : { 256, 1536, 2048 }) {
             for (int n : { 16, 64, 256 }) {
                 test_cases.emplace_back(new test_mul_mat(GGML_TYPE_TQ4_1S, GGML_TYPE_F32, m, n, k, {1, 1}, {1, 1}));
+            }
+        }
+    }
+
+    // TQ3_1S: same two sweeps as TQ4_1S above, for the 3-bit sibling type.
+    // TQ3_1S packs 8 indices per 3 bytes rather than 2 per byte, so the
+    // per-thread unpack differs; the shared-memory WHT on the activation and
+    // the 32-thread workgroup are identical. Bugs in the packing offset only
+    // surface once k is large enough to cross many block boundaries.
+    for (int k : { 1536, 2048, 2304, 3072, 4096 }) {
+        for (int m : { 256, 1152, 1536, 2048, 5120, 6144 }) {
+            for (int n : { 1, 2, 4, 8 }) {
+                test_cases.emplace_back(new test_mul_mat(GGML_TYPE_TQ3_1S, GGML_TYPE_F32, m, n, k, {1, 1}, {1, 1}));
+                test_cases.emplace_back(new test_mul_mat(GGML_TYPE_TQ3_1S, GGML_TYPE_F16, m, n, k, {1, 1}, {1, 1}));
+            }
+        }
+    }
+
+    // TQ3_1S: large-batch MUL_MAT, i.e. the pipeline_dequant[TQ3_1S] +
+    // generic f16 matmul path taken when n > mul_mat_vec_max_cols = 8.
+    // This is the only coverage the dequant shader's inverse WHT gets.
+    for (int k : { 1536, 2048 }) {
+        for (int m : { 256, 1536, 2048 }) {
+            for (int n : { 16, 64, 256 }) {
+                test_cases.emplace_back(new test_mul_mat(GGML_TYPE_TQ3_1S, GGML_TYPE_F32, m, n, k, {1, 1}, {1, 1}));
             }
         }
     }


### PR DESCRIPTION
## What

Brings the TurboQuant weight types up on the Vulkan backend. Two commits:

1. **Restores `TQ4_1S` wiring lost in the rebase.** Simon Gardling already did this in #69 (f03d3314, 2026-04-20). That commit is not an ancestor of 2a716ac4, so the current branch carries the shaders without the host wiring: `dequant_tq4_1s.comp` and `mul_mat_vec_tq4_1s.comp` are present but never compiled, because the Vulkan SPIR-V build is driven entirely by explicit `string_to_spv()` calls in `vulkan-shaders-gen.cpp` (there is no glob) and `tq4_1s` appears in neither `type_names` nor any generation loop. `ggml-vulkan.cpp` on the current tip has zero references to `GGML_TYPE_TQ4_1S`, so no pipeline is created. This is the same class of loss as 28c68fe7 ("reconstruct supports_op after rebase merge damage"), which re-applied the three turbo KV grafts but not the weight types. This commit adds no shader code.
2. **Adds `TQ3_1S`.** New `dequant_tq3_1s.comp` and `mul_mat_vec_tq3_1s.comp`, plus the `types.glsl` / `dequant_funcs.glsl` entries and the same host wiring. Ported from the in-tree CUDA (`ggml-cuda/mmvq-tq.cu`, `turbo-quant.cuh`) and Metal (`ggml-metal.metal`) implementations against the C reference in `ggml-turbo-quant.c`.

Both are generated by explicit `string_to_spv()` calls rather than by adding the type names to `type_names`, because that loop would also emit three things that must not be used:

- `USE_SUBGROUP_ADD` / `_NO_SHMEM` reduction variants. Both mat-vec shaders map one thread to one element of a 32-element block: they index a 32-entry shared array by `gl_LocalInvocationID.x`, pair lanes as `(tid, tid + step)` for the WHT butterfly, and select the half-block scale with `(tid < 16 ? d0 : d1)`. All three are correct only at a 32-thread workgroup, and a subgroup reduction over a wave that is not exactly the workgroup folds in lanes from an unrelated block. RADV on gfx1151 reports `warp size: 64`, so this is not hypothetical there. The host side pins these pipelines to a 32-thread workgroup with a shared-memory reduction, independent of the device subgroup size.
- `mul_mat_vec_id_*`, for which no host pipeline is created. `MUL_MAT_ID` stays rejected by the existing `mul_mat_id_s/m/l` guard in `supports_op`.
- `get_rows_*` via `get_rows_quant.comp`, which applies no inverse RHT and whose `get_dm()` returns `vec2(1, 0)`. `GET_ROWS` support is deliberately not claimed for either type; see the note below.

Also adds the TQ3_1S MUL_MAT sweeps to `test-backend-ops.cpp`, mirroring the TQ4_1S blocks (production dimensions plus the large-batch block that exercises the dequant + f16 matmul path), and the matching tolerance entry.

## Why

Every TQ4_1S `MUL_MAT` on Vulkan currently falls back to CPU, and nothing says so. On gfx1151 `test-backend-ops -o MUL_MAT` reported `991/991 tests passed / OK` while every TQ4_1S case was skipped rather than run, including the 258 Gemma-4-dimension cases added alongside the shaders, whose comments describe the fused mul_mat_vec kernel and `pipeline_dequant[TQ4_1S]` as though both were wired. A fully skipped op still reports success (#242), so the gap was invisible from the test suite.

The practical cost is in the llama-bench numbers below: prefill on a real TQ4_1S GGUF was running at 1.19 t/s because the matmuls were on the CPU.

TQ3_1S had no Vulkan kernels at all, which is what blocks DeepSeek-V4-Flash Config-I (expert-down, attention, indexer and compressor tensors are TQ3_1S) from running on a 128GB Strix Halo box.

## Validation

All on gfx1151, `Radeon 8060S Graphics (RADV STRIX_HALO)`, `warp size: 64`, `matrix cores: KHR_coopmat`.

**Full `test-backend-ops` sweep, all ops:**

```
24472/24472 tests passed
2/2 backends passed
  tq3_1s:  OK=149  FAIL=0  NOT_SUPPORTED=120
  tq4_1s:  OK=149  FAIL=0  NOT_SUPPORTED=120
```

Zero FAIL, error or mismatch lines anywhere in the sweep.

**MUL_MAT progression**, one arm per commit: `991/991` (before) to `1139/1139` (TQ4_1S wiring restored, +148, no new shader code) to `1287/1287` (TQ3_1S kernels, +148). The TQ4_1S delta is entirely host wiring, which is the cleanest evidence that the shaders themselves were fine and only the registration was missing.

**llama-bench**, `thetom-ai/Nemotron-H-8B-Base-8K-Config-I-GGUF` (`...-tq4_1s.gguf`, 4.82 GiB, 8.10B), `-ngl 99 -p 512 -n 128 -r 2`, same image base and same GPU on both arms:

| | before (d0e2a8b6) | after | ratio |
|---|---|---|---|
| pp512 | 1.19 ± 0.00 t/s | 461.71 ± 2.93 t/s | 388x |
| tg128 | 1.11 ± 0.00 t/s | 7.95 ± 0.02 t/s | 7.2x |

Worth being precise about what that measures: both arms report `backend: Vulkan` and load `libggml-vulkan.so`, so the before arm is on the GPU. Only the TQ4_1S matmuls fall back to CPU per-op via the scheduler. Prefill is matmul-dominated so nearly all of its work was on the CPU, hence 1.19 t/s; decode is bandwidth-bound with more non-matmul work already on the GPU, hence the smaller recovery. This is prefill moving from CPU-bound to GPU-resident, not a kernel getting 388x faster. llama.cpp also prints `nemotron_h 31B.A3.5B unknown, may not work` for this arch, unrelated to this change, so the ratio is the meaningful number rather than the absolute t/s.

Pre-hardware checks on the TQ3_1S port, since silent numeric corruption is the failure mode for this family: the 3-bit unpack was verified exhaustively against the reference bit-field unpack over all 2^24 possible 3-byte groups; a C transliteration of the dequant shader is bit-for-bit identical to `dequantize_row_tq3_1s` over 4096 random blocks; the mat-vec identity holds to 1.2e-8 relative against dequant-then-dot at K = 32/256/1536/2048/3072/4096; and the emitted SPIR-V confirms `ArrayStride 16` matching `sizeof(block_tq3_1s)` (the drift class #204 had to fix for turbo4) with zero subgroup capabilities in the mat-vec module.

## Not covered

- The **f16 activation pipelines are registered but unverified**. `test-backend-ops`' CPU comparison backend cannot run `type_b=f16` for these types, so 120 of 269 cases per type report `not supported [CPU]`. This is a pre-existing limitation that TQ4_1S shares; I did not want to imply those cases passed.
- **TQ3_1S is unbenchmarked.** It is correctness-verified across 149 cases against the CPU reference, but the only TQ3_1S model I know of is the 95 GiB DeepSeek-V4-Flash Config-I, which I have not staged. All the llama-bench numbers above are TQ4_1S.
- **Only tested on one device.** gfx1151 / RADV, which is wave64. The 32-thread pin is what makes that correct, but a wave32 device (NVIDIA, Intel) would be a useful second data point and I do not have one to hand.
- `copy_to_quant.comp` / `copy_from_quant.comp` have TQ4_1S branches that are **also** orphaned today (no cpy shaders are generated for either TQ type). **#69 wired `set_rows_tq4_1s` and `cpy_tq4_1s_f32` and this PR does not**, so that part of the regression is still outstanding. I left it out because I have no `SET_ROWS`/`CPY` coverage for these types on hardware; happy to restore it here if you would rather it land in one go.

## Note on get_rows

`dequant_funcs.glsl`'s TQ branches return `centroid * scale` with no inverse RHT, and `get_dm()` returns `vec2(1, 0)`, which the comment there already says. That is harmless on master precisely because nothing registers a `get_rows` pipeline for these types, so the path is unreachable. I have kept it that way: no `pipeline_get_rows[TQ*]`, no `GET_ROWS` case in `supports_op`. Flagging it because it is a live trap for whoever wires `get_rows` for a TurboQuant type next, and the generic `all_types` GET_ROWS sweep would go green against a wrong implementation.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. Claude wrote the shader and host-side code and ran the validation on my hardware, working from the in-tree CUDA/Metal/C references. I directed the work, chose the approach (clean-room from the in-tree references rather than reusing #140), reviewed the diff, and independently re-verified the centroid and sign tables against `ggml-turbo-quant.c` before submitting. The commits carry `Assisted-by:` trailers. I am responsible for these changes.
