### PR TITLE
graph: derive V-unpad head count from the attention output tensor (hardening)

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -2889,11 +2889,15 @@ ggml_tensor * llm_graph_context::build_attn(
         if (padded_v_head != orig_v_head) {
             // Reshape to 4D, extract original head_dim, reshape back to 2D
             // Fix #78 (bingh0): cur shape post-MHA is (n_embd_head * n_head, n_tokens),
-            // not (n_embd_head * n_head_kv, n_tokens). Reshape needs n_head
-            // (Q-head count) so GQA models with n_head != n_head_kv (e.g.
-            // Qwen2.5-0.5B head_dim=64 padded → 128) don't fail the element
-            // count check in ggml_reshape_3d.
-            const int64_t n_head_v = hparams.n_head(il);
+            // not (n_embd_head * n_head_kv, n_tokens). The output carries one
+            // row per Q head, so derive the head count from the tensor itself:
+            // hparams.n_head(il) is correct but is a second source of truth
+            // that has to agree with cur — ne[0]/padded_v_head cannot disagree,
+            // and the assert turns a silent nelements mismatch (observed live:
+            // gpt-oss 64->128 V pad, 64q/8kv, abort in ggml_reshape_3d during
+            // graph reserve) into a loud failure at the exact site.
+            GGML_ASSERT(cur->ne[0] % padded_v_head == 0);
+            const int64_t n_head_v = cur->ne[0] / padded_v_head;
             const int64_t n_tokens_cur = cur->ne[1];
             cur = ggml_reshape_3d(ctx0, cur, padded_v_head, n_head_v, n_tokens_cur);
             // ggml_view_3d to extract first orig_v_head elements per head
@@ -3016,11 +3020,15 @@ ggml_tensor * llm_graph_context::build_attn(
         if (padded_v_head != orig_v_head) {
             // cur is 2D: (padded_v_head * n_head, n_tokens) after build_attn_mha
             // Fix #78 (bingh0): cur shape post-MHA is (n_embd_head * n_head, n_tokens),
-            // not (n_embd_head * n_head_kv, n_tokens). Reshape needs n_head
-            // (Q-head count) so GQA models with n_head != n_head_kv (e.g.
-            // Qwen2.5-0.5B head_dim=64 padded → 128) don't fail the element
-            // count check in ggml_reshape_3d.
-            const int64_t n_head_v = hparams.n_head(il);
+            // not (n_embd_head * n_head_kv, n_tokens). The output carries one
+            // row per Q head, so derive the head count from the tensor itself:
+            // hparams.n_head(il) is correct but is a second source of truth
+            // that has to agree with cur — ne[0]/padded_v_head cannot disagree,
+            // and the assert turns a silent nelements mismatch (observed live:
+            // gpt-oss 64->128 V pad, 64q/8kv, abort in ggml_reshape_3d during
+            // graph reserve) into a loud failure at the exact site.
+            GGML_ASSERT(cur->ne[0] % padded_v_head == 0);
+            const int64_t n_head_v = cur->ne[0] / padded_v_head;
             const int64_t n_tokens_cur = cur->ne[1];
             cur = ggml_reshape_3d(ctx0, cur, padded_v_head, n_head_v, n_tokens_cur);
             cur = ggml_view_3d(ctx0, cur, orig_v_head, n_head_v, n_tokens_cur,
@@ -3212,11 +3220,15 @@ ggml_tensor * llm_graph_context::build_attn(
         const int64_t padded_v_head = v->ne[0];
         if (padded_v_head != orig_v_head) {
             // Fix #78 (bingh0): cur shape post-MHA is (n_embd_head * n_head, n_tokens),
-            // not (n_embd_head * n_head_kv, n_tokens). Reshape needs n_head
-            // (Q-head count) so GQA models with n_head != n_head_kv (e.g.
-            // Qwen2.5-0.5B head_dim=64 padded → 128) don't fail the element
-            // count check in ggml_reshape_3d.
-            const int64_t n_head_v = hparams.n_head(il);
+            // not (n_embd_head * n_head_kv, n_tokens). The output carries one
+            // row per Q head, so derive the head count from the tensor itself:
+            // hparams.n_head(il) is correct but is a second source of truth
+            // that has to agree with cur — ne[0]/padded_v_head cannot disagree,
+            // and the assert turns a silent nelements mismatch (observed live:
+            // gpt-oss 64->128 V pad, 64q/8kv, abort in ggml_reshape_3d during
+            // graph reserve) into a loud failure at the exact site.
+            GGML_ASSERT(cur->ne[0] % padded_v_head == 0);
+            const int64_t n_head_v = cur->ne[0] / padded_v_head;
             const int64_t n_tokens_cur = cur->ne[1];
             cur = ggml_reshape_3d(ctx0, cur, padded_v_head, n_head_v, n_tokens_cur);
             cur = ggml_view_3d(ctx0, cur, orig_v_head, n_head_v, n_tokens_cur,


### PR DESCRIPTION
Retarget of the head-count half of #299 at the integration branch, per review there — as hardening on top of the `hparams.n_head(il)` fix the branch already carries.

Rationale as discussed: `hparams.n_head(il)` is correct but is a second source of truth that has to agree with the tensor. `cur->ne[0] / padded_v_head` cannot disagree, and the divisibility assert turns a silent nelements mismatch into a loud failure at the exact site rather than a reshape abort downstream. Same change at all three V-unpad blocks.

To answer the runtime question from #299: yes, hit live, not found by reading. gpt-oss-20b (V head_dim 64 padded to 128, 64 query heads over 8 KV heads) aborts at graph reserve on any turbo K/V type without a head-count fix. Repro is CPU-only and takes seconds past model load:

```
llama-server -m gpt-oss-20b.gguf -ngl 0 -fa on -ctk turbo3 -ctv turbo3 -c 8192
# /ggml/src/ggml.c: GGML_ASSERT(ggml_nelements(a) == ne0*ne1*ne2) failed  (ggml_reshape_3d,
#  via llm_graph_context::build_attn(llm_graph_input_attn_kv_iswa*, ...) during graph_reserve)
```

The GGUF is the stock `unsloth/gpt-oss-20b` conversion (`gpt-oss-20b.gguf`). Reproduced identically on gfx1100/HIP and CPU-only, so it needs no AMD hardware to see. Fair warning if you go past the crash into quality: with the head-count fixed, gpt-oss *serves* on turbo-K but measures badly against its own f16 logits (median KLD ~0.7, top-token agreement ~35% on our KL harness) — its sink-style K rows carry outliers to ~23x typical magnitude and even q8_0-K measurably degrades it. We concluded that's a model-class sensitivity, not an encoder bug (decode fidelity measures at spec), and serve it f16-K. Mentioning it so the padding path's first real exerciser doesn't get read as a turbo regression.

Build-verified on this branch (default config, CPU). One note from the verify: `-DLLAMA_BUILD_SERVER=OFF -DLLAMA_BUILD_EXAMPLES=OFF` breaks the `llama` app link on this branch (it links `-lllama-server-impl`/`-lllama-cli-impl` unconditionally) — unrelated to this change, flagging in passing.

Authorship as in #299: Claude (AI) operating apollosenvy's machine, campaign directed and reviewed by him; trailers on the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UW1vMQntyeYGc1TiKKkzo2
