### PR TITLE
ggml-cpu : remove the per-call mallocs from the TurboQuant vec_dot kernels

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -3492,6 +3492,88 @@ enum ggml_status ggml_graph_compute_with_ctx(struct ggml_context * ctx, struct g
     return ggml_graph_compute(cgraph, &cplan);
 }
 
+// The TurboQuant vec_dot kernels below have no SIMD path yet, so they dequantize
+// to f32 and dot. They used to stage that through a malloc'd n-element buffer
+// (two of them, for the q8_0 variants) freed on every call. vec_dot runs once
+// per row, per tensor, per token: a large MoE decode step made millions of
+// malloc/free pairs, and an n-element buffer is far too big to stay resident in
+// cache. Staging a fixed-size chunk instead removes the allocation entirely and
+// keeps both operands in L1.
+//
+// Every TurboQuant row dequant is a pure per-block loop with no cross-block
+// state (ggml-turbo-quant.c), so splitting on block boundaries yields identical
+// bytes. The accumulator is carried across chunks, so the summation order is
+// unchanged too and results are bit-identical to the previous implementation.
+#define GGML_TQ_DOT_CHUNK 256
+
+// vy is plain f32 — used by CPU flash attention against a TurboQuant KV cache
+// for head dims the GPU backends do not support (e.g. D=192).
+static void ggml_vec_dot_turbo_f32_impl(enum ggml_type type_x, int n, float * GGML_RESTRICT s,
+                                        const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy) {
+    const struct ggml_type_traits * trx = ggml_get_type_traits(type_x);
+
+    const int64_t blk = trx->blck_size;
+    GGML_ASSERT(n % blk == 0);
+    GGML_ASSERT(blk <= GGML_TQ_DOT_CHUNK);
+
+    const int64_t chunk = (GGML_TQ_DOT_CHUNK / blk) * blk;
+
+    const char  * px = (const char  *) vx;
+    const float * y  = (const float *) vy;
+
+    float xb[GGML_TQ_DOT_CHUNK];
+    float sum = 0.0f;
+
+    for (int64_t i = 0; i < n; i += chunk) {
+        const int64_t nc = MIN(chunk, n - i);
+        trx->to_float(px, xb, nc);
+        for (int64_t j = 0; j < nc; j++) {
+            sum += xb[j] * y[i + j];
+        }
+        px += (nc / blk) * trx->type_size;
+    }
+
+    *s = sum;
+}
+
+// vy is q8_0 — the weight-matmul path for the TQ*_1S types.
+static void ggml_vec_dot_tq_q8_0_impl(enum ggml_type type_x, int n, float * GGML_RESTRICT s,
+                                      const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy) {
+    const struct ggml_type_traits * trx = ggml_get_type_traits(type_x);
+    const struct ggml_type_traits * trq = ggml_get_type_traits(GGML_TYPE_Q8_0);
+
+    const int64_t blk_x = trx->blck_size;
+    const int64_t blk_y = trq->blck_size;
+
+    // A chunk must be a whole number of blocks on both sides.
+    const int64_t blk = MAX(blk_x, blk_y);
+    GGML_ASSERT(blk % blk_x == 0 && blk % blk_y == 0);
+    GGML_ASSERT(n % blk == 0);
+    GGML_ASSERT(blk <= GGML_TQ_DOT_CHUNK);
+
+    const int64_t chunk = (GGML_TQ_DOT_CHUNK / blk) * blk;
+
+    const char * px = (const char *) vx;
+    const char * py = (const char *) vy;
+
+    float xb[GGML_TQ_DOT_CHUNK];
+    float yb[GGML_TQ_DOT_CHUNK];
+    float sum = 0.0f;
+
+    for (int64_t i = 0; i < n; i += chunk) {
+        const int64_t nc = MIN(chunk, n - i);
+        trx->to_float(px, xb, nc);
+        trq->to_float(py, yb, nc);
+        for (int64_t j = 0; j < nc; j++) {
+            sum += xb[j] * yb[j];
+        }
+        px += (nc / blk_x) * trx->type_size;
+        py += (nc / blk_y) * trq->type_size;
+    }
+
+    *s = sum;
+}
+
 // TurboQuant3 vec_dot: dequantize turbo3 block to f32, then dot with f32 operand.
 // Used by CPU flash attention for models with D not supported by CUDA FA (e.g. D=192).
 static void ggml_vec_dot_turbo3_0_f32(int n, float * GGML_RESTRICT s, size_t bs,
@@ -3500,18 +3582,7 @@ static void ggml_vec_dot_turbo3_0_f32(int n, float * GGML_RESTRICT s, size_t bs,
     GGML_ASSERT(nrc == 1);
     GGML_UNUSED(bs); GGML_UNUSED(bx); GGML_UNUSED(by); GGML_UNUSED(nrc);
 
-    // Dequantize turbo3 to f32 temp buffer, then dot
-    float * tmp = (float *)malloc(n * sizeof(float));
-    GGML_ASSERT(tmp != NULL);
-    ggml_get_type_traits(GGML_TYPE_TURBO3_0)->to_float(vx, tmp, n);
-
-    const float * y = (const float *)vy;
-    float sum = 0.0f;
-    for (int i = 0; i < n; i++) {
-        sum += tmp[i] * y[i];
-    }
-    free(tmp);
-    *s = sum;
+    ggml_vec_dot_turbo_f32_impl(GGML_TYPE_TURBO3_0, n, s, vx, vy);
 }
 
 // TurboQuant2 vec_dot: dequantize turbo2 block to f32, then dot with f32 operand.
@@ -3521,17 +3592,7 @@ static void ggml_vec_dot_turbo2_0_f32(int n, float * GGML_RESTRICT s, size_t bs,
     GGML_ASSERT(nrc == 1);
     GGML_UNUSED(bs); GGML_UNUSED(bx); GGML_UNUSED(by); GGML_UNUSED(nrc);
 
-    float * tmp = (float *)malloc(n * sizeof(float));
-    GGML_ASSERT(tmp != NULL);
-    ggml_get_type_traits(GGML_TYPE_TURBO2_0)->to_float(vx, tmp, n);
-
-    const float * y = (const float *)vy;
-    float sum = 0.0f;
-    for (int i = 0; i < n; i++) {
-        sum += tmp[i] * y[i];
-    }
-    free(tmp);
-    *s = sum;
+    ggml_vec_dot_turbo_f32_impl(GGML_TYPE_TURBO2_0, n, s, vx, vy);
 }
 
 // TurboQuant4 vec_dot: dequantize turbo4 block to f32, then dot with f32 operand.
@@ -3541,17 +3602,7 @@ static void ggml_vec_dot_turbo4_0_f32(int n, float * GGML_RESTRICT s, size_t bs,
     GGML_ASSERT(nrc == 1);
     GGML_UNUSED(bs); GGML_UNUSED(bx); GGML_UNUSED(by); GGML_UNUSED(nrc);
 
-    float * tmp = (float *)malloc(n * sizeof(float));
-    GGML_ASSERT(tmp != NULL);
-    ggml_get_type_traits(GGML_TYPE_TURBO4_0)->to_float(vx, tmp, n);
-
-    const float * y = (const float *)vy;
-    float sum = 0.0f;
-    for (int i = 0; i < n; i++) {
-        sum += tmp[i] * y[i];
-    }
-    free(tmp);
-    *s = sum;
+    ggml_vec_dot_turbo_f32_impl(GGML_TYPE_TURBO4_0, n, s, vx, vy);
 }
 
 // TQ3_1S vec_dot: dequantize tq3_1s block to f32, then dot with q8_0.
@@ -3562,22 +3613,7 @@ static void ggml_vec_dot_tq3_1s_q8_0(int n, float * GGML_RESTRICT s, size_t bs,
     GGML_ASSERT(nrc == 1);
     GGML_UNUSED(bs); GGML_UNUSED(bx); GGML_UNUSED(by); GGML_UNUSED(nrc);
 
-    float * tmp = (float *)malloc(n * sizeof(float));
-    GGML_ASSERT(tmp != NULL);
-    ggml_get_type_traits(GGML_TYPE_TQ3_1S)->to_float(vx, tmp, n);
-
-    // Dequantize q8_0 and dot
-    float * tmp2 = (float *)malloc(n * sizeof(float));
-    GGML_ASSERT(tmp2 != NULL);
-    ggml_get_type_traits(GGML_TYPE_Q8_0)->to_float(vy, tmp2, n);
-
-    float sum = 0.0f;
-    for (int i = 0; i < n; i++) {
-        sum += tmp[i] * tmp2[i];
-    }
-    free(tmp);
-    free(tmp2);
-    *s = sum;
+    ggml_vec_dot_tq_q8_0_impl(GGML_TYPE_TQ3_1S, n, s, vx, vy);
 }
 
 // TQ4_1S vec_dot: dequantize tq4_1s block to f32, then dot with q8_0.
@@ -3588,21 +3624,7 @@ static void ggml_vec_dot_tq4_1s_q8_0(int n, float * GGML_RESTRICT s, size_t bs,
     GGML_ASSERT(nrc == 1);
     GGML_UNUSED(bs); GGML_UNUSED(bx); GGML_UNUSED(by); GGML_UNUSED(nrc);
 
-    float * tmp = (float *)malloc(n * sizeof(float));
-    GGML_ASSERT(tmp != NULL);
-    ggml_get_type_traits(GGML_TYPE_TQ4_1S)->to_float(vx, tmp, n);
-
-    float * tmp2 = (float *)malloc(n * sizeof(float));
-    GGML_ASSERT(tmp2 != NULL);
-    ggml_get_type_traits(GGML_TYPE_Q8_0)->to_float(vy, tmp2, n);
-
-    float sum = 0.0f;
-    for (int i = 0; i < n; i++) {
-        sum += tmp[i] * tmp2[i];
-    }
-    free(tmp);
-    free(tmp2);
-    *s = sum;
+    ggml_vec_dot_tq_q8_0_impl(GGML_TYPE_TQ4_1S, n, s, vx, vy);
 }
 
 void ggml_cpu_fp32_to_fp32(const float * x, float * y, int64_t n) {

--- a/tests/test-turbo-quant.c
+++ b/tests/test-turbo-quant.c
@@ -1,5 +1,8 @@
+#include "ggml.h"
+
 #include <stdio.h>
 #include <math.h>
+#include <stdlib.h>
 #include <string.h>
 
 extern void quantize_row_turbo3_0_ref(const float * x, void * y, long long k);
@@ -7,6 +10,75 @@ extern void dequantize_row_turbo3_0(const void * x, float * y, long long k);
 extern void quantize_row_turbo4_0_ref(const float * x, void * y, long long k);
 extern void dequantize_row_turbo4_0(const void * x, float * y, long long k);
 extern void turbo_cpu_fwht_inverse(float * x, int group_size);
+
+/* Must match GGML_TQ_DOT_CHUNK in ggml/src/ggml-cpu/ggml-cpu.c. */
+#define TQ_DOT_CHUNK 256
+
+/* Block-boundary invariant behind the chunked TurboQuant vec_dot kernels.
+ *
+ * ggml_vec_dot_{turbo,tq}_* stage their dequant through a fixed-size chunk
+ * instead of a malloc'd whole-row buffer. That is only correct because every
+ * TurboQuant row dequant is a pure per-block loop with no cross-block state:
+ * dequantizing [0, k) in one call must be bit-identical to dequantizing it in
+ * block-aligned pieces with the source pointer advanced by
+ * (piece / blck_size) * type_size.
+ *
+ * This asserts exactly that, at row lengths that straddle the chunk size, so a
+ * future row dequant that carries state across blocks -- or a wrong stride in
+ * the vec_dot pointer advance -- fails here rather than silently corrupting a
+ * CPU-offloaded matmul. */
+static int check_chunked_dequant(enum ggml_type type, const char * name, int64_t k) {
+    const struct ggml_type_traits * tr = ggml_get_type_traits(type);
+
+    const int64_t blck = tr->blck_size;
+    if (k % blck != 0) {
+        printf("  %-9s k=%-5lld SKIP (not a whole number of blocks)\n", name, (long long) k);
+        return 0;
+    }
+
+    float * src   = malloc((size_t) k * sizeof(float));
+    void  * q     = malloc(ggml_row_size(type, k));
+    float * whole = malloc((size_t) k * sizeof(float));
+    float * piece = malloc((size_t) k * sizeof(float));
+
+    for (int64_t i = 0; i < k; i++) {
+        src[i] = sinf((float) i * 0.037f) * 3.0f;
+    }
+    ggml_quantize_chunk(type, src, q, 0, 1, k, NULL);
+
+    tr->to_float(q, whole, k);
+
+    const int64_t chunk = (TQ_DOT_CHUNK / blck) * blck;
+    const char * p = (const char *) q;
+    for (int64_t i = 0; i < k; i += chunk) {
+        const int64_t nc = (chunk < k - i) ? chunk : (k - i);
+        tr->to_float(p, piece + i, nc);
+        p += (nc / blck) * tr->type_size;
+    }
+
+    int64_t bad = -1;
+    for (int64_t i = 0; i < k; i++) {
+        if (memcmp(&whole[i], &piece[i], sizeof(float)) != 0) {
+            bad = i;
+            break;
+        }
+    }
+
+    if (bad >= 0) {
+        printf("  %-9s k=%-5lld FAIL at [%lld]: whole=%.9g chunked=%.9g\n",
+               name, (long long) k, (long long) bad,
+               (double) whole[bad], (double) piece[bad]);
+    } else {
+        printf("  %-9s k=%-5lld ok (blck=%lld, chunk=%lld)\n",
+               name, (long long) k, (long long) blck, (long long) chunk);
+    }
+
+    free(src);
+    free(q);
+    free(whole);
+    free(piece);
+    return bad >= 0 ? 1 : 0;
+}
 
 int main(void) {
     const int d = 128;
@@ -61,6 +133,30 @@ int main(void) {
     mse = cosv = ni = no = 0;
     for (int i = 0; i < d; i++) { mse += (input[i]-output[i])*(input[i]-output[i]); cosv += input[i]*output[i]; ni += input[i]*input[i]; no += output[i]*output[i]; }
     printf("  MSE=%.8f Cosine=%.6f\n\n",  (double)(mse/d), (double)(cosv/sqrtf(ni)/sqrtf(no)));
+
+    /* Test 4: chunk-boundary invariant for every type with a chunked vec_dot */
+    printf("Test 4: chunked dequant == whole-row dequant\n");
+    {
+        const enum ggml_type types[] = {
+            GGML_TYPE_TQ3_1S, GGML_TYPE_TQ4_1S,
+            GGML_TYPE_TURBO2_0, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO4_0,
+        };
+        const char * names[] = { "tq3_1s", "tq4_1s", "turbo2_0", "turbo3_0", "turbo4_0" };
+        /* straddle TQ_DOT_CHUNK from both sides, plus a realistic row */
+        const int64_t lens[] = { 128, 256, 384, 512, 4096 };
+
+        int failures = 0;
+        for (size_t t = 0; t < sizeof(types) / sizeof(types[0]); t++) {
+            for (size_t i = 0; i < sizeof(lens) / sizeof(lens[0]); i++) {
+                failures += check_chunked_dequant(types[t], names[t], lens[i]);
+            }
+        }
+        printf("\n");
+        if (failures) {
+            printf("=== FAILED: %d chunk-boundary mismatches ===\n", failures);
+            return 1;
+        }
+    }
 
     printf("=== Done ===\n");
     return 0;


### PR DESCRIPTION
The five TurboQuant vec_dot kernels have no SIMD path yet, so they dequantize to
f32 and dot. Each one staged that through a malloc'd n-element buffer — two of
them, for the q8_0 variants — and freed it again on every call.

vec_dot runs once per row, per tensor, per token. On a large MoE model whose
expert tensors fall back to the CPU backend that is millions of malloc/free
pairs per decode token, and an n-element staging buffer is far too large to stay
resident in cache either way.

This stages a fixed 256-element chunk instead. It is safe because every
TurboQuant row dequant in `ggml-turbo-quant.c` is a pure per-block loop with no
cross-block state, so splitting on block boundaries yields identical bytes; the
accumulator is carried across chunks, so the summation order is unchanged too.

## Correctness

Output is bit-identical, not just close. I diffed the raw f32 bit patterns of
`ggml_mul_mat` on the CPU backend before and after the change, for all five
types at row lengths that straddle the chunk size (32 / 128 / 256 / 288 / 384 /
512 / 4096): **75/75 cases identical**.

`test-turbo-quant` gains a case asserting the invariant the chunking rests on —
whole-row dequant must equal block-aligned piecewise dequant with the source
pointer advanced by `(piece / blck_size) * type_size`, for all five types on
both sides of the chunk boundary.

That assertion is mutation-tested rather than assumed: introducing a one-byte
stride error in the pointer advance turns 15 of the 25 cases red, and the
single-chunk lengths correctly stay green (they never take the advance). So it
fails for the right reason.

## Performance

M-series CPU, `mul_mat` n=4096 m=8192, mean of 20 reps, run-to-run spread under
0.05 ms:

| type     | before   | after    |        |
|----------|----------|----------|--------|
| tq3_1s   | 16.886ms | 15.404ms | -8.8%  |
| tq4_1s   | 17.251ms | 15.869ms | -8.0%  |
| turbo3_0 |  6.982ms |  6.312ms | -9.6%  |

This benefits every backend's CPU fallback on every platform, which for a
TQ-quantized MoE today includes all of the expert matmuls.

## Scope note

The three `turbo{2,3,4}_0_f32` KV kernels had the same pattern and are fixed
here too, not just the two TQ weight ones.

AI usage disclosure: written with Claude Code; I reviewed and validated every
change and ran all the measurements above myself.
