### PR TITLE
vulkan : add mul_mat_vec_id for the TurboQuant weight types

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -5213,6 +5213,17 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
         ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_id_f32[w][GGML_TYPE_MXFP4],   "mul_mat_vec_id_mxfp4_f32",   OCP_DMMV_LEN(arr_dmmv_id_mxfp4_f32_f32, reduc16), OCP_DMMV_DATA(arr_dmmv_id_mxfp4_f32_f32, reduc16), "main", mul_mat_vec_id_num_bindings, sizeof(vk_mat_vec_id_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq}, 1, true, use_subgroups16, force_subgroup_size16);
         ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_id_f32[w][GGML_TYPE_NVFP4],   "mul_mat_vec_id_nvfp4_f32",   OCP_DMMV_LEN(arr_dmmv_id_nvfp4_f32_f32, reduc16), OCP_DMMV_DATA(arr_dmmv_id_nvfp4_f32_f32, reduc16), "main", mul_mat_vec_id_num_bindings, sizeof(vk_mat_vec_id_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq}, 1, true, use_subgroups16, force_subgroup_size16);
 
+        // TurboQuant weight types. Same 32-thread pin and SHMEM reduction as the
+        // non-id pipelines above (tq_wg_size / tq_use_subgroups are declared at
+        // the top of this loop): the id shaders are the same source compiled
+        // with MUL_MAT_ID, so the workgroup constraint is identical. No
+        // arr_dmmv_id_tq*_f32_f32[] array exists -- these are generated
+        // explicitly rather than from type_names -- so the raw _len/_data
+        // symbols are referenced directly, as the non-id pipelines do. The id
+        // pipelines have no num_cols dimension, hence {tq_wg_size, 1}.
+        ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_id_f32[w][GGML_TYPE_TQ3_1S],  "mul_mat_vec_id_tq3_1s_f32",  mul_mat_vec_id_tq3_1s_f32_f32_len, mul_mat_vec_id_tq3_1s_f32_f32_data, "main", mul_mat_vec_id_num_bindings, sizeof(vk_mat_vec_id_push_constants), {1, 1, 1}, {tq_wg_size, 1}, 1, true, tq_use_subgroups, tq_force_subgroup_size);
+        ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_id_f32[w][GGML_TYPE_TQ4_1S],  "mul_mat_vec_id_tq4_1s_f32",  mul_mat_vec_id_tq4_1s_f32_f32_len, mul_mat_vec_id_tq4_1s_f32_f32_data, "main", mul_mat_vec_id_num_bindings, sizeof(vk_mat_vec_id_push_constants), {1, 1, 1}, {tq_wg_size, 1}, 1, true, tq_use_subgroups, tq_force_subgroup_size);
+
 #if defined(GGML_VULKAN_INTEGER_DOT_GLSLC_SUPPORT)
         if (device->integer_dot_product) {
             const uint32_t subgroup_size_int = (device->vendor_id == VK_VENDOR_ID_INTEL && device->subgroup_size_control) ? device->subgroup_min_size : device->subgroup_size;
@@ -7835,6 +7846,10 @@ static vk_pipeline ggml_vk_get_dequantize_mul_mat_vec_id(ggml_backend_vk_context
         case GGML_TYPE_IQ4_NL:
         case GGML_TYPE_MXFP4:
         case GGML_TYPE_NVFP4:
+        // TQ3_1S/TQ4_1S are deliberately absent from the q8_1 switch above:
+        // their id pipelines are f32-B only.
+        case GGML_TYPE_TQ3_1S:
+        case GGML_TYPE_TQ4_1S:
             break;
         default:
             return nullptr;
@@ -7855,6 +7870,13 @@ static vk_pipeline ggml_vk_get_dequantize_mul_mat_vec_id(ggml_backend_vk_context
                 dmmv_wg = DMMV_WG_SIZE_LARGE;
             }
         }
+    }
+
+    // Mirrors the pin in ggml_vk_get_dequantize_mul_mat_vec(): the TurboQuant
+    // mat-vec shaders are only correct at a 32-thread workgroup, so the size
+    // class must not be allowed to select a different pipeline.
+    if (a_type == GGML_TYPE_TQ3_1S || a_type == GGML_TYPE_TQ4_1S) {
+        dmmv_wg = DMMV_WG_SIZE_SUBGROUP;
     }
 
     if (b_type == GGML_TYPE_Q8_1) {
@@ -17813,19 +17835,24 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
             {
                 ggml_type src0_type = op->src[0]->type;
                 if (op->op == GGML_OP_MUL_MAT_ID) {
-                    // TurboQuant weight types have no mul_mat_vec_id pipeline. The
-                    // mul_mat_id_s/m/l check below does not reject them: it is a shared-memory
-                    // heuristic, and ggml_vk_matmul_shmem_support() has no lut_size case for
-                    // TQ3_1S/TQ4_1S, so it computes a trivially-fitting size and leaves those
-                    // flags true on mainstream vendors. Claiming support is only survivable
-                    // while n > 8, where ggml_vk_use_mul_mat_vec_id() routes to mul_mm_id and
-                    // the generic dequant-to-f16 path picks it up. On the decode path
-                    // (src2->ne[1] <= 8) it reaches ggml_vk_get_dequantize_mul_mat_vec_id(),
-                    // whose type switch has no TQ cases, and asserts on a null pipeline. That
-                    // is ordinary MoE decode for a TQ-quantized model, so reject explicitly
-                    // until mul_mat_vec_id_tq{3,4}_1s exists.
+                    // The TurboQuant weight types now have mul_mat_vec_id pipelines, so MoE
+                    // decode runs on the GPU. Prompt processing does not: there is still no TQ
+                    // mul_mm_id, so ggml_vk_get_mul_mat_mat_id_pipeline() returns nullptr,
+                    // qx_needs_dequant goes true, and the generic path stages the ENTIRE expert
+                    // tensor as f16 (x_ne = ggml_nelements(src0), all experts). Reject when that
+                    // staging buffer would not fit, or ggml_vk_mul_mat_id_q_f16() reaches
+                    // GGML_ABORT("Requested preallocation size is too large").
+                    //
+                    // The gate is deliberately independent of src2->ne[1]. An n-dependent gate is
+                    // worse than no support at all: weight_buft_supported() probes with a fixed
+                    // ids->ne[1] = 512, so a gate that answers differently at load and at decode
+                    // parks the experts in one backend's buffer and then runs the op in the
+                    // other, copying every expert tensor across the bus on every token.
                     if (src0_type == GGML_TYPE_TQ3_1S || src0_type == GGML_TYPE_TQ4_1S) {
-                        return false;
+                        const uint64_t x_sz_f16 = sizeof(ggml_fp16_t) * ggml_nelements(op->src[0]);
+                        if (x_sz_f16 > device->properties.limits.maxStorageBufferRange) {
+                            return false;
+                        }
                     }
                     if (!device->mul_mat_id_s[src0_type] && !device->mul_mat_id_m[src0_type] && !device->mul_mat_id_l[src0_type]) {
                         // If there's not enough shared memory for row_ids and the result tile, fallback to CPU

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -875,7 +875,9 @@ void process_shaders() {
     //      not exactly the workgroup is wrong, and RADV on gfx1151 (Strix Halo,
     //      Radeon 8060S) reports "warp size: 64". The host side pins these
     //      pipelines to a 32-thread workgroup with SHMEM reduction to match.
-    //   2. mul_mat_vec_id_tq4_1s_*, for which no host pipeline is created.
+    //   2. mul_mat_vec_id_tq4_1s_f16_f32. The MUL_MAT_ID host path asserts the
+    //      B operand is f32 or q8_1 (ggml_vk_get_dequantize_mul_mat_vec_id), so
+    //      only the f32 id variant is generated below.
     //   3. get_rows_tq4_1s via get_rows_quant.comp, which applies no inverse
     //      WHT and whose get_dm() returns vec2(1,0); it would hand back
     //      un-rotated centroid*scale values. GET_ROWS support is deliberately
@@ -884,6 +886,13 @@ void process_shaders() {
         merge_maps(base_dict, {{"DATA_A_TQ4_1S", "1"}, {"B_TYPE", "float"}, {"B_TYPEV2", "vec2"}, {"B_TYPEV4", "vec4"}, {"D_TYPE", "float"}}));
     string_to_spv("mul_mat_vec_tq4_1s_f16_f32", "mul_mat_vec_tq4_1s.comp",
         merge_maps(base_dict, {{"DATA_A_TQ4_1S", "1"}, {"B_TYPE", "float16_t"}, {"B_TYPEV2", "f16vec2"}, {"B_TYPEV4", "f16vec4"}, {"D_TYPE", "float"}}));
+    // MoE decode. The same source compiled with MUL_MAT_ID: all of the expert
+    // indirection lives in mul_mat_vec_base.glsl (get_offsets(), reduce_result()),
+    // which this shader already includes, and the expert id arrives via
+    // gl_WorkGroupID.y, which it never touches. The 32-thread pin and the
+    // shared-memory butterfly are therefore unaffected.
+    string_to_spv("mul_mat_vec_id_tq4_1s_f32_f32", "mul_mat_vec_tq4_1s.comp",
+        merge_maps(base_dict, {{"MUL_MAT_ID", "1"}, {"DATA_A_TQ4_1S", "1"}, {"B_TYPE", "float"}, {"B_TYPEV2", "vec2"}, {"B_TYPEV4", "vec4"}, {"D_TYPE", "float"}}));
     // Cold path: dequantize the whole tensor to f16 and run the generic matmul.
     // Used when n > mul_mat_vec_max_cols (prompt processing).
     string_to_spv("dequant_tq4_1s", "dequant_tq4_1s.comp",
@@ -904,6 +913,8 @@ void process_shaders() {
         merge_maps(base_dict, {{"DATA_A_TQ3_1S", "1"}, {"B_TYPE", "float"}, {"B_TYPEV2", "vec2"}, {"B_TYPEV4", "vec4"}, {"D_TYPE", "float"}}));
     string_to_spv("mul_mat_vec_tq3_1s_f16_f32", "mul_mat_vec_tq3_1s.comp",
         merge_maps(base_dict, {{"DATA_A_TQ3_1S", "1"}, {"B_TYPE", "float16_t"}, {"B_TYPEV2", "f16vec2"}, {"B_TYPEV4", "f16vec4"}, {"D_TYPE", "float"}}));
+    string_to_spv("mul_mat_vec_id_tq3_1s_f32_f32", "mul_mat_vec_tq3_1s.comp",
+        merge_maps(base_dict, {{"MUL_MAT_ID", "1"}, {"DATA_A_TQ3_1S", "1"}, {"B_TYPE", "float"}, {"B_TYPEV2", "vec2"}, {"B_TYPEV4", "vec4"}, {"D_TYPE", "float"}}));
     string_to_spv("dequant_tq3_1s", "dequant_tq3_1s.comp",
         merge_maps(base_dict, {{"DATA_A_TQ3_1S", "1"}, {"D_TYPE", "float16_t"}}));
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9418,6 +9418,22 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 4, 2, false, 64, 1, 3*ggml_blck_size(type_a)));
     }
 
+    // TurboQuant MUL_MAT_ID. TQ3_1S/TQ4_1S are in all_types but not base_types, so the
+    // two cases above are their only MUL_MAT_ID coverage and the rich sweep below never
+    // reaches them. Cover both sides of the n <= 8 threshold that
+    // ggml_vk_use_mul_mat_vec_id() splits on (mul_mat_vec_id vs mul_mm_id), several
+    // n_used counts, and broadcast -- which exercises the expert-index wrap that a
+    // single non-broadcast case never touches.
+    for (ggml_type type_a : {GGML_TYPE_TQ3_1S, GGML_TYPE_TQ4_1S}) {
+        for (int n_used : {1, 2, 4}) {
+            for (bool b : {false, true}) {
+                for (int n : {1, 4, 8, 9, 17, 32}) {
+                    test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 4, n_used, b, 512, n, 256));
+                }
+            }
+        }
+    }
+
     for (ggml_type type_a : base_types) {
         for (ggml_type type_b : {GGML_TYPE_F32 /*, GGML_TYPE_F16 */}) {
             for (int n_mats : {4, 8}) {


### PR DESCRIPTION
MoE decode for a TQ3_1S/TQ4_1S model ran entirely on the CPU. #259 rejected MUL_MAT_ID for both types because no `mul_mat_vec_id` pipeline existed, and reaching `ggml_vk_get_dequantize_mul_mat_vec_id()` with a TQ src0 asserted on a null pipeline.

No new shader source is needed. All of the expert indirection already lives in `mul_mm_vec_base.glsl` (`get_offsets()`, `reduce_result()`), which both TQ mat-vec shaders include, and the expert id arrives via `gl_WorkGroupID.y`, which neither shader touches. Compiling the existing sources with `MUL_MAT_ID` adds exactly one binding — the ids buffer, 5 → 6, matching `mul_mat_vec_id_num_bindings` — and introduces no subgroup capability, so the 32-thread workgroup pin and shared-memory butterfly that make these kernels wave64-safe are unaffected. `spirv-val` passes on both.

## The reject became a size gate rather than being removed

There is still no TQ `mul_mm_id`, so prompt processing takes the generic path: `ggml_vk_get_mul_mat_mat_id_pipeline()` returns nullptr, `qx_needs_dequant` goes true, and the **entire** expert tensor is staged as f16 (`x_ne = ggml_nelements(src0)`, across all experts). This rejects the cases where that staging buffer would not fit, otherwise `ggml_vk_mul_mat_id_q_f16()` reaches `GGML_ABORT("Requested preallocation size is too large")`.

The gate is deliberately independent of `src2->ne[1]`. An n-dependent gate is worse than no support: `weight_buft_supported()` (`llama-model-loader.cpp`) probes with a fixed `ids->ne[1] = 512`, so a gate that answers differently at load and at decode parks the experts in one backend's buffer and then runs the op in the other, copying every expert tensor across the bus on every token.

Worked example of what it excludes: DeepSeek-V4-Flash Config-I has `ffn_{gate,up,down}_exps` of 2048 × 4096 × 256 = 2,147,483,648 elements, so the f16 staging buffer is exactly 4,294,967,296 bytes — one byte over RADV's `UINT32_MAX` `maxStorageBufferRange`. Its experts stay on the CPU, as before this change. Lifting that needs a real TQ `mul_mm_id` that reads the quantized data through `dequant_funcs.glsl` and never allocates the f16 buffer. I have that in progress.

## Validation on gfx1151 (Radeon 8060S, RADV, wave64)

`test-backend-ops -o MUL_MAT_ID`:

| | tq3_1s | tq4_1s | suite |
|---|---|---|---|
| before | 2 cases, both NOT_SUPPORTED | same | 891/891 |
| after | **38 OK, 0 FAIL, 0 skipped** | **38 OK, 0 FAIL, 0 skipped** | 967/967 |

891 + 4 newly-supported + 72 new sweep cases = 967, which reconciles exactly. That arithmetic matters here because of #242 — a fully skipped op still reports OK, so I counted executed cases rather than trusting the summary line.

Full sweep on an idle GPU: 24572/24572, 2/2 backends. An earlier run showed one failure, which turned out to be pre-existing: the same sweep on an image without any of this fails identically, on a `TOPK_MOE` case unrelated to TurboQuant. Filed separately as #261.

Real-model A/B on `thetom-ai/Qwen3.6-35B-A3B-ConfigI` (431 TQ3_1S tensors, 256 experts, sha256-verified), since synthetic kernel tests are exactly what let the CUDA fused-TQ3_1S bug survive:

| | chunk[1] | chunk[2] | final PPL |
|---|---|---|---|
| experts on CPU (control) | 4.5161 | 6.5144 | 6.5144 ± 0.76005 |
| experts on GPU (this PR) | 4.5241 | 6.5037 | **6.5037 ± 0.75956** |

0.16% apart, far inside the error band.

`llama-bench -ngl 99 -p 512 -n 128 -r 2`:

| | pp512 | tg128 |
|---|---|---|
| control | 7.86 ± 0.00 | 4.30 ± 0.01 |
| this PR | **397.31 ± 3.12** | **20.89 ± 0.02** |

To be precise about what those numbers mean: both arms report `backend: Vulkan` and the control is already on the GPU. What moved is the MoE expert matmuls, which the blanket reject forced onto the CPU per-op. The gain is not decode-only either — replacing the reject with the size gate enables both prefill (via `mul_mm_id` + f16 dequant) and decode (via `mul_mat_vec_id`).

## Tests

`test-backend-ops` gains a TurboQuant MUL_MAT_ID sweep. TQ3_1S/TQ4_1S are in `all_types` but not `base_types`, so their only prior coverage was two cases. This covers both sides of the `n <= 8` threshold that `ggml_vk_use_mul_mat_vec_id()` splits on, three `n_used` counts, and broadcast, which exercises the expert-index wrap.

AI usage disclosure: written with Claude Code; I reviewed every change and ran all the measurements above on my own hardware.
