### PR TITLE
Fix MSVC C2159: duplicate extern from GGML_API on Windows

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -181,7 +181,7 @@
 #            define GGML_API __declspec(dllimport) extern
 #        endif
 #    else
-#        define GGML_API __attribute__ ((visibility ("default")))
+#        define GGML_API __attribute__ ((visibility ("default"))) extern
 #    endif
 #else
 #    define GGML_API extern

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -19,11 +19,7 @@ extern "C" {
 // the two happen to unify is a property of the platform's symbol resolution
 // (ELF interposition may merge them; two-level-namespace and DLL targets will
 // not), which made the group-size propagation silently link-order dependent.
-#if defined(_WIN32) & defined(GGML_SHARED)
 GGML_API int turbo3_cpu_wht_group_size;
-#else
-GGML_API extern int turbo3_cpu_wht_group_size;
-#endif
 }
 
 // ggml_compute_forward_dup

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -19,7 +19,11 @@ extern "C" {
 // the two happen to unify is a property of the platform's symbol resolution
 // (ELF interposition may merge them; two-level-namespace and DLL targets will
 // not), which made the group-size propagation silently link-order dependent.
+#if defined(_WIN32) & defined(GGML_SHARED)
+GGML_API int turbo3_cpu_wht_group_size;
+#else
 GGML_API extern int turbo3_cpu_wht_group_size;
+#endif
 }
 
 // ggml_compute_forward_dup


### PR DESCRIPTION
## Overview

GGML_API already expands to '__declspec(dllexport/dllimport) extern' on Windows shared builds, so the explicit extern on turbo3_cpu_wht_group_size produced 'extern extern', which MSVC rejects. GCC's visibility-attribute expansion of GGML_API doesn't include extern, which is why this built fine on Linux. Made the extern conditional so both platforms get the semantics the original comment intended.

## Additional information

compiled and tested on Windows 11 using MSVC 19.44.35227 for x64

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)

- AI usage disclosure: fix created with information from Claude.ai online