### PR TITLE
[ggml-cuda] Compute the turbo4 centroid LUT in advance during the decoding process

### DIFF
--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -527,18 +527,30 @@ static __device__ __forceinline__ void flash_attn_ext_turbo4_load_tile(
             continue;
         }
         const char * row_ptr = KV_raw + (int64_t)row * stride_bytes;
-        // Which block(s) this column window spans. QK_TURBO4/2 == 64 half2 columns per block.
         // For D=128 there is exactly one block per row and col_offset==0.
-        for (int c = 0; c < D2; ++c) {
-            const int col = col_offset + c;                 // absolute half2 column in the row
-            const int blk_idx = col / (QK_TURBO4 / 2);      // 64 half2 cols per turbo4 block
-            const int in_blk  = col % (QK_TURBO4 / 2);      // half2 index within the block
+        // norm is constant within a block; precompute the 16 possible
+        // centroid*norm values once instead of recomputing per element.
+        int c = 0;
+        while (c < D2) {
+            const int col         = col_offset + c;                // absolute half2 column
+            const int blk_idx     = col / (QK_TURBO4 / 2);         // 64 half2 cols per turbo4 block
+            const int blk_col_end = (blk_idx + 1) * (QK_TURBO4 / 2) - col_offset;
+            const int c_end       = min(D2, blk_col_end);
+
             const block_turbo4_0 * blk = (const block_turbo4_0 *)(row_ptr) + blk_idx;
             const float norm = __half2float(blk->norm);
-            const uint8_t byte = blk->qs[in_blk];
-            const half lo = __float2half(TURBO_CENTROIDS_4BIT_FATTN[byte & 0xF] * norm);
-            const half hi = __float2half(TURBO_CENTROIDS_4BIT_FATTN[byte >>  4] * norm);
-            tile_KV[row*stride_tile + c] = __halves2half2(lo, hi);
+
+            half scaled[16];
+#pragma unroll
+            for (int i = 0; i < 16; ++i) {
+                scaled[i] = __float2half(TURBO_CENTROIDS_4BIT_FATTN[i] * norm);
+            }
+
+            for (; c < c_end; ++c) {
+                const int in_blk = (col_offset + c) % (QK_TURBO4 / 2);
+                const uint8_t byte = blk->qs[in_blk];
+                tile_KV[row*stride_tile + c] = __halves2half2(scaled[byte & 0xF], scaled[byte >> 4]);
+            }
         }
     }
 }


### PR DESCRIPTION
## Overview

### Summary
Create a temporary array in advance with centroid[i] * norm to eliminate redundant scaling operations within the block. Through this, the float multiplication operation per block is reduced from 128 to 16 during decoding.

### Profiling & Root Cause
nsys (Jetson AGX Orin 64GB / sm_87): The flash_attn_ext_f16 kernel for turbo4 degrades significantly vs f16 as context grows (2.63x slower at ctx=32768).

ncu: Warp stall sampling shows that two lines performing LUT recalculation in flash_attn_ext_turbo4_load_tile account for 88.9% of all warp stalls in the file.

### Changes
All 16 scaled centroid values (centroid[i] * norm) are now precomputed into a local register array upon entering the block, replacing repeated element-loop multiplications with register lookups without affecting numerical output. While PR #36 previously explored shared-memory LUT precomputation for turbo2/3 but skipped turbo4 owing to smem capacity constraints, leveraging registers bypasses this limitation entirely, lowering register usage from 128 to 121 and subtly enhancing occupancy.

### Verification & Benchmarks
**Accuracy**: Verified with llama-perplexity (wikitext-2, turbo4 KV, 6 chunks). Per-chunk values and final PPL (7.2441) match the baseline exactly.

**Decode Performance** (llama-bench -p 0 -n 32 -d \<ctx\> -ctk turbo4 -ctv turbo4, Llama-3.1-8B-Q4_K_M on Jetson AGX Orin 64GB):

| Context (ctx) | Baseline (tpot) | This PR (tpot) | Delta |
|---|---|---|---|
| 512 | 39.343ms | 38.987ms | -0.9% (within noise) |
| 32768 | 101.463ms | 92.047ms | -9.3% |

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Used Claude Code for profiling/debug assistance and initial code writing
