### PR TITLE
ggml-cuda (HIP): ThreadLocal stream capture on RDNA2 to avoid graph-capture GPF

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4313,7 +4313,17 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend, 
             ggml_cuda_lock_counter.fetch_add(1, std::memory_order_relaxed);
         }
 
+#if defined(GGML_USE_HIP)
+        // RDNA2 (gfx1030) faults (GPF in libamdhip64) capturing in Relaxed mode when
+        // driven from a worker thread; ThreadLocal capture avoids it. Other archs keep Relaxed.
+        const hipStreamCaptureMode capture_mode =
+            GGML_CUDA_CC_IS_RDNA2(ggml_cuda_info().devices[cuda_ctx->device].cc)
+                ? hipStreamCaptureModeThreadLocal
+                : hipStreamCaptureModeRelaxed;
+        CUDA_CHECK(cudaStreamBeginCapture(cuda_ctx->stream(), capture_mode));
+#else
         CUDA_CHECK(cudaStreamBeginCapture(cuda_ctx->stream(), cudaStreamCaptureModeRelaxed));
+#endif
     }
 
     ggml_cuda_graph_evaluate_and_capture(cuda_ctx, cgraph, use_cuda_graph, cuda_graph_update_required, graph_key);


### PR DESCRIPTION
## What

On RDNA2 (gfx1030), capturing a CUDA graph with `cudaStreamCaptureModeRelaxed` **general-protection-faults inside `libamdhip64`** when the capture is driven from a worker thread (in my case the `grpc-server`'s gRPC handler thread). Switching to `hipStreamCaptureModeThreadLocal` on RDNA2 avoids the fault.

Graphs stay **enabled** on every architecture — only the RDNA2 capture *mode* changes; all other archs keep `Relaxed`, and the block is `#if defined(GGML_USE_HIP)`-guarded so the CUDA path is byte-identical.

## How it was found

V620 (gfx1030) via the `turboquant-fallback` grpc-server backend. The model-load warmup decode faulted; a core-dump backtrace pinned it to:

```
rms_norm_f32_cuda
  -> ggml_cuda_op_rms_norm
  -> ggml_cuda_graph_evaluate_and_capture
  -> GPF in libamdhip64
```

...on a `grpcpp_sync_ser` worker thread. `GGML_CUDA_DISABLE_GRAPHS=1` avoids it, confirming it's the graph capture/replay path rather than the kernels — and same-tree `llama-cli`/`llama-server` run clean because they capture from the main thread. The ThreadLocal-vs-Relaxed capture *mode* was the actual fix; graphs don't need to be disabled on RDNA2.

Tested on gfx1030 (V620) with graphs **on**: no GPF, coherent generation, ~28 tok/s serving. HIP-only change; CUDA untouched.

## Possibly related (not confirmed the same root cause)

- **#230** (RDNA2/gfx1030 custom ROCm binaries failing with "ROCm error" on recent tags) — closest match: same arch, same "ROCm error" class. *If* that report is this capture-mode fault, this should fix it — but I can't confirm it's the same bug from the info in the issue.
- **#247** (CUDA-graph segfault on GB10/sm_121, graphs-disabled passes) — same *shape* of problem (crash in `ggml_backend_cuda_graph_compute`, avoided by disabling graphs), but a different vendor/path. This HIP capture-mode change wouldn't touch the sm_121 CUDA case, so likely a separate root cause; noting it only because the symptom rhymes.
