### PR TITLE
tests: initialise non-contiguous tensors row by row

### DIFF
--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -129,7 +129,24 @@ static void init_tensor_uniform(ggml_tensor * tensor, float min = -1.0f, float m
                 }
             }
         }
-        ggml_backend_tensor_set(tensor, dataq.data(), 0, dataq.size());
+        // A non-contiguous tensor (e.g. a k_v view whose rows are strided over a
+        // wider base) must be written row by row. ggml_backend_tensor_set copies
+        // `size` bytes contiguously from tensor->data, so a single packed write
+        // lays row i at i*row_size instead of i*nb[1], leaving the tail of the
+        // logical extent holding whatever was there before.
+        if (!ggml_is_contiguous(tensor) && ggml_n_dims(tensor) >= 2) {
+            const size_t row_sz = ggml_row_size(tensor->type, tensor->ne[0]);
+            const int64_t nrows = ggml_nrows(tensor);
+            for (int64_t r = 0; r < nrows; r++) {
+                const int64_t i3 =  r / (tensor->ne[1]*tensor->ne[2]);
+                const int64_t i2 = (r / tensor->ne[1]) % tensor->ne[2];
+                const int64_t i1 =  r % tensor->ne[1];
+                const size_t off = i1*tensor->nb[1] + i2*tensor->nb[2] + i3*tensor->nb[3];
+                ggml_backend_tensor_set(tensor, dataq.data() + r*row_sz, off, row_sz);
+            }
+        } else {
+            ggml_backend_tensor_set(tensor, dataq.data(), 0, dataq.size());
+        }
     } else if (tensor->type == GGML_TYPE_I8 || tensor->type == GGML_TYPE_I16) {
         // This is going to create some weird integers though.
         ggml_backend_tensor_set(tensor, data.data(), 0, nels * ggml_type_size(tensor->type));


### PR DESCRIPTION
Fixes the harness half of #268.

`init_tensor_uniform` wrote quantized data with one packed `ggml_backend_tensor_set`. That function copies `size` bytes contiguously from `tensor->data` and never strides by `nb[1]`, so for a view whose rows are spaced over a wider base the data lands at `i*row_size` instead of `i*nb[1]`.

Observed directly for the TQ4_1S `k_v=1600` case:

```
[COPYDBG] tensor_set name=leaf_0 ne=[1600,256] nb1=1000 offset=0 size=256000 nbytes=256000 view_src=no
[COPYDBG] tensor_set name=a      ne=[1536,256] nb1=1000 offset=0 size=245760 nbytes=255960 view_src=yes
```

245,760 bytes into a 255,960-byte logical extent, leaving the final rows holding prior buffer contents. The reference then read them and produced NaN, which presented as *CUDA* failing because CPU is the reference and is skipped as a backend under test.

Credit to @apollo-mg, whose byte arithmetic in #268 predicted both the NaN population (2,816) and the first affected row (245) from the geometry alone, and whose observation that a generic `nbytes`-based copy could not produce that signature is what ruled out the copy path and pointed at the initialiser.

## Effect

- `tq3_1s` at `k_v=1600` now reports **OK**; it previously had no meaningful coverage at this shape.
- The `tq4_1s` case still fails, but the failure **reverses**: CPU is finite and CUDA now returns NaN, consistently across runs. That is a separate genuine defect in the CUDA TQ4_1S path with non-contiguous `src0` which this bug was masking. #268 stays open for it.

Verified on GB10 (sm_121): MUL_MAT 1492/1493, no other case affected.