### PR TITLE
tests: port 11 DSv4-shaped TQ MUL_MAT cases from the deleted sync/upstream-master

### DIFF
--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9228,6 +9228,26 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         }
     }
 
+    // TQ3_1S: DeepSeek-V4 MLA head_dim=512 batched-prefill shape.
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_TQ3_1S, GGML_TYPE_F32, 128, 512, 512, {1, 1}, {1, 1}));
+
+    // TQ3_1S / TQ4_1S: non-contiguous src1 (k_v > k view) with batched n, to exercise
+    // the rotate-act contiguity fallback. rotate-act walks src1 as a flat array so it
+    // requires contiguous src1; non-contiguous must fall back to the standard mul_mm
+    // path (inverse-RHT dequant), which handles strides via nb1x.
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_TQ3_1S, GGML_TYPE_F32, 256, 256, 1536, {1, 1}, {1, 1}, {0, 1, 2, 3}, 1600));
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_TQ4_1S, GGML_TYPE_F32, 256, 256, 1536, {1, 1}, {1, 1}, {0, 1, 2, 3}, 1600));
+
+    // TQ3_1S: small-batch (n<=8) FUSED multi-token kernel path. This is DeepSeek-V4-Flash's
+    // real attn_q_a shape (n_embd=4096 -> q_lora_rank=1024) at an 8-token prefill batch,
+    // contiguous src1 -- the case found to diverge (~2% on real weights) via eval-callback
+    // node diffing against the CPU reference. The k=16384/m=24 pair mirrors hc_attn_fn's
+    // shape as a control that was observed numerically fine.
+    for (int nb : { 1, 2, 4, 8 }) {
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_TQ3_1S, GGML_TYPE_F32, 1024, nb, 4096, {1, 1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(GGML_TYPE_TQ3_1S, GGML_TYPE_F32, 24, nb, 16384, {1, 1}, {1, 1}));
+    }
+
     // m == 1, with n on both sides of MMVF_MAX_BATCH_SIZE (8): mmvf below, operand swap above
     for (int64_t n : {1, 7, 8, 9, 16, 128, 512}) {
         test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F32, GGML_TYPE_F32, 1, n, 2048, {1, 1}, {1, 1}));


### PR DESCRIPTION
Ports the TQ `MUL_MAT` coverage that existed only on `sync/upstream-master` and was lost when that branch was deleted. Follow-up to #249; one of the ported cases is the reproducer for #268.

## Scope, measured rather than counted

I originally described this to you as "29 TQ-relevant lines" from a source diff. That was the wrong instrument and it overstated the loss — correcting it here.

Building both trees and diffing the cases they actually **generate**:

| | distinct TQ `MUL_MAT` cases |
|---|---|
| `6aa97d810` (deleted branch) | 293 |
| `feature/turboquant-kv-cache` | **536** |

The default branch has roughly **1.8× more** TQ coverage, not less — it gained 254 TQ3_1S cases (120 `f16`, 134 `f32`) the deleted branch never had. Counting source lines was misleading because the existing loop over `m ∈ {256,1536,2048}` × `n ∈ {16,64,256}` already generates one of the "missing" lines: different text, identical coverage.

What is genuinely absent is **11 generated cases**, and they are all DeepSeek-V4 shapes.

## The 11 cases

| n | shape | what it covers |
|---|---|---|
| 1 | `tq3_1s m=128, n=512, k=512` | DSv4 MLA head_dim=512 batched prefill |
| 4 | `tq3_1s m=1024, n∈{1,2,4,8}, k=4096` | DSv4-Flash `attn_q_a` (n_embd 4096 → q_lora_rank 1024), fused multi-token path — the case found to diverge ~2% on real weights via eval-callback node diffing |
| 4 | `tq3_1s m=24, n∈{1,2,4,8}, k=16384` | `hc_attn_fn` shape, the control observed numerically fine |
| 2 | `tq3_1s` + `tq4_1s` `m=256, n=256, k=1536, k_v=1600` | non-contiguous `src1` → rotate-act contiguity fallback (**#268**) |

Comments are carried over verbatim from the deleted branch, since they document why each shape was chosen and I can't improve on that.

## Test results

`test-backend-ops test -o MUL_MAT`, 2× Tesla P100 (sm_60), CUDA arch 60, Release:

```
Backend 1/3: CUDA0   1492/1493 tests passed
Backend 2/3: CUDA1   1492/1493 tests passed
Backend 3/3: CPU     Skipping CPU backend
1/3 backends passed
```

**10 of 11 pass. The single failure is the TQ4_1S `k_v=1600` case:**

```
[MUL_MAT] NaN at index 245 (CUDA0=-2.388598  CPU=-nan)
[MUL_MAT] NaN at index 246 (CUDA1=-0.040736  CPU=-nan)
Failing tests:
  MUL_MAT(type_a=tq4_1s,type_b=f32,m=256,n=256,k=1536,bs=[1,1],nr=[1,1],per=[0,1,2,3],k_v=1600,o=1)
```

That is #268, and it is included **deliberately** — the missing coverage is precisely what let the defect sit undetected. Note the TQ3_1S case at the identical shape passes, so this reads TQ4_1S-specific.

**This turns the suite red until #268 is fixed.** If you would rather land the 9 clean cases now and hold the `k_v=1600` pair until there is a fix, say so and I will split it — but I would argue for merging as-is, since a red test that names a real bug is doing its job.

## Provenance

Cases are verbatim from `6aa97d810:tests/test-backend-ops.cpp:9137–9159`. That commit is PR #256's merge into `sync/upstream-master`; with the branch deleted it is no longer reachable from the repo, and the copy this PR is built from survives only because a local worktree still pins it. I have archived the full file separately in case anything else from it is wanted later.

`test_mul_mat`'s member layout (`m, n, k, bs[2], nr[2], per[4], k_v`) is identical on both branches, so the constructor calls compile unchanged and no API surface is carried across. The diff is 20 insertions, no deletions, tests only.

## One note that may help with #268

Both branches already carry this, in the `SET_ROWS_TQ4_1S` test:

```cpp
// Zero-fill TQ4_1S dst to avoid fp16 NaN in unwritten rows' d0/d1
```

That is a documented workaround for the same failure signature #268 shows — unwritten TQ4_1S memory yields fp16 NaN through the `d0`/`d1` scale fields. It suggests the property "unwritten TQ4_1S regions are NaN-producing" was already known and worked around at the test level rather than fixed underneath.

That fits what I found bisecting: the NaN first appears at `309de108e`, which is three lines adding `n_tasks = n_threads; break;` for `FLASH_ATTN_BACK`/`SSM_CONV`/`SSM_SCAN` in `ggml_get_n_tasks` — code that a `MUL_MAT`-only graph never reaches. Its parent `00fda770b` is clean across 5 runs × 468 registrations (2,340 executions of the exact shape, zero NaN), so the clean side is not luck. But since the diff has no causal path to `MUL_MAT`, `309de108e` is a **reliable trigger, not the cause** — consistent with a latent uninitialized read whose manifestation depends on binary layout.

If that reading is right, further bisecting will not find it, and the cheapest next step is running the single case under valgrind or `-fsanitize=memory` on the CPU backend.
