### PR TITLE
fix(server): batch restored-checkpoint prompt processing instead of one token/iter

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3565,6 +3565,16 @@ private:
                         }
                     }
 
+                    // A restored-checkpoint slot is unstable when co-batched with other
+                    // active slots (turbo/CUDA path). Give it its own batch: if other slots
+                    // already contributed to this batch, defer — next update_slots() it starts
+                    // empty and fills a FULL batch instead of one token per iteration.
+                    // (Replaces an in-loop per-token `break` that crippled restored-prefix
+                    //  prompt processing to decode speed ~40 tok/s; see feature/turboquant fix.)
+                    if (slot.prompt_checkpoint_restored && n_tokens_prev > 0) {
+                        return;
+                    }
+
                     const int64_t t_now = ggml_time_us();
                     slot.t_prompt_processing = (t_now - slot.t_start_process_prompt) / 1e3;
                     slot.print_timings_pp();
@@ -3699,12 +3709,8 @@ private:
                             }
                         }
 
-                        // a restored checkpoint leaves a short prompt suffix to evaluate; keep it
-                        // in small batches (the CUDA path is not stable when it is evaluated
-                        // concurrently with other active slots)
-                        if (slot.prompt_checkpoint_restored) {
-                            break;
-                        }
+                        // NOTE: the restored-checkpoint suffix is now filled as a full batch
+                        // (isolation handled by the pre-loop guard above), not one token/iter.
                     }
 
                     // the number of tokens added to the batch for the current slot


### PR DESCRIPTION
## Problem

Prompt processing intermittently collapses from batched prefill (~1100 tok/s) to **one token per `llama_decode`** (~40 tok/s, decode speed), flooding the log with a `prompt processing, n_tokens = N` line per token. It hits requests that reuse a slot via prompt similarity (`selected slot by LCP similarity ...`), not fresh ones. Full write-up in the linked issue.

## Root cause

`tools/server/server-context.cpp`, in the `while (... && batch.size() < n_batch)` prompt fill loop:

```cpp
// a restored checkpoint leaves a short prompt suffix to evaluate; keep it
// in small batches (the CUDA path is not stable when it is evaluated
// concurrently with other active slots)
if (slot.prompt_checkpoint_restored) {
    break;
}
```

The `break` is at the end of the loop body, after one token is added, so a restored-checkpoint slot evaluates its entire divergent suffix one token at a time. `git blame` shows these lines were inserted by `e130aef60` between upstream lines; upstream `ggml-org/llama.cpp` has no such break and fills the batch normally.

## Change

Remove the per-token break and instead isolate a restored slot with a **pre-loop** guard: if other slots have already contributed to the current batch, defer the restored slot to the next `update_slots()` pass (where it starts with an empty batch and fills a full one). This preserves the original intent — keep a restored slot out of a *mixed* batch on the turbo/CUDA path — while letting it prefill at full batch size. It mirrors the approach the sxlmnwb fork used (which never showed this bug).

```cpp
if (slot.prompt_checkpoint_restored && n_tokens_prev > 0) {
    return;
}
```

With `-np 1` the guard never fires (no other slots), so the restored suffix simply prefills as a full batch, exactly like a fresh prompt. A bare deletion of the block (matching upstream, which does no isolation) is also viable if you consider the isolation unnecessary — happy to switch to that.

## Validation

- Builds clean on CUDA (`CMAKE_CUDA_ARCHITECTURES=86`, RTX 3090).
- No regression: with checkpoints on and `--slot-prompt-similarity 0.10`, a similarity-reused request (`f_keep = 0.378`, same range as the bug reports) now prefills in full 2048-token batches at ~1115 tok/s — no token-by-token, no crash.
- Note: reproducing an actual checkpoint *restore* synthetically is finicky (needs multi-turn / mid-context divergence to create then roll back to a checkpoint), so runtime confirmation of the exact restore path in a long real session is welcome. The root cause itself is established by `git blame` + the upstream comparison, and this removes the only code path that emits single-token prompt processing.

Fixes #270
