### PR TITLE
cuda: enable fused TQ3_1S mul_mat on HIP (gfx1100) — the disable is CUDA-only

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1951,7 +1951,18 @@ static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor
     // TQ4_1S (dp4a and the AMD scalar variant) is untouched — no model on
     // hand uses it and there's no evidence it shares this bug, so the fast
     // path stays enabled for that type to avoid regressing existing users.
+#if defined(GGML_USE_HIP)
+    // HIP A/B (gfx1100): the TQ3_1S fused-kernel disable was root-caused and
+    // confirmed only on CUDA0 (DeepSeek-V4). Reduction-order cancellation is
+    // hardware-specific, so test the fused path on RDNA3 rather than inheriting
+    // the CUDA disable and forcing the slow dequant+hipBLAS path.
+    // Toggleable for the perplexity A/B: fused-on by default on gfx1100,
+    // TQ3_FUSE_OFF=1 forces the verified dequant+hipBLAS path.
+    static const bool tq3_fuse_off = (getenv("TQ3_FUSE_OFF") != nullptr);
+    const bool tq3_1s_fused_disabled = (src0->type == GGML_TYPE_TQ3_1S) && tq3_fuse_off;
+#else
     const bool tq3_1s_fused_disabled = (src0->type == GGML_TYPE_TQ3_1S);
+#endif
 
     if (is_tq_weight && tq_fast_path_ok && !tq3_1s_fused_disabled && ne11 <= MMVQ_MAX_BATCH_SIZE) {
         // Fused TQ weight mul_mat with pre-rotated activations via warp shuffle WHT


### PR DESCRIPTION
`ggml_cuda_mul_mat` unconditionally sets `tq3_1s_fused_disabled` for TQ3_1S weights, routing every TQ3_1S mul_mat to the dequant → cuBLAS fallback instead of the fused `mmvq-tq` kernel. Per the comment, this was root-caused and confirmed **only on CUDA0** (DeepSeek-V4): a reduction-order / cancellation sensitivity in the fused kernel's per-lane accumulation that compounds (~2%/layer) into incoherent generation on real weight/activation distributions.

That failure mode is specific to the CUDA warp reduction. RDNA3 (wavefront-32) is a different FP-accumulation regime and was never tested. On **gfx1100 / RX 7900 XTX, ROCm 7.2.3** the fused kernel is correct:

- **Coherence** — full-inference output is coherent. A greedy A/B (fused vs. the verified dequant path, temp 0) diverges only via the expected butterfly effect of a sub-noise numerical difference; both paths stay sensible for the whole generation.
- **Perplexity** (Qwen3.6-35B-A3B TQ4-opt, wikitext-2, `-ctk q8_0 -ctv turbo4 -fa on`):
  - fused **on**:  `PPL = 5.6999 ± 0.113`
  - fused **off**: `PPL = 5.7037 ± 0.113`

  Identical within error (Δ ≈ 0.004, ~30× under the error bar; fused-on is if anything marginally lower).
- **Speed** — +33% decode (9.9 → 13.2 tok/s) by staying on the fused path rather than dequant → hipBLAS, on a mixed TQ3_1S / TQ4_1S + q8_0 model.

So the disable is over-conservative for HIP. This gates it to non-HIP (`#if defined(GGML_USE_HIP)`), leaves CUDA behavior untouched, and keeps a `TQ3_FUSE_OFF=1` env escape hatch so the dequant path is one env var away if a future gfx target does trip it.
