### PR TITLE
moe-cache: fix pre-existing HIP nodiscard errors blocking the -Werror gate

### DIFF
--- a/ggml/src/ggml-cuda/moe-cache.cu
+++ b/ggml/src/ggml-cuda/moe-cache.cu
@@ -810,7 +810,7 @@ static bool moe_cache_grow_device(
         const size_t old_capacity = capacity;
         if (!moe_cache_cuda_ok(
                     device, cudaFree(*pointer), "scratch replacement free", true)) {
-            cudaFree(fresh);
+            (void)cudaFree(fresh);
             return false;
         }
         moe_cache_budget_reallocation(device, old_capacity, requested);
@@ -1010,7 +1010,7 @@ static bool moe_cache_grow_host(
         return false;
     }
     if (*pointer) {
-        cudaFreeHost(*pointer);
+        (void)cudaFreeHost(*pointer);
     }
     *pointer = fresh;
     capacity = requested;
@@ -1069,7 +1069,7 @@ static void moe_cache_worker(moe_cache_session * session, moe_cache_device * dev
             cudaError_t alloc_error = cudaMallocHost((void **)&fresh, job.bytes);
             if (alloc_error == cudaSuccess) {
                 if (stage) {
-                    cudaFreeHost(stage);
+                    (void)cudaFreeHost(stage);
                 }
                 stage = fresh;
                 stage_capacity = job.bytes;
@@ -1143,11 +1143,11 @@ static void moe_cache_worker(moe_cache_session * session, moe_cache_device * dev
     }
 
     if (stream) {
-        cudaStreamSynchronize(stream);
-        cudaStreamDestroy(stream);
+        (void)cudaStreamSynchronize(stream);
+        (void)cudaStreamDestroy(stream);
     }
     if (stage) {
-        cudaFreeHost(stage);
+        (void)cudaFreeHost(stage);
     }
 }
 
@@ -1264,7 +1264,7 @@ static bool moe_cache_allocate_pool(
 
     std::unique_ptr<moe_cache_pool> pool(new (std::nothrow) moe_cache_pool());
     if (!pool) {
-        cudaFree(slab);
+        (void)cudaFree(slab);
         moe_cache_budget_allocation(device, allocated, false);
         return false;
     }
@@ -1282,7 +1282,7 @@ static bool moe_cache_allocate_pool(
         }
         device.pools.push_back(std::move(pool));
     } catch (...) {
-        cudaFree(slab);
+        (void)cudaFree(slab);
         moe_cache_budget_allocation(device, allocated, false);
         return false;
     }
@@ -1291,7 +1291,7 @@ static bool moe_cache_allocate_pool(
     device.allocated_bytes += allocated;
 
     if (!moe_cache_start_worker(session, device)) {
-        cudaFree(device.pools.back()->slab);
+        (void)cudaFree(device.pools.back()->slab);
         moe_cache_budget_allocation(device, allocated, false);
         device.pools.back()->slab = nullptr;
         device.pools.pop_back();
@@ -1646,41 +1646,41 @@ static void moe_cache_cancel_queue_locked(
 static void moe_cache_free_device(moe_cache_device & device) {
     ggml_cuda_set_device(device.logical);
     if (device.compute_stream) {
-        cudaStreamSynchronize(device.compute_stream);
+        (void)cudaStreamSynchronize(device.compute_stream);
     }
     for (auto & pool_ptr : device.pools) {
         if (pool_ptr->slab) {
-            cudaFree(pool_ptr->slab);
+            (void)cudaFree(pool_ptr->slab);
             moe_cache_budget_allocation(
                     device, (size_t)pool_ptr->n_slots * pool_ptr->expert_size, false);
             pool_ptr->slab = nullptr;
         }
     }
     if (device.d_input) {
-        cudaFree(device.d_input);
+        (void)cudaFree(device.d_input);
         moe_cache_budget_allocation(device, device.d_input_cap, false);
         device.d_input = nullptr;
     }
     if (device.d_act_q8) {
-        cudaFree(device.d_act_q8);
+        (void)cudaFree(device.d_act_q8);
         moe_cache_budget_allocation(device, device.act_q8_cap, false);
         device.d_act_q8 = nullptr;
     }
     if (device.d_out) {
-        cudaFree(device.d_out);
+        (void)cudaFree(device.d_out);
         moe_cache_budget_allocation(device, device.d_out_cap, false);
         device.d_out = nullptr;
     }
     if (device.h_input) {
-        cudaFreeHost(device.h_input);
+        (void)cudaFreeHost(device.h_input);
         device.h_input = nullptr;
     }
     if (device.h_out) {
-        cudaFreeHost(device.h_out);
+        (void)cudaFreeHost(device.h_out);
         device.h_out = nullptr;
     }
     if (device.compute_stream) {
-        cudaStreamDestroy(device.compute_stream);
+        (void)cudaStreamDestroy(device.compute_stream);
         device.compute_stream = nullptr;
     }
     device.pools.clear();
@@ -2531,7 +2531,7 @@ static int moe_cache_dispatch_internal(
     }
 
     if (!ok) {
-        cudaStreamSynchronize(device.compute_stream);
+        (void)cudaStreamSynchronize(device.compute_stream);
         std::lock_guard<std::mutex> lock(session.mu);
         device.dispatch_failures++;
         return 0;
@@ -2586,7 +2586,7 @@ static int moe_cache_collect(
                 device, cudaStreamSynchronize(device.compute_stream),
                 "output synchronization", true);
     } else {
-        cudaStreamSynchronize(device.compute_stream);
+        (void)cudaStreamSynchronize(device.compute_stream);
     }
     node->dispatched = false;
 


### PR DESCRIPTION
## What

`ubuntu-22-hip-quality-check` builds with `-Werror` and fails on 19 discarded-return CUDA runtime calls in `moe-cache.cu`:

```
error: ignoring return value of type 'hipError_t' declared with 'nodiscard' attribute [-Werror,-Wunused-value]
```

HIP declares `hipError_t` as `[[nodiscard]]`. CUDA does not mark `cudaError_t` that way, so these compile clean under nvcc and hard-error under HIP. Nothing here is new. The gate has been red on every PR in the repo for this reason, and contributors keep being asked to look at a failure that is not theirs.

I confirmed it is pre-existing rather than introduced by any open PR. Against #300, which touches this file, the reported line numbers are exactly the base-branch sites plus that PR's insertions:

```
base 813,1013,1072,1146,1147,1150,1267,1285,1294  ->  CI 824,1024,1083,1157,1158,1161,1278,1296,1305   (+11)
base 1649,1653,1660,1665,1670,1675                ->  CI 1661,1665,1672,1677,1682,1687                 (+12)
```

## The fix

`(void)` on all 19, which is the idiom this file already uses. There are six pre-existing `(void)cudaGetLastError();` sites in `moe-cache.cu` (lines 771, 796, 1062, 1077, 1254, 2495), so this is matching local convention rather than introducing one.

Deliberately **not** `CUDA_CHECK`. That macro calls `ggml_cuda_error`, which is `[[noreturn]]` and aborts. All 19 sites are teardown, rollback, or best-effort drain, and eight of them are inside `moe_cache_free_device`, which is called from `moe_cache_session_destroy`. Converting those to `CUDA_CHECK` would introduce aborts during shutdown, which is a behavior change and a worse one. The file's own `moe_cache_cuda_ok(...)` soft-check helper was also considered and rejected for the same reason: none of these sites were checked before, and making them checked is a separate decision from making them compile.

Every hunk is a single-statement `(void)` wrap. No reordering, no control flow change, no statements added or removed. This is compile-time only and CUDA behavior is bit-for-bit identical.

## Verification

I have no HIP or CUDA toolchain on this machine, so **the HIP build itself was not run locally.** This needs the CI job to confirm green. Being explicit about that rather than implying it was tested.

What I did verify locally, since the whole fix rests on one assumption:

```cpp
enum [[nodiscard]] fakeError_t { ok = 0 };
fakeError_t doThing();
void bare()   { doThing(); }        // error
void voided() { (void)doThing(); }  // clean
```

```
$ clang++ -std=c++17 -Wall -Wunused-value -Wunused-result -Werror -fsyntax-only
nd.cpp:3:17: error: ignoring return value of type 'fakeError_t' declared with 'nodiscard' attribute [-Werror,-Wunused-value]
```

That reproduces the CI diagnostic exactly, same wording and same `-Wunused-value` flag, and the `(void)` form compiles clean under the same flags. So the suppression mechanism is confirmed even though the real HIP compile is not.

Also swept the file for all 47 `cuda*(` occurrences and classified each as assigned, wrapped in `moe_cache_cuda_ok`, already `(void)`, or bare. The 19 bare ones are the ones changed here, and none remain.
