### PR TITLE
server : forward Anthropic output_config.effort to Jinja templates

### DIFF
--- a/tools/server/server-chat.cpp
+++ b/tools/server/server-chat.cpp
@@ -592,6 +592,17 @@ json server_chat_convert_anthropic_to_oai(const json & body) {
         }
     }
 
+    // Handle Anthropic-specific output_config param
+    if (body.contains("output_config") && body.at("output_config").is_object()) {
+        const json & output_config = body.at("output_config");
+        if (output_config.contains("effort") && output_config.at("effort").is_string()) {
+            if (!oai_body.contains("chat_template_kwargs")) {
+                oai_body["chat_template_kwargs"] = json::object();
+            }
+            oai_body["chat_template_kwargs"]["reasoning_effort"] = output_config.at("effort");
+        }
+    }
+
     // Handle Anthropic-specific metadata param
     if (body.contains("metadata")) {
         json metadata = json_value(body, "metadata", json::object());

--- a/tools/server/tests/unit/test_compat_anthropic.py
+++ b/tools/server/tests/unit/test_compat_anthropic.py
@@ -1088,3 +1088,120 @@ def test_anthropic_thinking_with_reasoning_model(stream):
         # should also have text block
         text_blocks = [b for b in content if b.get("type") == "text"]
         assert len(text_blocks) > 0, "Should have text content block"
+
+
+# Output config / reasoning effort tests
+
+def test_anthropic_output_config_effort():
+    """Test that output_config.effort is accepted"""
+    server.start()
+
+    res = server.make_request("POST", "/v1/messages", data={
+        "model": "test",
+        "max_tokens": 50,
+        "output_config": {"effort": "low"},
+        "messages": [
+            {"role": "user", "content": "Hello"}
+        ]
+    })
+
+    assert res.status_code == 200
+    assert res.body["type"] == "message"
+
+
+def test_anthropic_output_config_effort_xhigh():
+    """Test that non-standard effort values are forwarded unchanged"""
+    server.start()
+
+    res = server.make_request("POST", "/v1/messages", data={
+        "model": "test",
+        "max_tokens": 50,
+        "output_config": {"effort": "xhigh"},
+        "messages": [
+            {"role": "user", "content": "Hello"}
+        ]
+    })
+
+    assert res.status_code == 200
+    assert res.body["type"] == "message"
+
+
+def test_anthropic_output_config_effort_preserves_kwargs():
+    """Test that existing chat_template_kwargs are preserved alongside output_config.effort"""
+    server.start()
+
+    res = server.make_request("POST", "/v1/messages", data={
+        "model": "test",
+        "max_tokens": 50,
+        "output_config": {"effort": "high"},
+        "chat_template_kwargs": {"some_key": "some_value"},
+        "messages": [
+            {"role": "user", "content": "Hello"}
+        ]
+    })
+
+    assert res.status_code == 200
+    assert res.body["type"] == "message"
+
+
+def test_anthropic_output_config_effort_reaches_template():
+    """Test that output_config.effort reaches the Jinja template as reasoning_effort."""
+    global server
+    server.jinja = True
+    server.chat_template_file = '../../../models/templates/upstage-Solar-Open-100B.jinja'
+    server.start()
+
+    res_without = server.make_request("POST", "/v1/messages/count_tokens", data={
+        "model": "test",
+        "messages": [
+            {"role": "user", "content": "Hello"}
+        ]
+    })
+    assert res_without.status_code == 200
+
+    res_with = server.make_request("POST", "/v1/messages/count_tokens", data={
+        "model": "test",
+        "output_config": {"effort": "low"},
+        "messages": [
+            {"role": "user", "content": "Hello"}
+        ]
+    })
+    assert res_with.status_code == 200
+
+    # Solar template adds an empty think block when reasoning_effort is "low",
+    # so the token count should increase
+    assert res_with.body["input_tokens"] > res_without.body["input_tokens"], \
+        f"Expected more tokens with effort=low ({res_with.body['input_tokens']}) than without ({res_without.body['input_tokens']})"
+
+
+def test_anthropic_output_config_effort_precedence():
+    """Test that output_config.effort takes precedence over chat_template_kwargs.reasoning_effort."""
+    global server
+    server.jinja = True
+    server.chat_template_file = '../../../models/templates/upstage-Solar-Open-100B.jinja'
+    server.start()
+
+    # Baseline: reasoning_effort="high" via chat_template_kwargs (no extra think block)
+    res_high = server.make_request("POST", "/v1/messages/count_tokens", data={
+        "model": "test",
+        "chat_template_kwargs": {"reasoning_effort": "high"},
+        "messages": [
+            {"role": "user", "content": "Hello"}
+        ]
+    })
+    assert res_high.status_code == 200
+
+    # output_config.effort="low" should override chat_template_kwargs
+    res_override = server.make_request("POST", "/v1/messages/count_tokens", data={
+        "model": "test",
+        "output_config": {"effort": "low"},
+        "chat_template_kwargs": {"reasoning_effort": "high"},
+        "messages": [
+            {"role": "user", "content": "Hello"}
+        ]
+    })
+    assert res_override.status_code == 200
+
+    # If output_config.effort takes precedence, "low" adds the extra think block
+    assert res_override.body["input_tokens"] > res_high.body["input_tokens"], \
+        f"Expected output_config.effort='low' to override chat_template_kwargs.reasoning_effort='high'"


### PR DESCRIPTION
## Overview

Forward Anthropic-compatible `output_config.effort` to Jinja chat templates as `reasoning_effort`.

Currently, requests made through the Anthropic-compatible API can specify reasoning effort via:

```json
{
  "output_config": {
    "effort": "low"
  }
}
```

but this value is not propagated to the chat template. As a result, templates that support different reasoning effort levels cannot adjust their behavior based on the request.

This PR maps:

```text
output_config.effort
```

to:

```text
chat_template_kwargs.reasoning_effort
```

during Anthropic-to-OpenAI request conversion.

The value is forwarded unchanged and no model-specific reasoning logic is introduced. Existing `chat_template_kwargs` are preserved, while an explicitly provided `output_config.effort` takes precedence over an existing `reasoning_effort` value.

Tests cover:

* forwarding `output_config.effort`
* different effort values such as `low` and `xhigh`
* preserving unrelated `chat_template_kwargs`
* requests without `output_config.effort`
* precedence when `reasoning_effort` is already present in `chat_template_kwargs`

## Additional information

I also manually verified the change end-to-end with Claude Code using:

* Model: `Qwen3.8-27B-UD-Q4_K_XL.gguf`
* Chat template: `froggeric/Qwen-Fixed-Chat-Templates`
* Backend: `llama-server`

The chat template reads `reasoning_effort`, making it possible to verify that Anthropic `output_config.effort` is propagated through the request conversion and reaches the Jinja template.

I used the same probability reasoning problem for all three effort levels. All three runs produced the correct final answer, while showing different reasoning behavior and resource usage:

| `reasoning_effort` | Wall time | Total tokens |
| ------------------ | --------: | -----------: |
| `low`              |    1m 05s |         2528 |
| `medium`           |    1m 35s |         2719 |
| `xhigh`            |    2m 08s |         4391 |

The `low` response reached the correct result with relatively concise reasoning. The `xhigh` response used substantially more time and tokens and found an additional structural simplification of the reporting protocol.

This is intended only as an end-to-end functional sanity check, not as a performance benchmark. It uses a single prompt, and the current server output reports total tokens rather than reasoning tokens separately.



## Requirements

* I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
* AI usage disclosure: YES - Claude Code was used to assist with the implementation and test development. I reviewed the changes and manually tested the resulting behavior with Claude Code using different reasoning effort levels.
