### PR TITLE
tests: cover turbo KV flash attention at head dim 256

### DIFF
--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -129,24 +129,7 @@ static void init_tensor_uniform(ggml_tensor * tensor, float min = -1.0f, float m
                 }
             }
         }
-        // A non-contiguous tensor (e.g. a k_v view whose rows are strided over a
-        // wider base) must be written row by row. ggml_backend_tensor_set copies
-        // `size` bytes contiguously from tensor->data, so a single packed write
-        // lays row i at i*row_size instead of i*nb[1], leaving the tail of the
-        // logical extent holding whatever was there before.
-        if (!ggml_is_contiguous(tensor) && ggml_n_dims(tensor) >= 2) {
-            const size_t row_sz = ggml_row_size(tensor->type, tensor->ne[0]);
-            const int64_t nrows = ggml_nrows(tensor);
-            for (int64_t r = 0; r < nrows; r++) {
-                const int64_t i3 =  r / (tensor->ne[1]*tensor->ne[2]);
-                const int64_t i2 = (r / tensor->ne[1]) % tensor->ne[2];
-                const int64_t i1 =  r % tensor->ne[1];
-                const size_t off = i1*tensor->nb[1] + i2*tensor->nb[2] + i3*tensor->nb[3];
-                ggml_backend_tensor_set(tensor, dataq.data() + r*row_sz, off, row_sz);
-            }
-        } else {
-            ggml_backend_tensor_set(tensor, dataq.data(), 0, dataq.size());
-        }
+        ggml_backend_tensor_set(tensor, dataq.data(), 0, dataq.size());
     } else if (tensor->type == GGML_TYPE_I8 || tensor->type == GGML_TYPE_I16) {
         // This is going to create some weird integers though.
         ggml_backend_tensor_set(tensor, data.data(), 0, nels * ggml_type_size(tensor->type));
@@ -9999,7 +9982,11 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
                                                     if (hsk != 128 && prec == GGML_PREC_DEFAULT) continue;
                                                     for (ggml_type type_KV : {GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_BF16, GGML_TYPE_Q8_0, GGML_TYPE_Q5_1, GGML_TYPE_Q5_0, GGML_TYPE_Q4_1, GGML_TYPE_Q4_0, GGML_TYPE_IQ4_NL, GGML_TYPE_TURBO3_0, GGML_TYPE_TURBO4_0}) {
                                                         if ((type_KV == GGML_TYPE_TURBO3_0 || type_KV == GGML_TYPE_TURBO4_0) && hsk < 128) continue;
-                                                        if (type_KV != GGML_TYPE_F16 && hsk != 64 && hsk != 72 && hsk != 128) continue;
+                                                        // turbo KV types are also used at head dim 256 (e.g. qwen35moe
+                                                        // key_length=value_length=256); allow 256 for them so that shape
+                                                        // is exercised rather than silently skipped.
+                                                        const bool turbo_kv = (type_KV == GGML_TYPE_TURBO3_0 || type_KV == GGML_TYPE_TURBO4_0 || type_KV == GGML_TYPE_TURBO2_0);
+                                                        if (type_KV != GGML_TYPE_F16 && hsk != 64 && hsk != 72 && hsk != 128 && !(turbo_kv && hsk == 256)) continue;
                                                         test_cases.emplace_back(new test_flash_attn_ext(
                                                                     hsk, hsv, nh, {nr2, nr3}, kv, nb, mask, sinks, max_bias, logit_softcap, prec, type_KV, type_KV));
                                                         // run fewer test cases permuted


### PR DESCRIPTION
Closes the coverage gap behind #252.

Two filters compounded at `test-backend-ops.cpp:10001-10002`:

```cpp
if ((type_KV == TURBO3_0 || type_KV == TURBO4_0) && hsk < 128) continue;
if (type_KV != F16 && hsk != 64 && hsk != 72 && hsk != 128) continue;
```

The first excludes below 128, the second admits only 64, 72 and 128 for non-f16 KV. Net effect: **every turbo FLASH_ATTN_EXT case in the suite runs at hsk=hsv=128**, and no other head dim has ever been exercised on any backend.

That is not a hypothetical shape. `qwen35moe` carries `key_length = value_length = 256`, which is the model @jasstrong reports turbo4-V corruption on in #252.

## Result

224 new cases, all passing on CUDA (GB10, sm_121): FLASH_ATTN_EXT **7656/7656 to 7880/7880**, zero failures.

So head dim 256 is correct on CUDA, which narrows #252 usefully:

| | hsk=128 | hsk=256 |
|---|---|---|
| CUDA (sm_121) | 752 OK | **224 OK** |
| HIP (gfx1100) | 528 OK, by @jasstrong | **untested** |

Three of the four squares are clean. The corruption lives in the remaining one, HIP at head dim 256, which is precisely what nothing covered.

I have no AMD hardware, so I cannot close the last square. @jasstrong this branch is what you offered to write; running it on gfx1100 should turn your full-inference corruption into a failing harness case.