### PR TITLE
fattn-vec: split the turbo K dot at D>128 to stop the VGPR spill (#294) — needs AMD validation

### DIFF
--- a/ggml/src/ggml-cuda/fattn-vec.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec.cuh
@@ -94,21 +94,22 @@ static __global__ void flash_attn_ext_vec(
     // nthreads_KQ=1: each thread computes a full KQ product alone — eliminates warp_reduce_sum
     // shuffle and halves KQ loop iterations. Each thread holds full Q vector in registers.
     //
-    // That last property is what makes it unaffordable at large D. Q_reg below is
-    // [ncols][(D/2)/nthreads_KQ], so with nthreads_KQ=1 the per-thread Q working set grows
-    // linearly with D: at D=256, ncols=2 it is float2[2][128] = 2 KiB per lane. Measured
-    // spills for K=turbo at D=256 (issue #294):
+    // That last property is what makes it unaffordable in general: Q_reg below is
+    // [ncols][(D/2)/nthreads_KQ], so at nthreads_KQ=1 the per-lane Q working set is the whole
+    // Q vector. Measured spill for turbo K (issue #294): ~4.3 KB/lane at ncols=2 on SM 86,
+    // 295-786 VGPRs across CDNA/RDNA2/RDNA3/RDNA4, at both hsk=128 and hsk=256.
     //
-    //     gfx908 (CDNA)    550-586 VGPR (255 + 295-330)
-    //     gfx1100 (RDNA3)  884-907 VGPR (256 + 628-651)
-    //     gfx1030 (RDNA2)  890-976 VGPR (256 + 634-720)
+    // The shared-memory LUT paths below are the exception. They compute the full D-length dot
+    // per lane with no nthreads_KQ striding and never call warp_reduce_sum, so they structurally
+    // require nthreads_KQ==1; raising it there makes every lane redundantly recompute the whole
+    // dot (correct, but measured at -12.6% / -31.1% turbo2 decode at 8K / 32K on SM 86).
+    // Those same shapes are also the ones that do not spill. So the split is gated on the LUT
+    // being inactive rather than on D: keep 1 exactly where the LUT runs, split everywhere else.
     //
-    // while the same shapes with a non-turbo K spill nothing. Above D=128 the reduction
-    // shuffle is much cheaper than the spill, so fall back to the split the other
-    // unquantized K types already use. The turbo KQ dots are templated on nthreads and
-    // stride correctly for any value, and warp_reduce_sum<nthreads_KQ> is a no-op at 1,
-    // so both settings are already supported by the kernel.
-    constexpr int nthreads_KQ = K_is_turbo ? (D > 128 ? 128 / cpy_nb : 1)
+    // Kept in sync with n_centroids_lut below; turbo4 never gets a LUT (shmem budget).
+    constexpr bool turbo_lut_active = (ncols == 1) && (D <= 256) &&
+        (type_K == GGML_TYPE_TURBO3_0 || type_K == GGML_TYPE_TURBO2_0);
+    constexpr int nthreads_KQ = K_is_turbo ? (turbo_lut_active ? 1 : 128 / cpy_nb)
                                            : (K_is_unquantized ? 128 / cpy_nb : nthreads_KQ_q);
     constexpr bool V_is_turbo = (type_V == GGML_TYPE_TURBO3_0 || type_V == GGML_TYPE_TURBO2_0 || type_V == GGML_TYPE_TURBO4_0);
     // Turbo V dequant is scalar (byte extract + LUT), not vectorized loads.
@@ -164,8 +165,8 @@ static __global__ void flash_attn_ext_vec(
     // then the hot loop does turbo_lut[d][idx] (shmem read, no multiply).
     // turbo4 excluded: 16 centroids × D exceeds shmem budget.
     // Stride = n_centroids+1 to avoid bank conflicts.
-    constexpr int n_centroids_lut = (D <= 256 && type_K == GGML_TYPE_TURBO3_0) ? 8 :
-                                    (D <= 256 && type_K == GGML_TYPE_TURBO2_0) ? 4 : 0;
+    constexpr int n_centroids_lut = !turbo_lut_active ? 0 :
+                                    (type_K == GGML_TYPE_TURBO3_0) ? 8 : 4;
     constexpr int lut_stride = n_centroids_lut > 0 ? n_centroids_lut + 1 : 1;
     __shared__ half turbo_lut[n_centroids_lut > 0 ? D : 1][lut_stride];
 

--- a/ggml/src/ggml-cuda/fattn-vec.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec.cuh
@@ -93,7 +93,23 @@ static __global__ void flash_attn_ext_vec(
     // Turbo KQ dot does byte extraction + centroid lookup + scalar mul, not vectorized f16 loads.
     // nthreads_KQ=1: each thread computes a full KQ product alone — eliminates warp_reduce_sum
     // shuffle and halves KQ loop iterations. Each thread holds full Q vector in registers.
-    constexpr int nthreads_KQ = K_is_turbo ? 1 : (K_is_unquantized ? 128 / cpy_nb : nthreads_KQ_q);
+    //
+    // That last property is what makes it unaffordable at large D. Q_reg below is
+    // [ncols][(D/2)/nthreads_KQ], so with nthreads_KQ=1 the per-thread Q working set grows
+    // linearly with D: at D=256, ncols=2 it is float2[2][128] = 2 KiB per lane. Measured
+    // spills for K=turbo at D=256 (issue #294):
+    //
+    //     gfx908 (CDNA)    550-586 VGPR (255 + 295-330)
+    //     gfx1100 (RDNA3)  884-907 VGPR (256 + 628-651)
+    //     gfx1030 (RDNA2)  890-976 VGPR (256 + 634-720)
+    //
+    // while the same shapes with a non-turbo K spill nothing. Above D=128 the reduction
+    // shuffle is much cheaper than the spill, so fall back to the split the other
+    // unquantized K types already use. The turbo KQ dots are templated on nthreads and
+    // stride correctly for any value, and warp_reduce_sum<nthreads_KQ> is a no-op at 1,
+    // so both settings are already supported by the kernel.
+    constexpr int nthreads_KQ = K_is_turbo ? (D > 128 ? 128 / cpy_nb : 1)
+                                           : (K_is_unquantized ? 128 / cpy_nb : nthreads_KQ_q);
     constexpr bool V_is_turbo = (type_V == GGML_TYPE_TURBO3_0 || type_V == GGML_TYPE_TURBO2_0 || type_V == GGML_TYPE_TURBO4_0);
     // Turbo V dequant is scalar (byte extract + LUT), not vectorized loads.
     // Halve nthreads_V to double V_cols_per_iter (process 2 V rows per loop iteration),


### PR DESCRIPTION
Proposed fix for #294, opened specifically so @jasstrong can test it. **I have no AMD hardware and cannot validate the thing this is meant to fix.** Details of exactly what is and is not verified are at the bottom, and I would rather you read that part first than trust the diff.

## The mechanism

`fattn-vec.cuh` forces the KQ dot onto a single lane for turbo K:

```cpp
constexpr int nthreads_KQ = K_is_turbo ? 1 : (K_is_unquantized ? 128 / cpy_nb : nthreads_KQ_q);
```

with the stated rationale that one lane per dot "eliminates warp_reduce_sum shuffle and halves KQ loop iterations". The cost is in the next declaration:

```cpp
float2 Q_reg[ncols][(D/2)/nthreads_KQ];
```

With `nthreads_KQ = 1` the per-lane Q working set scales linearly with D:

| shape | Q_reg per lane |
|---|---|
| D=128, ncols=2 | `float2[2][64]` = 1 KiB |
| **D=256, ncols=2** | **`float2[2][128]` = 2 KiB** |
| D=256, ncols=2, split 8 | `float2[2][16]` = 256 B |

2 KiB per lane lines up with the 2.5-2.8 KB/lane scratch you measured, and it explains the two things your data showed that a microarchitectural story would not:

- **why K=Q8_0 spills nothing at the same shape** — it takes the `nthreads_KQ_q` / `128/cpy_nb` split, so its Q_reg is a fraction of the size
- **why CDNA, RDNA2 and RDNA3 all do it** — it is a register-budget problem, not an architecture one

## The change

Above D=128, use the same split the other unquantized K types already use. Turbo K is already in `K_is_unquantized` and already uses the float Q path, so this is treating it like its neighbours rather than inventing anything.

The kernel already supports both settings, which is the part that makes this a one-liner rather than a rewrite:

- the turbo KQ dots are `template <int D, int nthreads>` and stride `k_KQ_0 += nthreads*cpy_ne`, indexing `Q_v[k_KQ_0/nthreads + k_KQ_1]`, which is exactly the packed layout `Q_reg` provides
- `warp_reduce_sum<nthreads_KQ>(sum)` is already called unconditionally and is a no-op at 1
- the write-back guard already handles any split
- the shared-memory LUT branch that does assume a single lane is gated on `ncols == 1`, and every spilling shape in your tables is `ncols = 2`, so none of them touch it

## What I verified, and what I did not

Verified on CUDA sm_121 (GB10), `-DLLAMA_FATAL_WARNINGS=ON`:

```
build                     clean, 0 errors
test-backend-ops -o FLASH_ATTN_EXT   2/2 backends passed
turbo-K FA cases          1504 OK, 0 FAIL
```

**Now the caveat that matters.** All 1504 of those cases run at `hsk=128`. My change only takes effect at `D > 128`. So that run demonstrates I did not break the existing path, and demonstrates **nothing whatsoever about the branch this PR adds**. On CUDA the suite generates no turbo FA above hsk=128 at all, so there is no configuration on my hardware that exercises the new code.

What I cannot answer, and what would make this mergeable:

1. **Does the spill actually go away** at `<256,2,K=TURBO4_0,*>` on gfx1100/gfx1030/gfx908? The arithmetic says Q_reg drops 8x, but predicted register pressure and measured register pressure are different things.
2. **What does it cost in throughput?** It buys back occupancy and pays a `warp_reduce_sum`. At 2.5 KB/lane of scratch I would expect a large net win, but that is a guess, and if it turns out slower at D=256 the change is not worth making.
3. **Is the output still correct** on AMD at D=256 with turbo K? The dot is written to be split-safe and I have read it carefully, but reading is not running.

If it helps: I closed #279 earlier today, which added exactly the `hsk=256` turbo FA coverage that would exercise this. Reviving it would give a reproducible harness case rather than relying on the metrics build. Say the word and I will reopen it.

Entirely reasonable outcomes here include "the spill moves but does not go away", "it is slower", or "the mechanism is right but the split value should be different". Any of those is more useful than this sitting unmeasured, and I would rather you shoot it down with numbers than have me merge it on arithmetic.
