### PR TITLE
turbo kv-cache: no_alloc guard for rotation re-upload + V-unpad head-count fix

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -2195,8 +2195,13 @@ ggml_tensor * llm_graph_context::build_attn(
         // cur is 2D: (n_embd_head * n_head, n_tokens) after build_attn_mha
         const int64_t padded_v_head = v->ne[0];
         if (padded_v_head != orig_v_head) {
-            // Reshape to 4D, extract original head_dim, reshape back to 2D
-            const int64_t n_head_v = hparams.n_head_kv(il);
+            // Reshape to 4D, extract original head_dim, reshape back to 2D.
+            // The output carries one row per QUERY head, so the head count must
+            // come from the tensor, not n_head_kv — GQA models with misaligned
+            // V head_dim (gpt-oss: 64->128, 64 q-heads over 8 kv-heads) hit an
+            // nelements mismatch otherwise.
+            GGML_ASSERT(cur->ne[0] % padded_v_head == 0);
+            const int64_t n_head_v = cur->ne[0] / padded_v_head;
             const int64_t n_tokens_cur = cur->ne[1];
             cur = ggml_reshape_3d(ctx0, cur, padded_v_head, n_head_v, n_tokens_cur);
             // ggml_view_3d to extract first orig_v_head elements per head
@@ -2311,8 +2316,11 @@ ggml_tensor * llm_graph_context::build_attn(
         const int64_t orig_v_head = v_cur->ne[0];  // original V head_dim from model
         const int64_t padded_v_head = v->ne[0];     // padded V head_dim in cache
         if (padded_v_head != orig_v_head) {
-            // cur is 2D: (padded_v_head * n_head, n_tokens) after build_attn_mha
-            const int64_t n_head_v = hparams.n_head_kv(il);
+            // cur is 2D: (padded_v_head * n_head, n_tokens) after build_attn_mha.
+            // Head count from the tensor (query heads), not n_head_kv — see the
+            // matching block in the input_attn_kv overload.
+            GGML_ASSERT(cur->ne[0] % padded_v_head == 0);
+            const int64_t n_head_v = cur->ne[0] / padded_v_head;
             const int64_t n_tokens_cur = cur->ne[1];
             cur = ggml_reshape_3d(ctx0, cur, padded_v_head, n_head_v, n_tokens_cur);
             cur = ggml_view_3d(ctx0, cur, orig_v_head, n_head_v, n_tokens_cur,
@@ -2421,7 +2429,10 @@ ggml_tensor * llm_graph_context::build_attn(
         const int64_t orig_v_head = hparams.n_embd_head_v(il);
         const int64_t padded_v_head = v->ne[0];
         if (padded_v_head != orig_v_head) {
-            const int64_t n_head_v = hparams.n_head_kv(il);
+            // Head count from the tensor (query heads), not n_head_kv — see the
+            // matching block in the input_attn_kv overload.
+            GGML_ASSERT(cur->ne[0] % padded_v_head == 0);
+            const int64_t n_head_v = cur->ne[0] / padded_v_head;
             const int64_t n_tokens_cur = cur->ne[1];
             cur = ggml_reshape_3d(ctx0, cur, padded_v_head, n_head_v, n_tokens_cur);
             cur = ggml_view_3d(ctx0, cur, orig_v_head, n_head_v, n_tokens_cur,

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -498,8 +498,12 @@ void llama_kv_cache::clear(bool data) {
             ggml_backend_buffer_clear(buf.get(), 0);
         }
 
-        // Re-initialize turbo rotation matrices after buffer clear (clear zeroes everything)
-        if (turbo_rotation != nullptr && turbo_rotation->buffer != nullptr) {
+        // Re-initialize turbo rotation matrices after buffer clear (clear zeroes everything).
+        // no_alloc guard: the fit-params dry run constructs caches whose tensors carry a
+        // measure buffer but NULL data, and llama_kv_cache_dsv4's ctor calls clear(true)
+        // before any real allocation exists — writing here would trip the tensor_set
+        // assert. Mirrors the init-path guard above.
+        if (turbo_rotation != nullptr && turbo_rotation->buffer != nullptr && !model.hparams.no_alloc) {
             #include "turbo-rotation-data.h"
             ggml_backend_tensor_set(turbo_rotation, TURBO_ROTATION_R, 0, 128 * 128 * sizeof(float));
             ggml_backend_tensor_set(turbo_rotation_inv, TURBO_ROTATION_RT, 0, 128 * 128 * sizeof(float));


### PR DESCRIPTION
Two fixes for latent bugs in the turbo KV-cache integration, both found while bringing new architectures up on turbo3 (gpt-oss head_dim 64, DeepSeek-V4 MLA). Both apply to master today; neither depends on the newer upstream base.

## 1. `kv-cache`: guard the turbo rotation re-upload against the `no_alloc` measure pass

`llama_kv_cache::clear(true)` re-uploads the WHT rotation matrices via `ggml_backend_tensor_set` after zeroing buffers. During the fit-params dry run (`hparams.no_alloc`), cache tensors carry a measure buffer with NULL data, so any cache-clearing caller added in the future crashes with `tensor not allocated` at context creation the moment a turbo type is active. The sibling init-path upload two hunks above already guards on `!model.hparams.no_alloc`; `clear()` now mirrors it. We hit this through a constructor that clears its caches eagerly (DeepSeek-V4 branch); the guard is correct on master independently of that caller.

## 2. `graph`: derive the V-unpad head count from the attention output, not `n_head_kv`

The turbo V-unpadding blocks in the `build_attn` overloads reshape the attention output by `hparams.n_head_kv(il)` — but the output carries one row per **query** head. The bug is latent on every model with a 128-aligned V head_dim (`padded == orig` skips the block) and detonates on the first misaligned-V model: gpt-oss (V 64→128, 64 q-heads over 8 kv-heads) fails `ggml_nelements` in `ggml_reshape_3d` during graph reserve, an 8x mismatch. The head count now comes from `cur->ne[0] / padded_v_head` with a divisibility assert. Same change in all three overloads that carry the block.

Verified on gfx1100 (HIP): gpt-oss-20b loads and serves with `-ctk turbo3 -ctv turbo3` after the fix (first gpt-oss to run turbo on this fork), and the muse/qwen-class models we serve daily measure unchanged (KL vs own-f16 logits, median 0.018, same-top 91.5%).

Two related notes from the same campaign, for whenever the next upstream sync lands: the DeepSeek-V4 graph in newer upstream code calls `build_attn_mha` directly and needs the turbo Q-rotation at those call sites (we carry `deepseek4: rotate Q into the turbo cache basis` and a matching lightning-indexer fix on our sync branch, measured KLD 11.25 → 0.013 against own-f16); and a heads-up that sink-heavy models (gpt-oss) turn out to be hypersensitive to *any* K-cache quantization — even q8_0-K measurably degrades them, so turbo-K on that model class is a quality cliff no encoder fix can recover; the crash fix above is still worth having so it fails soft.

Authorship disclosure: this work was done by Claude (AI) operating this fork's maintainer machine, with the campaign directed and reviewed by @apollosenvy. Co-author trailers are on every commit. If that conflicts with how you want to run this repo's PR queue, happy to have @apollosenvy re-submit under his own authorship after review, or close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UW1vMQntyeYGc1TiKKkzo2
