### PR TITLE
vulkan : add rotated mul_mm_id for the TurboQuant weight types

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -7812,6 +7812,12 @@ static vk_matmul_pipeline ggml_vk_get_mul_mat_mat_id_pipeline(ggml_backend_vk_co
         case GGML_TYPE_IQ4_NL:
         case GGML_TYPE_MXFP4:
         case GGML_TYPE_NVFP4:
+        // TurboQuant, ROTATED. Selecting these commits the caller to staging and
+        // rotating the activation (tq_rotate in ggml_vk_mul_mat_id_q_f16); the A
+        // side is centroid*scale with no inverse WHT and is wrong against a raw
+        // activation.
+        case GGML_TYPE_TQ3_1S:
+        case GGML_TYPE_TQ4_1S:
             break;
         default:
             return nullptr;
@@ -7822,6 +7828,16 @@ static vk_matmul_pipeline ggml_vk_get_mul_mat_mat_id_pipeline(ggml_backend_vk_co
     bool prefer_fp16acc = ctx->device->fp16 /*&& prec == GGML_PREC_DEFAULT*/;
     bool support_fp16acc = !mmp.f16acc->is_empty();
     bool support_fp32acc = !mmp.f32acc->is_empty();
+
+    // The TQ pipelines are deliberately not created on the coopmat2 path (no
+    // dequant_funcs_cm2.glsl entry). This function ends in
+    // GGML_ASSERT(support_fp32acc), so without this guard a coopmat2 device would
+    // ABORT here rather than fall back. Returning nullptr lets the caller take the
+    // f16 dequant path, which needs no rotation.
+    if ((src0_type == GGML_TYPE_TQ3_1S || src0_type == GGML_TYPE_TQ4_1S) &&
+        !support_fp16acc && !support_fp32acc) {
+        return nullptr;
+    }
 
     if (support_fp16acc && (prefer_fp16acc || !support_fp32acc)) {
         return mmp.f16acc;
@@ -10065,18 +10081,35 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
         quantize_y = false;
     }
 
+    // TurboQuant rotated matmul. The A side is loaded as centroid*scale with no
+    // inverse WHT, which is correct only against a pre-rotated activation, so
+    // the activation is staged into ctx->prealloc_y and rotated there.
+    //
+    // Staging is FORCED even when src1 is already contiguous f32. Otherwise
+    // y_f32_kernel is true, qy_needs_dequant is false, d_Y aliases the real
+    // src1 buffer, and the rotate would mutate the graph's own activation --
+    // the hazard Metal's in-place rotate/un-rotate pair has to work around.
+    //
+    // Gated on mmp != nullptr && !x_non_contig, i.e. only when the TQ matmul
+    // pipeline was actually selected. If we fell back to the f16 dequant path
+    // the weights are true weights and must NOT see a rotated activation.
+    const bool tq_rotate = !quantize_y && mmp != nullptr && !x_non_contig &&
+                           (src0->type == GGML_TYPE_TQ3_1S || src0->type == GGML_TYPE_TQ4_1S);
+
     const bool qx_needs_dequant = mmp == nullptr || x_non_contig;
-    const bool qy_needs_dequant = !quantize_y && ((src1->type != f16_type && !y_f32_kernel) || y_non_contig);
+    const bool qy_needs_dequant = !quantize_y && (tq_rotate || (src1->type != f16_type && !y_f32_kernel) || y_non_contig);
 
     if (qx_needs_dequant) {
         // Fall back to dequant + f16 mulmat
         mmp = ggml_vk_get_mul_mat_mat_id_pipeline(ctx, f16_type, y_f32_kernel ? GGML_TYPE_F32 : f16_type, (ggml_prec)dst->op_params[0]);
     }
 
-    // Not implemented
-    GGML_ASSERT(y_non_contig || !qy_needs_dequant);  // NOLINT
+    // Not implemented. tq_rotate is the deliberate exception: it forces staging
+    // for a contiguous src1 so the rotate never touches the graph's own tensor.
+    GGML_ASSERT(y_non_contig || tq_rotate || !qy_needs_dequant);  // NOLINT
 
-    const ggml_type effective_src1_type = quantize_y ? GGML_TYPE_Q8_1 : (y_f32_kernel ? GGML_TYPE_F32 : src1->type);
+    // tq_rotate stages and rotates in f32, so the matmul must read f32.
+    const ggml_type effective_src1_type = quantize_y ? GGML_TYPE_Q8_1 : ((y_f32_kernel || tq_rotate) ? GGML_TYPE_F32 : src1->type);
 
     const uint32_t kpad = quantize_y ? 0 : ggml_vk_align_size(ne10, ggml_vk_guess_matmul_id_pipeline_align(ctx, mmp, ne01, nei1, qx_needs_dequant ? f16_type : src0->type, effective_src1_type));
     const bool aligned = !quantize_y && ne10 == kpad && ne01 > 8 && nei1 > 8;
@@ -10095,7 +10128,7 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
     const uint64_t qx_sz = ggml_type_size(src0->type) * x_ne / ggml_blck_size(src0->type);
     const uint64_t qy_sz = ggml_type_size(src1->type) * ggml_nelements(src1) / ggml_blck_size(src1->type);
     const uint64_t x_sz = !qx_needs_dequant ? qx_sz : sizeof(ggml_fp16_t) * x_ne;
-    const uint64_t y_sz = quantize_y ? (ggml_vk_align_size(y_ne, 128) * ggml_type_size(GGML_TYPE_Q8_1) / ggml_blck_size(GGML_TYPE_Q8_1)) : (y_f32_kernel ? sizeof(float) * y_ne : sizeof(ggml_fp16_t) * y_ne);
+    const uint64_t y_sz = quantize_y ? (ggml_vk_align_size(y_ne, 128) * ggml_type_size(GGML_TYPE_Q8_1) / ggml_blck_size(GGML_TYPE_Q8_1)) : ((y_f32_kernel || tq_rotate) ? sizeof(float) * y_ne : sizeof(ggml_fp16_t) * y_ne);
     const uint64_t ids_sz = nbi2;
     const uint64_t d_sz = sizeof(float) * d_ne;
 
@@ -10118,7 +10151,12 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
     } else {
         to_fp16_vk_0 = ggml_vk_get_to_fp16(ctx, src0->type);
     }
-    if (y_non_contig) {
+    if (tq_rotate) {
+        // Plain contiguous f32 copy into prealloc_y; tq_rotate_act then rotates
+        // that copy in place. f32 throughout: the butterfly is 5 rounds of adds
+        // and doing it in f16 would lose precision the quantization did not.
+        to_fp16_vk_1 = ggml_vk_get_cpy_pipeline(ctx, src1, nullptr, GGML_TYPE_F32);
+    } else if (y_non_contig) {
         ggml_tensor y_staged_dst;
         const ggml_tensor * y_staged_dst_ptr = nullptr;
         if (y_decode_vector_staging) {
@@ -10166,6 +10204,9 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
         }
         if (qy_needs_dequant) {
             ggml_pipeline_request_descriptor_sets(ctx, to_fp16_vk_1, 1);
+        }
+        if (tq_rotate) {
+            ggml_pipeline_request_descriptor_sets(ctx, ctx->device->pipeline_tq_rotate_act, 1);
         }
         if (quantize_y) {
             ggml_pipeline_request_descriptor_sets(ctx, to_q8_1, 1);
@@ -10242,7 +10283,31 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
         ggml_vk_dispatch_pipeline(ctx, subctx, to_fp16_vk_0,
             { vk_subbuffer{ d_Qx, qx_buf_offset, qx_sz }, vk_subbuffer{ d_X, 0, x_sz } }, pc, { (uint32_t)x_ne, 1, 1});
     }
-    if (y_non_contig) {
+    if (tq_rotate) {
+        // Cache identity is the ROTATE pipeline, not the cpy pipeline. prealloc_y
+        // now holds ROTATED data, so a later non-rotated consumer of the same src1
+        // must not reuse it -- keying on the rotate pipeline makes its pointer
+        // differ and forces a re-stage.
+        if (ctx->prealloc_y_last_pipeline_used != ctx->device->pipeline_tq_rotate_act.get() ||
+            ctx->prealloc_y_last_tensor_used != src1) {
+            if (ctx->prealloc_y_need_sync) {
+                ggml_vk_sync_buffers(ctx, subctx);
+            }
+            ggml_vk_cpy_to_contiguous(ctx, subctx, to_fp16_vk_1, src1, ggml_vk_subbuffer(ctx, d_Qy, qy_buf_offset), ggml_vk_subbuffer(ctx, d_Y, 0));
+            // The rotate reads what the copy just wrote.
+            ggml_vk_sync_buffers(ctx, subctx);
+            // Rotate only the rows the copy produced; the padded_n rows beyond
+            // ne11 are untouched, exactly as in the f16 staging path.
+            const uint32_t tq_rows = (uint32_t)(ne11 * ne12 * ne13);
+            const std::array<uint32_t, 3> tq_pc = { (uint32_t)ne10, tq_rows, (uint32_t)ne10 };
+            ggml_vk_dispatch_pipeline(ctx, subctx, ctx->device->pipeline_tq_rotate_act,
+                { ggml_vk_subbuffer(ctx, d_Y, 0) }, tq_pc,
+                { tq_rows * (uint32_t)ne10, 1, 1 });
+            ctx->prealloc_y_last_pipeline_used = ctx->device->pipeline_tq_rotate_act.get();
+            ctx->prealloc_y_last_tensor_used = src1;
+            ctx->prealloc_y_last_decode_vector_staging = false;
+        }
+    } else if (y_non_contig) {
         if (ctx->prealloc_y_last_pipeline_used != to_fp16_vk_1.get() ||
             ctx->prealloc_y_last_tensor_used != src1 ||
             ctx->prealloc_y_last_decode_vector_staging != y_decode_vector_staging) {

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -5293,8 +5293,9 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
     // mat-vec pipelines: the butterfly pairs lanes through a 32-entry shared
     // array, so it is only correct when the workgroup is exactly the block size
     // (RADV on gfx1151 reports warp size 64, so this must not be widened).
-    // Push constants: k, nrows, src_stride, dst_stride.
-    ggml_vk_create_pipeline(device, device->pipeline_tq_rotate_act, "tq_rotate_act", tq_rotate_act_len, tq_rotate_act_data, "main", 2, 4 * sizeof(uint32_t), {32, 1, 1}, {}, 1);
+    // Single read-write binding: rotates ctx->prealloc_y in place, never src1.
+    // Push constants: k, nrows, stride.
+    ggml_vk_create_pipeline(device, device->pipeline_tq_rotate_act, "tq_rotate_act", tq_rotate_act_len, tq_rotate_act_data, "main", 1, 3 * sizeof(uint32_t), {32, 1, 1}, {}, 1);
 
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_TQ3_1S],  "dequant_tq3_1s",  dequant_tq3_1s_len,  dequant_tq3_1s_data,  "main", 2, 5 * sizeof(uint32_t), {256 * 32, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_TQ4_1S],  "dequant_tq4_1s",  dequant_tq4_1s_len,  dequant_tq4_1s_data,  "main", 2, 5 * sizeof(uint32_t), {256 * 32, 1, 1}, {}, 1);

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -884,6 +884,11 @@ struct vk_device_struct {
     vk_pipeline pipeline_dequant_mul_mat_vec_q8_1_f32[DMMV_WG_SIZE_COUNT][GGML_TYPE_COUNT][mul_mat_vec_max_cols];
     vk_pipeline pipeline_dequant_mul_mat_vec_id_q8_1_f32[DMMV_WG_SIZE_COUNT][GGML_TYPE_COUNT];
 
+    // Activation pre-rotation for the TurboQuant rotated matmul path. One
+    // pipeline serves TQ3_1S and TQ4_1S: they share the 32-element sign pattern
+    // and butterfly, and the shader only touches the activation.
+    vk_pipeline pipeline_tq_rotate_act;
+
     vk_pipeline pipeline_mul_mat_vec_p021_f16_f32[p021_max_gqa_ratio];
     vk_pipeline pipeline_mul_mat_vec_nc_f16_f32;
     vk_pipeline pipeline_get_rows[GGML_TYPE_COUNT];
@@ -5284,6 +5289,13 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_IQ4_NL],  "dequant_iq4_nl",  dequant_iq4_nl_len,  dequant_iq4_nl_data,  "main", 2, 5 * sizeof(uint32_t), {256 * 16, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_MXFP4],   "dequant_mxfp4",   dequant_mxfp4_len,   dequant_mxfp4_data,   "main", 2, 5 * sizeof(uint32_t), {256 * 16, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_NVFP4],   "dequant_nvfp4",   dequant_nvfp4_len,   dequant_nvfp4_data,   "main", 2, 5 * sizeof(uint32_t), {256 * 16, 1, 1}, {}, 1);
+    // 32 threads, one 32-element group per workgroup. Fixed at 32 like the TQ
+    // mat-vec pipelines: the butterfly pairs lanes through a 32-entry shared
+    // array, so it is only correct when the workgroup is exactly the block size
+    // (RADV on gfx1151 reports warp size 64, so this must not be widened).
+    // Push constants: k, nrows, src_stride, dst_stride.
+    ggml_vk_create_pipeline(device, device->pipeline_tq_rotate_act, "tq_rotate_act", tq_rotate_act_len, tq_rotate_act_data, "main", 2, 4 * sizeof(uint32_t), {32, 1, 1}, {}, 1);
+
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_TQ3_1S],  "dequant_tq3_1s",  dequant_tq3_1s_len,  dequant_tq3_1s_data,  "main", 2, 5 * sizeof(uint32_t), {256 * 32, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_TQ4_1S],  "dequant_tq4_1s",  dequant_tq4_1s_len,  dequant_tq4_1s_data,  "main", 2, 5 * sizeof(uint32_t), {256 * 32, 1, 1}, {}, 1);
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -17952,9 +17952,19 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                     // parks the experts in one backend's buffer and then runs the op in the
                     // other, copying every expert tensor across the bus on every token.
                     if (src0_type == GGML_TYPE_TQ3_1S || src0_type == GGML_TYPE_TQ4_1S) {
-                        const uint64_t x_sz_f16 = sizeof(ggml_fp16_t) * ggml_nelements(op->src[0]);
-                        if (x_sz_f16 > device->properties.limits.maxStorageBufferRange) {
-                            return false;
+                        // Only reachable when we would fall back to the f16 dequant path.
+                        // The rotated mul_mm_id path reads the quantized weights directly
+                        // and never materialises the expert tensor as f16, so the limit
+                        // does not apply to it. It needs the pipelines to exist on this
+                        // device (they are not created for coopmat2) and a dim01-contiguous
+                        // src0, which is what ggml_vk_mul_mat_id_q_f16() gates tq_rotate on.
+                        const auto & tq_mmp = device->pipeline_dequant_mul_mat_mat_id[src0_type];
+                        const bool have_rotated = !tq_mmp.f16acc->is_empty() || !tq_mmp.f32acc->is_empty();
+                        if (!have_rotated || !ggml_vk_dim01_contiguous(op->src[0])) {
+                            const uint64_t x_sz_f16 = sizeof(ggml_fp16_t) * ggml_nelements(op->src[0]);
+                            if (x_sz_f16 > device->properties.limits.maxStorageBufferRange) {
+                                return false;
+                            }
                         }
                     }
                     if (!device->mul_mat_id_s[src0_type] && !device->mul_mat_id_m[src0_type] && !device->mul_mat_id_l[src0_type]) {

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4668,6 +4668,11 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
         CREATE_MM2(GGML_TYPE_IQ3_S,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ3_S],   matmul_id_subgroup_iq3_s_f32,   mmq_wg_denoms, warptile_mmq, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id);
         CREATE_MM2(GGML_TYPE_IQ4_XS,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ4_XS],  matmul_id_subgroup_iq4_xs_f32,  mmq_wg_denoms, warptile_mmq, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id);
         CREATE_MM2(GGML_TYPE_IQ4_NL,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ4_NL],  matmul_id_subgroup_iq4_nl_f32,  mmq_wg_denoms, warptile_mmq, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id);
+        // TurboQuant, ROTATED matmul. Correct ONLY against an activation pre-rotated by
+        // pipeline_tq_rotate_act; the A-side loads produce centroid*scale with no inverse
+        // WHT. coopmat2 is excluded above on purpose.
+        CREATE_MM2(GGML_TYPE_TQ3_1S,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_TQ3_1S],  matmul_id_subgroup_tq3_1s_f32,  mmq_wg_denoms, warptile_mmq, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id);
+        CREATE_MM2(GGML_TYPE_TQ4_1S,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_TQ4_1S],  matmul_id_subgroup_tq4_1s_f32,  mmq_wg_denoms, warptile_mmq, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id);
 #if defined(GGML_VULKAN_FLOAT_E2M1_GLSLC_SUPPORT) && defined(GGML_VULKAN_FLOAT_E4M3_GLSLC_SUPPORT)
         if (device->ocp_fp4) {
             CREATE_MM2(GGML_TYPE_MXFP4,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_MXFP4],   matmul_id_subgroup_mxfp4_f32_ocp,   mmq_wg_denoms, warptile_mmq, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id);
@@ -4806,6 +4811,11 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
             CREATE_MM2(GGML_TYPE_IQ3_S,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ3_S],   matmul_id_subgroup_iq3_s_f32,   mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, mul_mat_subgroup_size);
             CREATE_MM2(GGML_TYPE_IQ4_XS,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ4_XS],  matmul_id_subgroup_iq4_xs_f32,  mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, mul_mat_subgroup_size);
             CREATE_MM2(GGML_TYPE_IQ4_NL,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ4_NL],  matmul_id_subgroup_iq4_nl_f32,  mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, mul_mat_subgroup_size);
+            // TurboQuant, ROTATED matmul. Correct ONLY against an activation pre-rotated by
+            // pipeline_tq_rotate_act; the A-side loads produce centroid*scale with no inverse
+            // WHT. coopmat2 is excluded above on purpose.
+            CREATE_MM2(GGML_TYPE_TQ3_1S,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_TQ3_1S],  matmul_id_subgroup_tq3_1s_f32,  mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, mul_mat_subgroup_size);
+            CREATE_MM2(GGML_TYPE_TQ4_1S,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_TQ4_1S],  matmul_id_subgroup_tq4_1s_f32,  mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, mul_mat_subgroup_size);
             CREATE_MM2(GGML_TYPE_MXFP4,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_MXFP4],   matmul_id_subgroup_mxfp4_f32,   mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, mul_mat_subgroup_size);
             CREATE_MM2(GGML_TYPE_NVFP4,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_NVFP4],   matmul_id_subgroup_nvfp4_f32,   mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, mul_mat_subgroup_size);
 
@@ -4853,6 +4863,11 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
             CREATE_MM2(GGML_TYPE_IQ3_S,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ3_S],   matmul_id_iq3_s_f32,   mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, 0);
             CREATE_MM2(GGML_TYPE_IQ4_XS,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ4_XS],  matmul_id_iq4_xs_f32,  mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, 0);
             CREATE_MM2(GGML_TYPE_IQ4_NL,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ4_NL],  matmul_id_iq4_nl_f32,  mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, 0);
+            // TurboQuant, ROTATED matmul. Correct ONLY against an activation pre-rotated by
+            // pipeline_tq_rotate_act; the A-side loads produce centroid*scale with no inverse
+            // WHT. coopmat2 is excluded above on purpose.
+            CREATE_MM2(GGML_TYPE_TQ3_1S,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_TQ3_1S],  matmul_id_tq3_1s_f32,  mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, 0);
+            CREATE_MM2(GGML_TYPE_TQ4_1S,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_TQ4_1S],  matmul_id_tq4_1s_f32,  mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, 0);
             CREATE_MM2(GGML_TYPE_MXFP4,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_MXFP4],   matmul_id_mxfp4_f32,   mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, 0);
             CREATE_MM2(GGML_TYPE_NVFP4,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_NVFP4],   matmul_id_nvfp4_f32,   mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, 0);
 
@@ -4979,6 +4994,11 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
             CREATE_MM(GGML_TYPE_IQ3_S,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ3_S].f32acc,   matmul_id_subgroup_iq3_s_f32,   , mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, mul_mat_subgroup_size);
             CREATE_MM(GGML_TYPE_IQ4_XS,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ4_XS].f32acc,  matmul_id_subgroup_iq4_xs_f32,  , mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, mul_mat_subgroup_size);
             CREATE_MM(GGML_TYPE_IQ4_NL,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ4_NL].f32acc,  matmul_id_subgroup_iq4_nl_f32,  , mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, mul_mat_subgroup_size);
+            // TurboQuant, ROTATED matmul. Correct ONLY against an activation pre-rotated by
+            // pipeline_tq_rotate_act; the A-side loads produce centroid*scale with no inverse
+            // WHT. coopmat2 is excluded above on purpose.
+            CREATE_MM(GGML_TYPE_TQ3_1S,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_TQ3_1S].f32acc,  matmul_id_subgroup_tq3_1s_f32,  , mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, mul_mat_subgroup_size);
+            CREATE_MM(GGML_TYPE_TQ4_1S,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_TQ4_1S].f32acc,  matmul_id_subgroup_tq4_1s_f32,  , mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, mul_mat_subgroup_size);
             CREATE_MM(GGML_TYPE_MXFP4,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_MXFP4].f32acc,   matmul_id_subgroup_mxfp4_f32,   , mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, mul_mat_subgroup_size);
             CREATE_MM(GGML_TYPE_NVFP4,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_NVFP4].f32acc,   matmul_id_subgroup_nvfp4_f32,   , mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, mul_mat_subgroup_size);
         } else {
@@ -5008,6 +5028,11 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
             CREATE_MM(GGML_TYPE_IQ3_S,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ3_S].f32acc,   matmul_id_iq3_s_f32,   , mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, 0);
             CREATE_MM(GGML_TYPE_IQ4_XS,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ4_XS].f32acc,  matmul_id_iq4_xs_f32,  , mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, 0);
             CREATE_MM(GGML_TYPE_IQ4_NL,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ4_NL].f32acc,  matmul_id_iq4_nl_f32,  , mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, 0);
+            // TurboQuant, ROTATED matmul. Correct ONLY against an activation pre-rotated by
+            // pipeline_tq_rotate_act; the A-side loads produce centroid*scale with no inverse
+            // WHT. coopmat2 is excluded above on purpose.
+            CREATE_MM(GGML_TYPE_TQ3_1S,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_TQ3_1S].f32acc,  matmul_id_tq3_1s_f32,  , mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, 0);
+            CREATE_MM(GGML_TYPE_TQ4_1S,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_TQ4_1S].f32acc,  matmul_id_tq4_1s_f32,  , mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, 0);
             CREATE_MM(GGML_TYPE_MXFP4,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_MXFP4].f32acc,   matmul_id_mxfp4_f32,   , mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, 0);
             CREATE_MM(GGML_TYPE_NVFP4,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_NVFP4].f32acc,   matmul_id_nvfp4_f32,   , mmq_wg_denoms, warptile_mmqid, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id, 0);
         }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mm_funcs.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mm_funcs.glsl
@@ -553,6 +553,78 @@ void load_a_to_shmem(const uint pos_a, const uint row, const uint col, const uin
             buf_a[buf_idx + 4] = FLOAT_TYPEV2(kvalues_mxfp4[vui  >>  4] * d,
                                               kvalues_mxfp4[vui2 >>  4] * d);
 #endif
+#elif defined(DATA_A_TQ3_1S)
+            // TurboQuant, ROTATED formulation. These loads deliberately produce
+            // centroid*scale and do NOT apply the inverse WHT, so this shader is
+            // only correct when the B operand has already been rotated (see
+            // tq_rotate_act.comp and ggml_vk_tq_rotate_src1). The identity is
+            // <S.H.y.k, x> == k.<y, H.S.x> with H the symmetric 32x32 Hadamard,
+            // S = diag(signs) and k = 1/sqrt(32): rotate the activation once
+            // instead of un-rotating every weight block.
+            //
+            // LOAD_VEC_A is 8 for this type, which lines up exactly: one
+            // invocation covers one 3-byte packing group = 8 contiguous
+            // elements, so the 8 values are contiguous in k and buf_idx uses the
+            // LOAD_VEC_A/2 form (as F32 does) rather than Q4_0's split form.
+            {
+            const uint idx = pos_a + col * p.stride_a / LOAD_VEC_A + row;
+            const uint buf_idx = col * SHMEM_STRIDE + row * LOAD_VEC_A / 2;
+
+            const uint ib  = idx / 4u;   // 4 groups of 8 per 32-element block
+            const uint iqs = idx & 3u;   // which 3-byte group
+
+            // ASYMMETRIC -- must match TQ3_0_CENTROIDS in ggml-turbo-quant.c
+            // byte for byte, and dequant_funcs.glsl / dequant_tq3_1s.comp.
+            const float centroids[8] = float[8](
+                -1.996684, -1.291398, -0.740341, -0.247508,
+                 0.230106,  0.725222,  1.277503,  1.988943
+            );
+
+            // elements iqs*8 .. iqs*8+7, so d0 covers groups 0-1, d1 groups 2-3
+            const float d = (iqs < 2u) ? float(data_a[ib].d0) : float(data_a[ib].d1);
+
+            const uint g = iqs * 3u;
+            const uint pk = uint(data_a[ib].qs[g])
+                          | (uint(data_a[ib].qs[g + 1u]) << 8)
+                          | (uint(data_a[ib].qs[g + 2u]) << 16);
+
+            [[unroll]] for (uint i = 0; i < 4u; i++) {
+                const uint i0 = i * 2u;
+                const uint i1 = i0 + 1u;
+                buf_a[buf_idx + i] = FLOAT_TYPEV2(
+                    centroids[(pk >> (i0 * 3u)) & 7u] * d,
+                    centroids[(pk >> (i1 * 3u)) & 7u] * d);
+            }
+            }
+#elif defined(DATA_A_TQ4_1S)
+            // Same rotated formulation as TQ3_1S above; see that comment.
+            // 16 levels, 2 nibbles per byte, so one invocation covers 8
+            // contiguous elements = 4 bytes of qs.
+            {
+            const uint idx = pos_a + col * p.stride_a / LOAD_VEC_A + row;
+            const uint buf_idx = col * SHMEM_STRIDE + row * LOAD_VEC_A / 2;
+
+            const uint ib  = idx / 4u;
+            const uint iqs = idx & 3u;
+
+            // SYMMETRIC 16-level Lloyd-Max; must match TQ4_0_CENTROIDS.
+            const float centroids[16] = float[16](
+                -2.732590, -2.069017, -1.618046, -1.256231,
+                -0.942340, -0.656759, -0.388048, -0.128395,
+                 0.128395,  0.388048,  0.656759,  0.942340,
+                 1.256231,  1.618046,  2.069017,  2.732590
+            );
+
+            const float d = (iqs < 2u) ? float(data_a[ib].d0) : float(data_a[ib].d1);
+
+            const uint b0 = iqs * 4u;
+            [[unroll]] for (uint i = 0; i < 4u; i++) {
+                const uint byt = uint(data_a[ib].qs[b0 + i]);
+                buf_a[buf_idx + i] = FLOAT_TYPEV2(
+                    centroids[byt & 0xFu] * d,
+                    centroids[(byt >> 4u) & 0xFu] * d);
+            }
+            }
 #endif
 }
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/tq_rotate_act.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/tq_rotate_act.comp
@@ -17,24 +17,32 @@
 // k, so k belongs here, on the activation. (mul_mat_vec_tq3_1s.comp folds k
 // into the weight instead; either is fine, but exactly one must apply it.)
 //
-// Deliberately NOT in place. The Metal implementation rotates src1 in place,
-// runs the matmul, then un-rotates, which needs a hazard flag
-// (ggml_metal_op_mutates_tq_src1) and a barrier on both sides -- and its rotate
-// indexes src1 flat while the matmul reads it with nb11/nb12/nb13 strides, so a
-// padded or strided src1 rotates different elements than the matmul consumes.
-// Writing to a separate destination costs one small scratch buffer
-// (n_tokens * k * 4 bytes) and removes that entire class of bug.
+// This runs in place, but ONLY ever on ctx->prealloc_y -- the context-owned
+// staging copy of the activation -- never on the graph's src1. The host forces
+// src1 to be staged for these types precisely so that d_Y cannot alias the real
+// tensor. In-place is safe here because each workgroup reads, transforms and
+// writes back exactly its own 32 contiguous elements, with no cross-workgroup
+// dependency.
+//
+// Metal instead rotates src1 itself, matmuls, then un-rotates, which needs a
+// hazard flag (ggml_metal_op_mutates_tq_src1) plus barriers on both sides --
+// and its rotate indexes src1 flat while the matmul reads it with
+// nb11/nb12/nb13 strides, so a padded or strided src1 rotates different
+// elements than the matmul consumes. Rotating a packed scratch copy removes
+// that entire class: the staging pass has already made it contiguous.
+//
+// f32 throughout: the butterfly is 5 rounds of adds, and doing that in f16
+// would lose precision the quantization did not. The host selects the f32 B
+// variant of the matmul for these types to match.
 
 layout(local_size_x = 32, local_size_y = 1, local_size_z = 1) in;
 
-layout (binding = 0) readonly  buffer S {float data_s[];};
-layout (binding = 1) writeonly buffer D {float data_d[];};
+layout (binding = 0) buffer S {float data_s[];};
 
 layout (push_constant) uniform parameter {
     uint k;            // elements per row, guaranteed a multiple of 32
     uint nrows;        // total rows: ne11 * ne12 * ne13
-    uint src_stride;   // row stride in elements
-    uint dst_stride;   // row stride in elements
+    uint stride;       // row stride in elements of the packed staging buffer
 } p;
 
 // TQ3_0_SIGNS in ggml-turbo-quant.c / TQ_WEIGHT_SIGNS in turbo-quant.cuh.
@@ -66,10 +74,10 @@ void main() {
 
     const uint g   = gid % groups_per_row;
     const uint tid = gl_LocalInvocationID.x;
-    const uint off = g * 32u + tid;
+    const uint idx = row * p.stride + g * 32u + tid;
 
     // Stage 1: sign flip
-    tq_smem[tid] = data_s[row * p.src_stride + off] * TQ_SIGNS[tid];
+    tq_smem[tid] = data_s[idx] * TQ_SIGNS[tid];
     barrier();
 
     // Stage 2: forward WHT butterfly, 5 stages. Pairs (tid, tid + step) with
@@ -86,5 +94,5 @@ void main() {
         barrier();
     }
 
-    data_d[row * p.dst_stride + off] = tq_smem[tid] * TQ_INV_SQRT32;
+    data_s[idx] = tq_smem[tid] * TQ_INV_SQRT32;
 }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/tq_rotate_act.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/tq_rotate_act.comp
@@ -1,0 +1,90 @@
+#version 450
+
+#extension GL_EXT_control_flow_attributes : require
+
+// Pre-rotate an activation for the TurboQuant rotated matmul path.
+//
+// A stored TQ3_1S/TQ4_1S block holds c[j] = centroid[idx_j] * d_j, i.e. the
+// block *after* the rotation quantization applied. Recovering true weights costs
+// an inverse RHT per weight block. Instead use
+//
+//     <S.H.y.k, x> == k.<y, H.S.x>
+//
+// with H the symmetric 32x32 natural-ordered (Sylvester) Hadamard realised by
+// the in-place butterfly, S = diag(TQ_SIGNS) and k = 1/sqrt(32): rotate the
+// *activation* once per tile and dot it against raw centroid*scale weights.
+// mul_mm_funcs.glsl loads the A side as centroid*d with no inverse WHT and no
+// k, so k belongs here, on the activation. (mul_mat_vec_tq3_1s.comp folds k
+// into the weight instead; either is fine, but exactly one must apply it.)
+//
+// Deliberately NOT in place. The Metal implementation rotates src1 in place,
+// runs the matmul, then un-rotates, which needs a hazard flag
+// (ggml_metal_op_mutates_tq_src1) and a barrier on both sides -- and its rotate
+// indexes src1 flat while the matmul reads it with nb11/nb12/nb13 strides, so a
+// padded or strided src1 rotates different elements than the matmul consumes.
+// Writing to a separate destination costs one small scratch buffer
+// (n_tokens * k * 4 bytes) and removes that entire class of bug.
+
+layout(local_size_x = 32, local_size_y = 1, local_size_z = 1) in;
+
+layout (binding = 0) readonly  buffer S {float data_s[];};
+layout (binding = 1) writeonly buffer D {float data_d[];};
+
+layout (push_constant) uniform parameter {
+    uint k;            // elements per row, guaranteed a multiple of 32
+    uint nrows;        // total rows: ne11 * ne12 * ne13
+    uint src_stride;   // row stride in elements
+    uint dst_stride;   // row stride in elements
+} p;
+
+// TQ3_0_SIGNS in ggml-turbo-quant.c / TQ_WEIGHT_SIGNS in turbo-quant.cuh.
+// Shared by TQ3 and TQ4, which is why one rotate shader serves both types.
+const float TQ_SIGNS[32] = float[32](
+    +1.0, -1.0, +1.0, -1.0, +1.0, +1.0, -1.0, +1.0,
+    -1.0, -1.0, +1.0, -1.0, +1.0, +1.0, -1.0, +1.0,
+    -1.0, -1.0, +1.0, -1.0, +1.0, -1.0, -1.0, +1.0,
+    -1.0, +1.0, +1.0, -1.0, +1.0, -1.0, -1.0, +1.0
+);
+
+const float TQ_INV_SQRT32 = 0.17677669529663688;
+
+// 32 threads, one 32-element group per workgroup. Fixed at 32 for the same
+// reason as the TQ mat-vec kernels: the butterfly pairs lanes (tid, tid + step)
+// through a 32-entry shared array, so it is only correct when the workgroup is
+// exactly the block size. RADV on gfx1151 reports warp size 64, so this must
+// not be widened and must not use subgroup ops.
+shared float tq_smem[32];
+
+void main() {
+    const uint groups_per_row = p.k / 32u;
+    const uint gid            = gl_WorkGroupID.x;
+    const uint row            = gid / groups_per_row;
+
+    if (row >= p.nrows) {
+        return;
+    }
+
+    const uint g   = gid % groups_per_row;
+    const uint tid = gl_LocalInvocationID.x;
+    const uint off = g * 32u + tid;
+
+    // Stage 1: sign flip
+    tq_smem[tid] = data_s[row * p.src_stride + off] * TQ_SIGNS[tid];
+    barrier();
+
+    // Stage 2: forward WHT butterfly, 5 stages. Pairs (tid, tid + step) with
+    // (tid & step) == 0, matching tq3_0_rht_forward() in ggml-turbo-quant.c and
+    // stage 2 of mul_mat_vec_tq3_1s.comp.
+    [[unroll]] for (uint step = 1u; step < 32u; step <<= 1u) {
+        if ((tid & step) == 0u) {
+            const uint partner = tid + step;
+            const float a = tq_smem[tid];
+            const float b = tq_smem[partner];
+            tq_smem[tid]     = a + b;
+            tq_smem[partner] = a - b;
+        }
+        barrier();
+    }
+
+    data_d[row * p.dst_stride + off] = tq_smem[tid] * TQ_INV_SQRT32;
+}

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -646,10 +646,13 @@ void matmul_shaders(bool fp16, MatMulIdType matmul_id_type, bool coopmat, bool c
     if (!coopmat2) {
         for (const auto& tname : {std::string("tq3_1s"), std::string("tq4_1s")}) {
             const std::string data_a_key = "DATA_A_" + to_uppercase(tname);
+            // Must carry FLOAT_TYPEV8 as well: load_b_to_shmem() references it
+            // whenever LOAD_VEC_B is 8, which it is on the fp16 path.
             const std::map<std::string, std::string> float_type_dict = {
                 {"FLOAT_TYPE",   FLOAT_TYPE(1, tname)},
                 {"FLOAT_TYPEV2", FLOAT_TYPE(2, tname)},
                 {"FLOAT_TYPEV4", FLOAT_TYPE(4, tname)},
+                {"FLOAT_TYPEV8", FLOAT_TYPE(8, tname)},
             };
 
             string_to_spv(shader_name + "_" + tname + "_f32" + dot2_sfx, "mul_mm.comp",

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -627,6 +627,37 @@ void matmul_shaders(bool fp16, MatMulIdType matmul_id_type, bool coopmat, bool c
         }
 #endif
     }
+
+    // TurboQuant weight types, ROTATED matmul.
+    //
+    // Generated explicitly rather than by adding them to type_names, for the
+    // same reasons as the mat-vec kernels: that loop would also emit q8_1 mmq
+    // variants (no integer-dot path exists for these types) and pull them into
+    // paths that have no TQ support.
+    //
+    // The A side loads centroid*scale WITHOUT the inverse WHT, so these are only
+    // correct against an activation pre-rotated by tq_rotate_act.comp. The host
+    // must not dispatch them otherwise.
+    //
+    // coopmat2 is excluded: TQ has no dequant_funcs_cm2.glsl entry, and the
+    // target (gfx1151) exposes KHR_coopmat only. LOAD_VEC_A is pinned to 8
+    // because the A-side block indexes idx/4 and idx&3 to map one invocation
+    // onto exactly one 3-byte packing group of 8 contiguous elements.
+    if (!coopmat2) {
+        for (const auto& tname : {std::string("tq3_1s"), std::string("tq4_1s")}) {
+            const std::string data_a_key = "DATA_A_" + to_uppercase(tname);
+            const std::map<std::string, std::string> float_type_dict = {
+                {"FLOAT_TYPE",   FLOAT_TYPE(1, tname)},
+                {"FLOAT_TYPEV2", FLOAT_TYPE(2, tname)},
+                {"FLOAT_TYPEV4", FLOAT_TYPE(4, tname)},
+            };
+
+            string_to_spv(shader_name + "_" + tname + "_f32" + dot2_sfx, "mul_mm.comp",
+                merge_maps(merge_maps(base_dict, float_type_dict), {{data_a_key, "1"}, {"LOAD_VEC_A", "8"}, {"LOAD_VEC_B", load_vec}, {"B_TYPE", aligned_b_type_f32}, {"B_TYPE_SCALAR", "float"}, {"B_TYPEV4", "vec4"}, {"D_TYPE", "float"}}), fp16, coopmat, coopmat2, f16acc);
+            string_to_spv(shader_name + "_" + tname + "_f16" + dot2_sfx, "mul_mm.comp",
+                merge_maps(merge_maps(base_dict, float_type_dict), {{data_a_key, "1"}, {"LOAD_VEC_A", "8"}, {"LOAD_VEC_B", load_vec}, {"B_TYPE", aligned_b_type_f16}, {"B_TYPE_SCALAR", "float16_t"}, {"B_TYPEV4", "f16vec4"}, {"D_TYPE", "float"}}), fp16, coopmat, coopmat2, f16acc);
+        }
+    }
 }
 
 void process_shaders() {
@@ -917,6 +948,12 @@ void process_shaders() {
         merge_maps(base_dict, {{"MUL_MAT_ID", "1"}, {"DATA_A_TQ3_1S", "1"}, {"B_TYPE", "float"}, {"B_TYPEV2", "vec2"}, {"B_TYPEV4", "vec4"}, {"D_TYPE", "float"}}));
     string_to_spv("dequant_tq3_1s", "dequant_tq3_1s.comp",
         merge_maps(base_dict, {{"DATA_A_TQ3_1S", "1"}, {"D_TYPE", "float16_t"}}));
+
+    // Activation pre-rotation for the rotated matmul path. Type-independent:
+    // TQ3 and TQ4 share the same 32-element sign pattern and butterfly, so one
+    // pipeline serves both. Takes no DATA_A_* define -- it only touches the
+    // activation.
+    string_to_spv("tq_rotate_act", "tq_rotate_act.comp", {});
 
     auto get_type_str = [](bool f16) {
         return f16 ? "float16_t" : "float";


### PR DESCRIPTION
Follow-up to #264. That PR added `mul_mat_vec_id` so MoE **decode** runs on the GPU for the TurboQuant weight types, but left prompt processing on the f16 dequant path — and gated out any model whose expert tensor could not be staged as f16. This adds a real TQ `mul_mm_id`, which removes the staging entirely.

## The approach

The A side is loaded as `centroid * scale` with **no inverse WHT**, which is only correct against a pre-rotated activation. That is the identity

```
<S.H.y.k, x>  ==  k.<y, H.S.x>
```

with `H` the symmetric 32x32 Hadamard, `S = diag(TQ_SIGNS)` and `k = 1/sqrt(32)`: rotate the activation once per tile instead of un-rotating every weight block. `dequant_funcs.glsl` already produced exactly this form, so the A-side loads in `mul_mm_funcs.glsl` are the only new dequant code.

`LOAD_VEC_A` is pinned to 8 for these types, which lines up so one invocation covers one 3-byte packing group = 8 contiguous elements in k. `k` is applied in the rotate shader because the A-side loads omit it — `mul_mat_vec_tq3_1s.comp` does the opposite and folds it into the weight. Exactly one side must.

## Rotating scratch, not src1

Metal's rotated `mul_mm_id` rotates `src1` in place, matmuls, then un-rotates, which needs a hazard flag (`ggml_metal_op_mutates_tq_src1`) and barriers on both sides. Its rotate also indexes `src1` flat while the matmul reads it with `nb11`/`nb12`/`nb13`, so a strided or padded `src1` rotates different elements than the matmul consumes.

This rotates `ctx->prealloc_y` — the staging copy — instead, and never touches the graph's tensor. Staging is *forced* for these types even when `src1` is already contiguous f32, because otherwise `y_f32_kernel` is true, `qy_needs_dequant` is false, and `d_Y` aliases the real `src1`. The staging pass has already made the copy contiguous, so the stride mismatch cannot arise. Staged in f32: the butterfly is five rounds of adds and f16 would lose precision the quantization did not.

The `prealloc_y` reuse cache is keyed on the rotate pipeline rather than the copy pipeline, so a later non-rotated consumer of the same `src1` cannot reuse rotated data.

## The size gate from #264

It now applies only where the f16 dequant fallback is actually taken — when the TQ pipelines do not exist on the device (they are not created for coopmat2) or `src0` is not dim01-contiguous. Those are the two conditions `tq_rotate` is gated on, so the two must agree; if they diverge the fallback hits `GGML_ABORT("Requested preallocation size is too large")` again.

`ggml_vk_get_mul_mat_mat_id_pipeline()` ends in `GGML_ASSERT(support_fp32acc)`, so it now returns nullptr for TQ when both acc variants are empty rather than aborting on a coopmat2 device.

## Validation — gfx1151, RADV, wave64

`test-backend-ops -o MUL_MAT_ID`: **967/967, 2/2 backends** on the rebased head. Cases at n=9/17/32 exercise the rotated `mul_mm_id`; n=1/4/8 still take `mul_mat_vec_id`.

Before any host code, the identity was checked directly: the GLSL `(tid & step)==0` pairing is bit-identical to the `(j, j+step)` loop nest of `tq3_0_rht_forward()`, and `<x, rht_inverse(c)> == <rotate(x), c>` over 20000 random blocks gives median relative error 1.9e-16, max 1.2e-12.

Batched perplexity, Qwen3.6-35B-A3B-ConfigI (431 TQ3_1S tensors, 256 experts), `-c 512 --chunks 2`, three arms:

| path | chunk[1] | final PPL | s/pass |
|---|---|---|---|
| experts on CPU | 4.5768 | 6.5360 ± 0.76461 | 129.82 |
| f16 dequant `mul_mm_id` | 4.5271 | 6.5269 ± 0.76390 | 2.90 |
| rotated `mul_mm_id` | 4.5769 | 6.5663 ± 0.76962 | **1.45** |

Measuring the middle arm matters: against experts-on-CPU this looks like 89x, but 44.8x of that is what #264 already delivers. This PR's own contribution is **2.0x over the dequant path**, plus removing the staging buffer.

DeepSeek-V4-Flash Config-I, `-c 512 --chunks 2 -ub 64`:

| | chunk[1] | final PPL | s/pass |
|---|---|---|---|
| experts on CPU | 10.4794 | 13.3367 ± 1.86891 | 316.80 |
| experts on GPU | 8.9692 | **12.9997 ± 1.79589** | **23.68** |

Its `ffn_{gate,up,down}_exps` are 2048 x 4096 x 256, whose f16 staging would be exactly 4,294,967,296 bytes against a 4,294,967,295 limit — excluded by one byte under #264's gate. Nothing is staged now.

## Two things I would rather state than have found

The perplexity **improves**, which is also what a subtle bug looks like. The reason is that `TQ3_1S` has `.vec_dot_type = GGML_TYPE_Q8_0`, so the CPU fallback quantizes the activation to q8_0 before every dot; the rotated path keeps f32. The three DeepSeek runs order monotonically by how much intermediate quantization each avoids (10.4794 CPU q8_0, 9.7819 mat-vec q8_0, 8.9692 rotated f32), and on Qwen — where the comparison is GPU-versus-GPU — chunk[1] moves 4.5768 to 4.5769.

The rotated path is marginally *less* accurate than the dequant path (+0.46% versus -0.14% against the CPU control). Both are far inside the band. This is consistent with `buf_a` holding `centroid*scale` in f16 on the fp16 path: the rotated domain has a different dynamic range than true weights.

## Not included

`mul_mm` for plain MUL_MAT is untouched — it still uses the dequant path, which works and is validated. Only `mul_mm_id` is wired here. coopmat2 is excluded throughout: no `dequant_funcs_cm2.glsl` entry, and gfx1151 is KHR_coopmat only, so I cannot test it.

AI usage disclosure: written with Claude Code; I reviewed every change and ran all measurements above on my own hardware.
