### PR TITLE
fix: remove single-token batching after checkpoint restore

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3702,13 +3702,6 @@ private:
                                 break;
                             }
                         }
-
-                        // a restored checkpoint leaves a short prompt suffix to evaluate; keep it
-                        // in small batches (the CUDA path is not stable when it is evaluated
-                        // concurrently with other active slots)
-                        if (slot.prompt_checkpoint_restored) {
-                            break;
-                        }
                     }
 
                     // the number of tokens added to the batch for the current slot


### PR DESCRIPTION
## Overview

Fix performance regression: remove single-token batching after checkpoint restore.
The `prompt_checkpoint_restored` early break (introduced in e130aef60) forced
single-token batching during prompt processing, triggering excessive checkpoint
creation/erasure and dropping throughput from ~1200 t/s to ~10-26 t/s.
Removes 7 lines from tools/server/server-context.cpp.

## Additional information

Root cause analysis:
- The break caused remaining tokens < n_ubatch on every iteration
- This triggered `near_prompt_end` every batch, bypassing checkpoint_min_step
- Result: hundreds of checkpoint erasures
Verified:
- Pre-fix: 26 t/s prefill, 500+ checkpoint erasures
- Post-fix: ~2500 t/s prefill, ~60+ t/s generation, zero erasures

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI assisted with root cause analysis, debugging, and drafting commit message and PR description. All testing and validation performed manually by contributor. 