### PR TITLE
llama-bench: report the effective KV cache types, not the requested ones

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -581,6 +581,19 @@ extern "C" {
     LLAMA_API           llama_memory_t   llama_get_memory  (const struct llama_context * ctx);
     LLAMA_API  enum llama_pooling_type   llama_pooling_type(const struct llama_context * ctx); // TODO: rename to llama_get_pooling_type
 
+    // Return the *effective* K/V cache tensor type currently used by the context's memory.
+    // This can differ from the type_k/type_v requested via llama_context_params: some memory
+    // implementations silently rewrite the requested type at construction time (e.g. TurboQuant
+    // "auto-asymmetric" upgrades K to q8_0 for models with GQA ratio >= 6 when a symmetric turbo
+    // K+V cache was requested, to avoid catastrophic quality loss - see llama_kv_cache's ctor and
+    // its "auto-asymmetric" LLAMA_LOG_WARN).
+    //
+    // Returns GGML_TYPE_COUNT if ctx is NULL, if the memory has no K/V cache at all (e.g. pure
+    // recurrent/Mamba-style memory), or if the memory is a composite of multiple sub-caches that
+    // can legitimately hold different effective types (e.g. DSV4's raw/CSA/HCA/indexer caches).
+    LLAMA_API enum ggml_type llama_get_kv_cache_type_k(const struct llama_context * ctx);
+    LLAMA_API enum ggml_type llama_get_kv_cache_type_v(const struct llama_context * ctx);
+
     LLAMA_API const struct llama_vocab * llama_model_get_vocab(const struct llama_model * model);
     LLAMA_API enum llama_rope_type       llama_model_rope_type(const struct llama_model * model);
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -971,8 +971,10 @@ llama_memory_t llama_context::get_memory() const {
 // `want_k` selects K (true) or V (false). Returns GGML_TYPE_COUNT when the
 // memory object has no single representative K/V type (pure recurrent
 // memory, or a composite cache like DSV4 whose sub-caches - raw token
-// attention, CSA/HCA compressed blocks, lightning-indexer keys - can each
-// end up with different effective types, e.g. via TurboQuant auto-asymmetric).
+// attention, CSA/HCA compressed blocks, lightning-indexer keys - are
+// configured independently and need not share a single type. Note that
+// auto-asymmetric is not the reason here: it skips MLA architectures, DSV4
+// included, so it never rewrites these.
 static enum ggml_type llama_memory_get_kv_type(const llama_memory_i * mem, bool want_k) {
     if (!mem) {
         return GGML_TYPE_COUNT;
@@ -1008,8 +1010,8 @@ static enum ggml_type llama_memory_get_kv_type(const llama_memory_i * mem, bool 
 
     // DSV4: raw token attention (iSWA), plus CSA/HCA compressed block caches
     // and a lightning-indexer key cache. These are independent llama_kv_cache
-    // instances that can each be rewritten differently by auto-asymmetric, so
-    // there is no single type that represents "the" cache - be honest about it.
+    // instances configured independently, so there is no single type that
+    // represents "the" cache - be honest about it rather than picking one.
     if (dynamic_cast<const llama_kv_cache_dsv4 *>(mem)) {
         return GGML_TYPE_COUNT;
     }

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -7,6 +7,14 @@
 #include "llama-batch.h"
 #include "llama-io.h"
 #include "llama-memory.h"
+#include "llama-memory-recurrent.h"
+#include "llama-memory-hybrid.h"
+#include "llama-memory-hybrid-iswa.h"
+#include "llama-kv-cache.h"
+#include "llama-kv-cache-iswa.h"
+#include "llama-kv-cache-dsa.h"
+#include "llama-kv-cache-dsv4.h"
+#include "llama-kv-cache-msa.h"
 #include "llama-mmap.h"
 #include "llama-model.h"
 #include "llama-ext.h"
@@ -949,6 +957,91 @@ uint32_t llama_context::n_threads_batch() const {
 
 llama_memory_t llama_context::get_memory() const {
     return memory.get();
+}
+
+// Resolve the effective K/V cache type of a memory object.
+//
+// llama_memory_i has many concrete implementations (plain KV cache, iSWA,
+// DSA, DSV4, MSA, recurrent, hybrid, hybrid-iSWA, ...) and none of them
+// carry a common "type_k()/type_v()" accessor on the base interface, so we
+// have to downcast to figure out which one we're holding. This mirrors how
+// llama-model.cpp::create_memory() picks the concrete type in the first
+// place - see the switch over `arch` there.
+//
+// `want_k` selects K (true) or V (false). Returns GGML_TYPE_COUNT when the
+// memory object has no single representative K/V type (pure recurrent
+// memory, or a composite cache like DSV4 whose sub-caches - raw token
+// attention, CSA/HCA compressed blocks, lightning-indexer keys - can each
+// end up with different effective types, e.g. via TurboQuant auto-asymmetric).
+static enum ggml_type llama_memory_get_kv_type(const llama_memory_i * mem, bool want_k) {
+    if (!mem) {
+        return GGML_TYPE_COUNT;
+    }
+
+    // plain unified/non-SWA KV cache
+    if (const auto * kv = dynamic_cast<const llama_kv_cache *>(mem)) {
+        return want_k ? kv->type_k() : kv->type_v();
+    }
+
+    // interleaved-SWA cache: base and swa sub-caches are built with the same
+    // requested type_k/type_v and the same hparams-derived GQA ratio, so any
+    // auto-asymmetric rewrite is consistent between them - report the base.
+    if (const auto * kv = dynamic_cast<const llama_kv_cache_iswa *>(mem)) {
+        const llama_kv_cache * base = kv->get_base();
+        return base ? (want_k ? base->type_k() : base->type_v()) : GGML_TYPE_COUNT;
+    }
+
+    // DeepSeek sparse-attention (DSA): the MLA cache is the real K/V cache
+    // (MLA models are always symmetric and skip auto-asymmetric); the
+    // lightning-indexer cache is a separate, unrelated key-only cache.
+    if (const auto * kv = dynamic_cast<const llama_kv_cache_dsa *>(mem)) {
+        const llama_kv_cache * mla = kv->get_mla();
+        return mla ? (want_k ? mla->type_k() : mla->type_v()) : GGML_TYPE_COUNT;
+    }
+
+    // MiniMax-style sparse attention (MSA): report the base attention cache,
+    // not the separate indexer key cache.
+    if (const auto * kv = dynamic_cast<const llama_kv_cache_msa *>(mem)) {
+        const llama_kv_cache * base = kv->get_base();
+        return base ? (want_k ? base->type_k() : base->type_v()) : GGML_TYPE_COUNT;
+    }
+
+    // DSV4: raw token attention (iSWA), plus CSA/HCA compressed block caches
+    // and a lightning-indexer key cache. These are independent llama_kv_cache
+    // instances that can each be rewritten differently by auto-asymmetric, so
+    // there is no single type that represents "the" cache - be honest about it.
+    if (dynamic_cast<const llama_kv_cache_dsv4 *>(mem)) {
+        return GGML_TYPE_COUNT;
+    }
+
+    // hybrid (recurrent + attention): report the attention sub-cache; the
+    // recurrent sub-cache has no K/V concept (type_r/type_s instead).
+    if (const auto * hy = dynamic_cast<const llama_memory_hybrid *>(mem)) {
+        const llama_kv_cache * attn = hy->get_mem_attn();
+        return attn ? (want_k ? attn->type_k() : attn->type_v()) : GGML_TYPE_COUNT;
+    }
+
+    if (const auto * hy = dynamic_cast<const llama_memory_hybrid_iswa *>(mem)) {
+        const llama_kv_cache_iswa * attn = hy->get_mem_attn();
+        const llama_kv_cache * base = attn ? attn->get_base() : nullptr;
+        return base ? (want_k ? base->type_k() : base->type_v()) : GGML_TYPE_COUNT;
+    }
+
+    // pure recurrent memory (Mamba/RWKV-style): no K/V cache at all.
+    if (dynamic_cast<const llama_memory_recurrent *>(mem)) {
+        return GGML_TYPE_COUNT;
+    }
+
+    // unknown memory implementation - don't guess.
+    return GGML_TYPE_COUNT;
+}
+
+enum ggml_type llama_context::get_kv_type_k() const {
+    return llama_memory_get_kv_type(memory.get(), /* want_k */ true);
+}
+
+enum ggml_type llama_context::get_kv_type_v() const {
+    return llama_memory_get_kv_type(memory.get(), /* want_k */ false);
 }
 
 bool llama_context::memory_update(bool optimize) {
@@ -3961,6 +4054,22 @@ llama_memory_t llama_get_memory(const struct llama_context * ctx) {
     }
 
     return ctx->get_memory();
+}
+
+enum ggml_type llama_get_kv_cache_type_k(const struct llama_context * ctx) {
+    if (!ctx) {
+        return GGML_TYPE_COUNT;
+    }
+
+    return ctx->get_kv_type_k();
+}
+
+enum ggml_type llama_get_kv_cache_type_v(const struct llama_context * ctx) {
+    if (!ctx) {
+        return GGML_TYPE_COUNT;
+    }
+
+    return ctx->get_kv_type_v();
 }
 
 float * llama_get_embeddings_nextn(llama_context * ctx) {

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -73,6 +73,16 @@ struct llama_context {
 
     llama_memory_t get_memory() const;
 
+    // return the *effective* K/V cache tensor types currently in use by the memory object.
+    // this can differ from what was requested via llama_context_params.type_k/type_v because
+    // some memory implementations silently rewrite the requested type (e.g. TurboQuant
+    // auto-asymmetric upgrades K to q8_0 for high-GQA-ratio models - see llama_kv_cache ctor).
+    // returns GGML_TYPE_COUNT if the memory object has no single meaningful K/V type
+    // (e.g. pure recurrent memory, or a composite cache like DSV4 whose sub-caches can
+    // legitimately hold different types).
+    enum ggml_type get_kv_type_k() const;
+    enum ggml_type get_kv_type_v() const;
+
     // return true if the memory was updated
     bool memory_update(bool optimize);
 

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -1677,8 +1677,16 @@ struct test {
         cpu_mask       = inst.cpu_mask;
         cpu_strict     = inst.cpu_strict;
         poll           = inst.poll;
-        type_k         = inst.type_k;
-        type_v         = inst.type_v;
+        // report the *effective* cache types, not just what was requested: some memory
+        // implementations silently rewrite the requested type at context-creation time
+        // (e.g. TurboQuant auto-asymmetric upgrading K to q8_0 for high-GQA-ratio models
+        // - see llama_kv_cache's ctor). fall back to the requested type when the memory
+        // object has no single meaningful K/V type (llama_get_kv_cache_type_k/v returns
+        // GGML_TYPE_COUNT in that case, e.g. recurrent-only or composite DSV4 memory).
+        const ggml_type eff_type_k = llama_get_kv_cache_type_k(ctx);
+        const ggml_type eff_type_v = llama_get_kv_cache_type_v(ctx);
+        type_k         = eff_type_k != GGML_TYPE_COUNT ? eff_type_k : inst.type_k;
+        type_v         = eff_type_v != GGML_TYPE_COUNT ? eff_type_v : inst.type_v;
         n_gpu_layers   = mparams.n_gpu_layers;
         n_cpu_moe      = inst.n_cpu_moe;
         moe_cache      = inst.moe_cache;


### PR DESCRIPTION
## The problem

`llama-bench` reports the cache types you **asked for**, never the ones it actually ran.

The auto-asymmetric block in `llama_kv_cache`'s constructor rewrites `type_k` to `q8_0` when a symmetric turbo K+V cache is requested on a model with GQA ratio >= 6. That rewrite is correct and I am not touching it. The problem is that nothing outside the context could ever learn it happened. `llama-bench` builds its output row from `ggml_type_name(type_k)` taken straight off the parsed CLI params, and there was no public API to ask the context what it actually built.

So `-ctk turbo3 -ctv turbo3` on any GQA >= 6 model prints `turbo3 | turbo3` while running `q8_0` K. Qwen3.x, Llama-3 70B and friends are all in that bucket. Any turbo3 or turbo2 benchmark published from this tool on such a model is labelled as a config that did not run.

Worth being precise about the blast radius: the runtime log was always honest. `llama_kv_cache: size = ... K (q8_0), V (turbo3)` prints the post-rewrite value from the same constructor that did the rewrite. It is specifically the `llama-bench` table, the output people paste into issues and READMEs, that was wrong.

## Evidence

Qwen3.8-27B-Q4_K_M, n_head=24 / n_head_kv=4, so GQA 6:1. Metal, M5 Max.

Before, `-ctk turbo3 -ctv turbo3`:
```
| qwen35 27B Q4_K - Medium |  15.92 GiB | 27.32 B | MTL,BLAS | 6 | turbo3 | turbo3 | tg8 | 24.91 ± 0.30 |
```

After, same command:
```
| qwen35 27B Q4_K - Medium |  15.92 GiB | 27.32 B | MTL,BLAS | 6 |   q8_0 | turbo3 | tg4 | 24.33 ± 0.00 |
```

Two controls, to show the getter tracks reality rather than just always saying `q8_0`:

```
TURBO_AUTO_ASYMMETRIC=0, -ctk turbo3 -ctv turbo3  ->  turbo3 | turbo3
-ctk turbo4 -ctv turbo3 (asymmetric, gate needs type_k==type_v)  ->  turbo4 | turbo3
```

## What changed

`llama_get_kv_cache_type_k/v(ctx)` in `include/llama.h`, resolving through a downcast chain over every `llama_memory_i` implementation in the tree: plain KV cache, iSWA, DSA, MSA, hybrid, hybrid-iSWA. All eight concrete classes derive directly from `llama_memory_i` with no inheritance between them, so the cast order cannot shadow a branch.

Returns `GGML_TYPE_COUNT`, and `llama-bench` falls back to the requested type, for the two cases where no single answer is honest: pure recurrent memory, which has no K/V concept, and DSV4, whose raw/CSA/HCA/indexer sub-caches are configured independently.

## Not covered

The `GGML_TYPE_COUNT` fallbacks for DSV4 and recurrent-only memory are verified by code reading only. Neither was loaded and benched, so if someone has a Mamba-only or DeepSeek-V4 GGUF handy a quick `llama-bench` run against this branch would close that gap. Everything else above was run on hardware.
