### PR TITLE
cuda: HIP graph-capture fixes + device-routed TQ MoE matvec (AMD + NVIDIA, ~2x TQ decode)

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1427,6 +1427,14 @@ struct ggml_backend_cuda_context {
 
     int curr_stream_no = 0;
 
+    // [TAG_FA_F16_CUDA_GRAPHS] Set once per compute call in ggml_backend_cuda_graph_compute: true
+    // when the current cgraph is graph-enabled AND graph-compatible (i.e. it will be captured).
+    // On HIP the flash-attention launcher reads this to place its f16 KV-dequant temp buffers in the
+    // capture-safe memory pool instead of raw cudaMalloc/cudaFree, which are illegal while a CUDA
+    // graph is being captured. Left false for graph-incompatible graphs so those keep the raw
+    // release-after-use path (avoids the legacy pool retaining the temp; ref llama.cpp #22107).
+    bool fa_f16_use_pool = false;
+
 #ifdef USE_CUDA_GRAPH
     // Map from first_node_ptr to cuda_graph - allows multiple graphs per context
     // when the computation is split across CPU/GPU (e.g., with --n-cpu-moe)

--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -1390,34 +1390,51 @@ void launch_fattn(
     const int nsm = ggml_cuda_info().devices[id].nsm;
 
 #ifdef GGML_USE_HIP
-    // HIP/ROCm: bypass the memory pool for f16 temp buffers.
-    // The legacy pool (ggml_cuda_pool_leg) retains peak-sized allocations permanently
-    // because free() stores buffers for reuse rather than releasing them.
-    // On HIP without VMM support (RDNA 3/4), this means the f16 dequant temp buffers
-    // for quantized KV stay allocated after use, consuming more VRAM than the KV
-    // compression saves — causing OOM before f16 at equivalent context lengths.
-    // Using raw cudaMalloc/cudaFree ensures memory is released after the kernel completes.
+    // HIP/ROCm: allocate the f16 KV-dequant temp buffers in a CUDA-graph-capture-aware way.
+    //
+    // Default (no graph capture): bypass the memory pool and use raw cudaMalloc/cudaFree so the
+    // temp buffer (up to ~2x the quantized KV size) is released the moment the kernel completes.
+    // The legacy pool (ggml_cuda_pool_leg) retains peak-sized allocations permanently on HIP
+    // without VMM support (RDNA 3/4) because free() stores buffers for reuse rather than releasing
+    // them; pooling this temp would negate the KV compression and OOM at long context.
     // Ref: https://github.com/ggml-org/llama.cpp/issues/22107
+    //
+    // While a CUDA graph is being captured, cudaMalloc/cudaFree/cudaStreamSynchronize are all
+    // illegal. When the current graph will be captured (ctx.fa_f16_use_pool, set for graph-enabled
+    // and graph-compatible cgraphs), use the pool instead: capture only begins once the shape is
+    // stable (see ggml_cuda_graph_update_required), so this temp is a single fixed-size buffer that
+    // the pool allocates during the eager warmup passes and then reuses across every graph replay
+    // — exactly the capture-safe path the non-HIP build always takes. Holding it is required anyway
+    // for replay to reference a stable buffer address.
+    const bool fa_f16_use_pool = ctx.fa_f16_use_pool;
     struct hip_f16_alloc {
         half * ptr = nullptr;
         cudaStream_t stream;
-        hip_f16_alloc(cudaStream_t s) : stream(s) {}
+        bool use_pool;
+        ggml_cuda_pool_alloc<half> pool_alloc;
+        hip_f16_alloc(cudaStream_t s, ggml_cuda_pool & p, bool use_pool)
+            : stream(s), use_pool(use_pool), pool_alloc(p) {}
         hip_f16_alloc(const hip_f16_alloc &) = delete;
         hip_f16_alloc & operator=(const hip_f16_alloc &) = delete;
         ~hip_f16_alloc() {
-            if (ptr) {
-                // Destructor: cannot propagate errors, and under HIP both calls are
-                // [[nodiscard]], which is fatal under -Werror. Discard explicitly.
-                (void) cudaStreamSynchronize(stream);
-                (void) cudaFree(ptr);
+            if (use_pool || ptr == nullptr) {
+                return;  // pool_alloc releases back to the pool; nothing to do if unused
             }
+            // Destructor: cannot propagate errors, and under HIP both calls are
+            // [[nodiscard]], which is fatal under -Werror. Discard explicitly.
+            (void) cudaStreamSynchronize(stream);
+            (void) cudaFree(ptr);
         }
         void alloc(size_t nelements) {
-            CUDA_CHECK(cudaMalloc(&ptr, nelements * sizeof(half)));
+            if (use_pool) {
+                ptr = pool_alloc.alloc(nelements);
+            } else {
+                CUDA_CHECK(cudaMalloc(&ptr, nelements * sizeof(half)));
+            }
         }
     };
-    hip_f16_alloc K_f16(main_stream);
-    hip_f16_alloc V_f16(main_stream);
+    hip_f16_alloc K_f16(main_stream, pool, fa_f16_use_pool);
+    hip_f16_alloc V_f16(main_stream, pool, fa_f16_use_pool);
 #else
     ggml_cuda_pool_alloc<half>   K_f16(pool);
     ggml_cuda_pool_alloc<half>   V_f16(pool);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2171,11 +2171,17 @@ static void ggml_cuda_mul_mat_id(ggml_backend_cuda_context & ctx, ggml_tensor * 
     const int cc = ggml_cuda_info().devices[ggml_cuda_get_device()].cc;
 
     // [TAG_MUL_MAT_ID_CUDA_GRAPHS]
-    // TQ weight types use dequant-to-f16 cuBLAS path only (no mmvq/mmq kernels)
+    // TQ weights: small batch uses the capture-safe device-routed matvec (ggml_cuda_mul_mat_id_tq);
+    // large batch falls through to the dequant-to-f16 cuBLAS path, which synchronizes the stream.
     const bool is_tq_weight_id = (src0->type == GGML_TYPE_TQ4_1S || src0->type == GGML_TYPE_TQ3_1S);
     if (src1->type == GGML_TYPE_F32 && dst->type == GGML_TYPE_F32) {
         static_assert(MMVQ_MAX_BATCH_SIZE == MMVF_MAX_BATCH_SIZE);
         if (ne2 <= MMVQ_MAX_BATCH_SIZE) {
+            if (is_tq_weight_id && ggml_is_contiguous(src1)) {
+                // Device-side expert routing: no host sync, so the whole decode step is graph-capturable.
+                ggml_cuda_mul_mat_id_tq(ctx, src0, src1, ids, dst);
+                return;
+            }
             if (ggml_is_quantized(src0->type) && !is_tq_weight_id) {
                 const int mmvq_mmid_max = get_mmvq_mmid_max_batch(src0->type, cc);
                 if (ne2 <= mmvq_mmid_max) {
@@ -2824,8 +2830,15 @@ static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
         if (node->op == GGML_OP_MUL_MAT_ID) {
             const int cc = ggml_cuda_info().devices[ggml_cuda_get_device()].cc;
             const int mmvq_mmid_max = get_mmvq_mmid_max_batch(node->src[0]->type, cc);
-            if (!ggml_is_quantized(node->src[0]->type) || is_tq_w || node->ne[2] > mmvq_mmid_max) {
-                // under these conditions, the mul_mat_id operation will need to synchronize the stream, so we cannot use CUDA graphs
+            // The mul_mat_id operation synchronizes the stream (forbidding graph capture) unless it
+            // takes a device-routed path. TQ weights now have a capture-safe device-routed matvec at
+            // small batch with contiguous src1 (ggml_cuda_mul_mat_id_tq); only the large-batch cuBLAS
+            // fallback still synchronizes. Other quantized weights use mmvq up to mmvq_mmid_max.
+            // Keep this condition in sync with the dispatch in ggml_cuda_mul_mat_id.
+            const bool needs_sync = is_tq_w
+                ? (node->ne[2] > MMVQ_MAX_BATCH_SIZE || !ggml_is_contiguous(node->src[1]))
+                : (!ggml_is_quantized(node->src[0]->type) || node->ne[2] > mmvq_mmid_max);
+            if (needs_sync) {
                 // TODO: figure out a way to enable for larger batch sizes, without hurting performance
                 // ref: https://github.com/ggml-org/llama.cpp/pull/18958
                 use_cuda_graph = false;

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4425,6 +4425,11 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend, 
     bool cuda_graph_update_required = false;
     const void * graph_key = nullptr;
 
+    // [TAG_FA_F16_CUDA_GRAPHS] default: no graph will be captured for this cgraph, so HIP flash-
+    // attention keeps its raw (release-after-use) f16 temp path. Set true below only when the graph
+    // is enabled and compatible, i.e. it will actually be captured.
+    cuda_ctx->fa_f16_use_pool = false;
+
 #ifdef USE_CUDA_GRAPH
     graph_key = ggml_cuda_graph_get_key(cgraph);
 
@@ -4433,6 +4438,9 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend, 
     ggml_cuda_graph * graph = cuda_ctx->cuda_graph(graph_key);
     if (graph->is_enabled()) {
         const bool graph_compatible = ggml_cuda_graph_check_compability(cgraph);
+        // [TAG_FA_F16_CUDA_GRAPHS] this graph will be captured -> HIP flash-attention must use the
+        // capture-safe pool for its f16 KV-dequant temp buffers instead of raw cudaMalloc/cudaFree.
+        cuda_ctx->fa_f16_use_pool = graph_compatible;
         if (graph_compatible) {
             const bool properties_changed = ggml_cuda_graph_update_required(cuda_ctx, cgraph);
 

--- a/ggml/src/ggml-cuda/mmvq-tq.cu
+++ b/ggml/src/ggml-cuda/mmvq-tq.cu
@@ -371,6 +371,194 @@ static void launch_tq3_1s_multi(
         src0_d, act_buf, dst_d, ncols_x, nrows_x, stride_col_y, stride_col_dst);
 }
 
+// ============================================================================
+// MoE (MUL_MAT_ID) matvec: capture-safe device-side expert routing.
+//
+// Replaces the generic ggml_cuda_mul_mat_id host-sync fallback for TQ weights at
+// small batch. That fallback copies `ids` to the host, sorts tokens per expert on
+// the CPU, copies back, and launches a data-dependent per-expert cuBLAS loop — two
+// cudaStreamSynchronize per layer, and illegal to record into a CUDA graph.
+//
+// Here each block instead reads ids[sample*ids_stride + expert_slot] ON-DEVICE to
+// select its expert's weight channel (mirrors the stock mmvq id path), so the launch
+// is a fixed grid with no host round-trip: fully graph-capturable, and cheaper.
+//   grid.x = row blocks (output neurons)   grid.y = expert slot (ne1 = n_expert_used)
+//   grid.z = token/sample (ne2)            one dot product per (row, expert_slot, sample)
+// ============================================================================
+
+static __global__ void mul_mat_tq3_1s_moe(
+        const void    * __restrict__ vx,       // all experts, base pointer
+        const float   * __restrict__ vy_rot,   // pre-rotated activations
+        float         * __restrict__ dst,
+        const int32_t * __restrict__ ids,
+        const int     ncols_x,
+        const int     nrows_x,
+        const int64_t nb_expert,               // byte stride between experts in vx
+        const int     ids_stride,              // element stride between samples in ids
+        const int     nchannels_y,             // ne11
+        const int64_t stride_channel_y,        // float elements to next y-channel in vy_rot
+        const int64_t stride_sample_y,         // float elements to next sample in vy_rot
+        const int64_t stride_channel_dst,      // elements to next expert slot in dst
+        const int64_t stride_sample_dst) {     // elements to next sample in dst
+
+    __shared__ float s_lut[8];
+    if (threadIdx.y == 0 && threadIdx.x < 8) {
+        s_lut[threadIdx.x] = TQ3_CENTROIDS_WEIGHT[threadIdx.x];
+    }
+    __syncthreads();
+
+    const int row = blockIdx.x * MMVQ_TQ_NWARPS + threadIdx.y;
+    if (row >= nrows_x) return;
+
+    const int expert_slot = blockIdx.y;
+    const int sample      = blockIdx.z;
+    const int expert      = ids[sample * ids_stride + expert_slot];
+    const int channel_y   = expert_slot % nchannels_y;
+
+    const int lane = threadIdx.x;
+    const int blocks_per_row = ncols_x / QK_TQ3_0;
+    const block_tq3_1s * x_row =
+        (const block_tq3_1s *) ((const char *) vx + (int64_t) expert * nb_expert)
+        + (int64_t) row * blocks_per_row;
+    const float * act = vy_rot + sample * stride_sample_y + (int64_t) channel_y * stride_channel_y;
+
+    float sumf = 0.0f;
+    for (int ib = 0; ib < blocks_per_row; ib++) {
+        const float d = (lane < 16) ? __half2float(x_row[ib].d0) : __half2float(x_row[ib].d1);
+        const uint8_t idx = tq3_extract_index(x_row[ib].qs, lane);
+        const float w = s_lut[idx] * d;
+        sumf += act[ib * QK_TQ3_0 + lane] * w;
+    }
+
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        sumf += __shfl_xor_sync(0xffffffff, sumf, offset);
+    }
+
+    if (lane == 0) {
+        dst[sample * stride_sample_dst + (int64_t) expert_slot * stride_channel_dst + row] = sumf;
+    }
+}
+
+static __global__ void mul_mat_tq4_1s_scalar_moe(
+        const void    * __restrict__ vx,
+        const float   * __restrict__ vy_rot,
+        float         * __restrict__ dst,
+        const int32_t * __restrict__ ids,
+        const int     ncols_x,
+        const int     nrows_x,
+        const int64_t nb_expert,
+        const int     ids_stride,
+        const int     nchannels_y,
+        const int64_t stride_channel_y,
+        const int64_t stride_sample_y,
+        const int64_t stride_channel_dst,
+        const int64_t stride_sample_dst) {
+
+    __shared__ float s_lut[16];
+    if (threadIdx.y == 0 && threadIdx.x < 16) {
+        s_lut[threadIdx.x] = TQ4_CENTROIDS_WEIGHT[threadIdx.x];
+    }
+    __syncthreads();
+
+    const int row = blockIdx.x * MMVQ_TQ_NWARPS + threadIdx.y;
+    if (row >= nrows_x) return;
+
+    const int expert_slot = blockIdx.y;
+    const int sample      = blockIdx.z;
+    const int expert      = ids[sample * ids_stride + expert_slot];
+    const int channel_y   = expert_slot % nchannels_y;
+
+    const int lane = threadIdx.x;
+    const int blocks_per_row = ncols_x / QK_TQ4_1S;
+    const block_tq4_1s * x_row =
+        (const block_tq4_1s *) ((const char *) vx + (int64_t) expert * nb_expert)
+        + (int64_t) row * blocks_per_row;
+    const float * act = vy_rot + sample * stride_sample_y + (int64_t) channel_y * stride_channel_y;
+
+    float sumf = 0.0f;
+    for (int ib = 0; ib < blocks_per_row; ib++) {
+        const float d = (lane < 16) ? __half2float(x_row[ib].d0) : __half2float(x_row[ib].d1);
+        const uint8_t idx = (x_row[ib].qs[lane / 2] >> ((lane & 1) * 4)) & 0xF;
+        const float w = s_lut[idx] * d;
+        sumf += act[ib * QK_TQ4_1S + lane] * w;
+    }
+
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        sumf += __shfl_xor_sync(0xffffffff, sumf, offset);
+    }
+
+    if (lane == 0) {
+        dst[sample * stride_sample_dst + (int64_t) expert_slot * stride_channel_dst + row] = sumf;
+    }
+}
+
+// Small-batch (decode / light speculative) TQ MoE: single fused, graph-capturable launch.
+// Requires contiguous src1 (checked by the caller) so the flat WHT pre-rotation is valid.
+void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx,
+                             const ggml_tensor * src0,
+                             const ggml_tensor * src1,
+                             const ggml_tensor * ids,
+                             ggml_tensor * dst) {
+    GGML_ASSERT(src0->type == GGML_TYPE_TQ4_1S || src0->type == GGML_TYPE_TQ3_1S);
+    GGML_ASSERT(src1->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type  == GGML_TYPE_F32);
+    GGML_ASSERT(ids->type  == GGML_TYPE_I32);
+
+    GGML_TENSOR_BINARY_OP_LOCALS;
+
+    const int ncols_x = ne00;   // hidden size
+    const int nrows_x = ne01;   // output features per expert
+    GGML_ASSERT(ncols_x % 32 == 0);
+
+    // MUL_MAT_ID layout: dst = [ne0 = nrows_x, ne1 = n_expert_used, ne2 = n_tokens]
+    const int n_expert_used = ne1;
+    const int n_tokens      = ne2;
+    const int nchannels_y   = ne11;
+
+    cudaStream_t stream = ctx.stream();
+    const int id = ggml_cuda_get_device();
+
+    const float   * src1_d = (const float *)   src1->data;
+    const int32_t * ids_d  = (const int32_t *) ids->data;
+    float         * dst_d  = (float *)         dst->data;
+
+    // Pre-rotate activations (WHT), contiguous [ncols_x, nchannels_y, n_tokens].
+    const int n_act_elements = ncols_x * nchannels_y * n_tokens;
+    ggml_cuda_pool_alloc<float> act_buf(ctx.pool(id), n_act_elements);
+    {
+        const int n_blocks = n_act_elements / 32;
+        const int wpb = 4;
+        const dim3 block(32, wpb);
+        const dim3 grid((n_blocks + wpb - 1) / wpb);
+        tq_prerotate_activation<<<grid, block, 0, stream>>>(src1_d, act_buf.get(), n_act_elements);
+    }
+
+    const int64_t nb_expert          = src0->nb[2];                              // bytes between experts
+    const int     ids_stride         = ids->nb[1] / ggml_type_size(ids->type);
+    const int64_t stride_channel_y   = ncols_x;                                  // float elems to next y-channel
+    const int64_t stride_sample_y    = (int64_t) nchannels_y * ncols_x;          // float elems to next token
+    const int64_t stride_channel_dst = dst->nb[1] / ggml_type_size(dst->type);
+    const int64_t stride_sample_dst  = dst->nb[2] / ggml_type_size(dst->type);
+
+    const dim3 block(WARP_SIZE, MMVQ_TQ_NWARPS);
+    const dim3 grid((nrows_x + MMVQ_TQ_NWARPS - 1) / MMVQ_TQ_NWARPS, n_expert_used, n_tokens);
+
+    if (src0->type == GGML_TYPE_TQ3_1S) {
+        mul_mat_tq3_1s_moe<<<grid, block, 0, stream>>>(
+            src0->data, act_buf.get(), dst_d, ids_d, ncols_x, nrows_x,
+            nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y,
+            stride_channel_dst, stride_sample_dst);
+    } else {
+        mul_mat_tq4_1s_scalar_moe<<<grid, block, 0, stream>>>(
+            src0->data, act_buf.get(), dst_d, ids_d, ncols_x, nrows_x,
+            nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y,
+            stride_channel_dst, stride_sample_dst);
+    }
+    CUDA_CHECK(cudaGetLastError());
+}
+
 void ggml_cuda_mul_mat_tq(ggml_backend_cuda_context & ctx,
                            const ggml_tensor * src0,
                            const ggml_tensor * src1,

--- a/ggml/src/ggml-cuda/mmvq-tq.cu
+++ b/ggml/src/ggml-cuda/mmvq-tq.cu
@@ -494,6 +494,77 @@ static __global__ void mul_mat_tq4_1s_scalar_moe(
     }
 }
 
+// NVIDIA TQ4_1S dp4a MoE variant: same device-side ids routing as the scalar kernels above, but
+// the int8 dp4a inner loop of mul_mat_tq4_1s_dp4a_multi (warp-strided over blocks, q8_1 activations,
+// packed-centroid LUT). One dot product per (row, expert_slot, sample) output element.
+static __global__ void mul_mat_tq4_1s_dp4a_moe(
+        const void       * __restrict__ vx,
+        const block_q8_1 * __restrict__ vy_q8,      // pre-rotated activations (q8_1)
+        float            * __restrict__ dst,
+        const int32_t    * __restrict__ ids,
+        const int     ncols_x,
+        const int     nrows_x,
+        const int64_t nb_expert,
+        const int     ids_stride,
+        const int     nchannels_y,
+        const int64_t stride_channel_y,             // q8_1 blocks to next y-channel
+        const int64_t stride_sample_y,              // q8_1 blocks to next sample
+        const int64_t stride_channel_dst,
+        const int64_t stride_sample_dst) {
+
+    const int row = blockIdx.x * MMVQ_TQ_NWARPS + threadIdx.y;
+    if (row >= nrows_x) return;
+
+    const int expert_slot = blockIdx.y;
+    const int sample      = blockIdx.z;
+    const int expert      = ids[sample * ids_stride + expert_slot];
+    const int channel_y   = expert_slot % nchannels_y;
+
+    const int lane = threadIdx.x;
+    const int blocks_per_row = ncols_x / QK_TQ4_1S;
+    const block_tq4_1s * x_row =
+        (const block_tq4_1s *) ((const char *) vx + (int64_t) expert * nb_expert)
+        + (int64_t) row * blocks_per_row;
+    const block_q8_1 * a_base = vy_q8 + sample * stride_sample_y + (int64_t) channel_y * stride_channel_y;
+
+    float sumf = 0.0f;
+    for (int ib = lane; ib < blocks_per_row; ib += WARP_SIZE) {
+        const block_tq4_1s * blk = &x_row[ib];
+        const float fd0 = __half2float(blk->d0);
+        const float fd1 = __half2float(blk->d1);
+
+        const uint32_t * qs32 = (const uint32_t *)(blk->qs);
+        const uint32_t w0 = qs32[0], w1 = qs32[1], w2 = qs32[2], w3 = qs32[3];
+
+        int c0_0, c1_0, c0_1, c1_1, c0_2, c1_2, c0_3, c1_3;
+        tq4_cents8_reg(w0, c0_0, c1_0);
+        tq4_cents8_reg(w1, c0_1, c1_1);
+        tq4_cents8_reg(w2, c0_2, c1_2);
+        tq4_cents8_reg(w3, c0_3, c1_3);
+
+        const block_q8_1 * a_blk = &a_base[ib];
+        const float d_act = __half2float((__half)a_blk->ds.x);
+        const int * a_qs = (const int *)(a_blk->qs);
+
+        const int s0 = ggml_cuda_dp4a(c0_0, a_qs[0], ggml_cuda_dp4a(c1_0, a_qs[1],
+                       ggml_cuda_dp4a(c0_1, a_qs[2], ggml_cuda_dp4a(c1_1, a_qs[3], 0))));
+        const int s1 = ggml_cuda_dp4a(c0_2, a_qs[4], ggml_cuda_dp4a(c1_2, a_qs[5],
+                       ggml_cuda_dp4a(c0_3, a_qs[6], ggml_cuda_dp4a(c1_3, a_qs[7], 0))));
+
+        sumf += d_act * (fd0 * (float)s0 + fd1 * (float)s1);
+    }
+
+    sumf *= TQ4_CENTROID_I8_RESCALE;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        sumf += __shfl_xor_sync(0xffffffff, sumf, offset);
+    }
+
+    if (lane == 0) {
+        dst[sample * stride_sample_dst + (int64_t) expert_slot * stride_channel_dst + row] = sumf;
+    }
+}
+
 // Small-batch (decode / light speculative) TQ MoE: single fused, graph-capturable launch.
 // Requires contiguous src1 (checked by the caller) so the flat WHT pre-rotation is valid.
 void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx,
@@ -519,42 +590,64 @@ void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx,
 
     cudaStream_t stream = ctx.stream();
     const int id = ggml_cuda_get_device();
+    const int cc = ggml_cuda_info().devices[id].cc;
 
     const float   * src1_d = (const float *)   src1->data;
     const int32_t * ids_d  = (const int32_t *) ids->data;
     float         * dst_d  = (float *)         dst->data;
 
-    // Pre-rotate activations (WHT), contiguous [ncols_x, nchannels_y, n_tokens].
-    const int n_act_elements = ncols_x * nchannels_y * n_tokens;
-    ggml_cuda_pool_alloc<float> act_buf(ctx.pool(id), n_act_elements);
-    {
-        const int n_blocks = n_act_elements / 32;
-        const int wpb = 4;
-        const dim3 block(32, wpb);
-        const dim3 grid((n_blocks + wpb - 1) / wpb);
-        tq_prerotate_activation<<<grid, block, 0, stream>>>(src1_d, act_buf.get(), n_act_elements);
-    }
-
     const int64_t nb_expert          = src0->nb[2];                              // bytes between experts
     const int     ids_stride         = ids->nb[1] / ggml_type_size(ids->type);
-    const int64_t stride_channel_y   = ncols_x;                                  // float elems to next y-channel
-    const int64_t stride_sample_y    = (int64_t) nchannels_y * ncols_x;          // float elems to next token
     const int64_t stride_channel_dst = dst->nb[1] / ggml_type_size(dst->type);
     const int64_t stride_sample_dst  = dst->nb[2] / ggml_type_size(dst->type);
 
+    const int n_act_elements = ncols_x * nchannels_y * n_tokens;
     const dim3 block(WARP_SIZE, MMVQ_TQ_NWARPS);
     const dim3 grid((nrows_x + MMVQ_TQ_NWARPS - 1) / MMVQ_TQ_NWARPS, n_expert_used, n_tokens);
 
-    if (src0->type == GGML_TYPE_TQ3_1S) {
-        mul_mat_tq3_1s_moe<<<grid, block, 0, stream>>>(
-            src0->data, act_buf.get(), dst_d, ids_d, ncols_x, nrows_x,
+    // NVIDIA TQ4_1S: int8 dp4a path (matches the non-MoE dispatch in ggml_cuda_mul_mat_tq).
+    // TQ3_1S (all vendors) + TQ4_1S on AMD: scalar float path (dp4a regresses on RDNA4; no dp4a TQ3).
+    const bool use_dp4a = !GGML_CUDA_CC_IS_AMD(cc) && src0->type == GGML_TYPE_TQ4_1S;
+
+    if (use_dp4a) {
+        // Pre-rotate activations to q8_1, contiguous [ncols_x, nchannels_y, n_tokens].
+        const int n_blocks_total = n_act_elements / 32;
+        ggml_cuda_pool_alloc<block_q8_1> q8_buf(ctx.pool(id), n_blocks_total);
+        {
+            const int wpb = 4;
+            const dim3 pblock(32, wpb);
+            const dim3 pgrid((n_blocks_total + wpb - 1) / wpb);
+            tq_prerotate_q8_1<<<pgrid, pblock, 0, stream>>>(src1_d, q8_buf.get(), n_act_elements);
+        }
+        const int64_t stride_channel_y = ncols_x / 32;                           // q8_1 blocks to next y-channel
+        const int64_t stride_sample_y  = (int64_t) nchannels_y * (ncols_x / 32); // q8_1 blocks to next token
+        mul_mat_tq4_1s_dp4a_moe<<<grid, block, 0, stream>>>(
+            src0->data, q8_buf.get(), dst_d, ids_d, ncols_x, nrows_x,
             nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y,
             stride_channel_dst, stride_sample_dst);
     } else {
-        mul_mat_tq4_1s_scalar_moe<<<grid, block, 0, stream>>>(
-            src0->data, act_buf.get(), dst_d, ids_d, ncols_x, nrows_x,
-            nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y,
-            stride_channel_dst, stride_sample_dst);
+        // Pre-rotate activations to float (WHT), contiguous [ncols_x, nchannels_y, n_tokens].
+        ggml_cuda_pool_alloc<float> act_buf(ctx.pool(id), n_act_elements);
+        {
+            const int n_blocks = n_act_elements / 32;
+            const int wpb = 4;
+            const dim3 pblock(32, wpb);
+            const dim3 pgrid((n_blocks + wpb - 1) / wpb);
+            tq_prerotate_activation<<<pgrid, pblock, 0, stream>>>(src1_d, act_buf.get(), n_act_elements);
+        }
+        const int64_t stride_channel_y = ncols_x;                                // float elems to next y-channel
+        const int64_t stride_sample_y  = (int64_t) nchannels_y * ncols_x;        // float elems to next token
+        if (src0->type == GGML_TYPE_TQ3_1S) {
+            mul_mat_tq3_1s_moe<<<grid, block, 0, stream>>>(
+                src0->data, act_buf.get(), dst_d, ids_d, ncols_x, nrows_x,
+                nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y,
+                stride_channel_dst, stride_sample_dst);
+        } else {
+            mul_mat_tq4_1s_scalar_moe<<<grid, block, 0, stream>>>(
+                src0->data, act_buf.get(), dst_d, ids_d, ncols_x, nrows_x,
+                nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y,
+                stride_channel_dst, stride_sample_dst);
+        }
     }
     CUDA_CHECK(cudaGetLastError());
 }

--- a/ggml/src/ggml-cuda/mmvq-tq.cuh
+++ b/ggml/src/ggml-cuda/mmvq-tq.cuh
@@ -10,6 +10,11 @@ inline void ggml_cuda_mul_mat_vec_tq(ggml_backend_cuda_context & ctx, const ggml
     ggml_cuda_mul_mat_tq(ctx, src0, src1, dst);
 }
 
+// Capture-safe MoE (MUL_MAT_ID) matvec for TQ weights at small batch (decode / light
+// speculative). Reads ids on-device; no host sync, so it can be recorded into a CUDA graph.
+// Caller must ensure src1 is contiguous and dst->ne[2] (n_tokens) <= MMVQ_MAX_BATCH_SIZE.
+void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1, const ggml_tensor * ids, ggml_tensor * dst);
+
 // Large prefill: runtime TQ4_1S → q8_0 scratch + cuBLAS
 void ggml_cuda_mul_mat_tq4_1s_cublas(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst);
 


### PR DESCRIPTION
## Overview

CUDA/HIP fixes that keep CUDA-graph capture enabled (the default) for TurboQuant models on RDNA, make TQ-weight MoE decode ~2x faster, and give that MoE path an NVIDIA variant. Three self-contained commits, reviewable in order.

### 1. `cuda: capture-safe f16 KV-dequant temp on HIP`

The HIP flash-attention f16 KV-dequant temp buffers use raw `cudaMalloc`/`cudaFree`/`cudaStreamSynchronize` to avoid the legacy pool retaining the temp on RDNA3/4 (no VMM), ref ggml-org #22107. Those calls are illegal during CUDA-graph capture, so any graph-compatible model with a quantized KV cache (e.g. gemma-4 MoE with `q8_0` K) aborts with `FLASH_ATTN_EXT ... operation not permitted when stream is capturing` whenever graphs are on.

The allocation is now capture-aware: a new `ggml_backend_cuda_context::fa_f16_use_pool` (set from `graph_compatible` in `ggml_backend_cuda_graph_compute`) routes the temp to the pool when the cgraph will be captured -- capture-safe, warmed during the eager warmup passes, reused across replays, exactly like the non-HIP path. Otherwise the raw release-after-use path is kept, preserving the #22107 low-watermark for graph-incompatible graphs.

### 2. `cuda: device-routed TQ MoE matvec (capture-safe, ~2x decode)`

TQ4_1S/TQ3_1S weights have no mmvq/mmq kernel, so MUL_MAT_ID (MoE) falls through to the generic `ggml_cuda_mul_mat_id` host path: copy `ids` to the host, sort tokens per expert on the CPU, copy back, then a data-dependent per-expert cuBLAS loop -- two `cudaStreamSynchronize` per layer. That both forbids graph capture (`[TAG_MUL_MAT_ID_CUDA_GRAPHS]` disabled graphs for all TQ MoE) and is slow.

New device-routed matvec kernels (`mul_mat_tq3_1s_moe`, `mul_mat_tq4_1s_scalar_moe`) read `ids[channel]` on-device to select each expert's weight channel -- mirroring the stock mmvq id path -- reusing the existing TQ dot-product. Small batch (`<= MMVQ_MAX_BATCH_SIZE`, contiguous `src1`) routes through it; large-batch prefill keeps the cuBLAS fallback. The graph-compat gate is narrowed to disable graphs only for the remaining sync (large-batch / non-contiguous) case, kept in sync with the dispatch.

### 3. `cuda: NVIDIA dp4a variant of the device-routed TQ MoE matvec`

Adds `mul_mat_tq4_1s_dp4a_moe` -- the int8 dp4a inner loop of `mul_mat_tq4_1s_dp4a_multi` (warp-strided over blocks, q8_1 activations, packed-centroid LUT) with the same on-device `ids` routing. `ggml_cuda_mul_mat_id_tq` routes TQ4_1S to the dp4a path on NVIDIA and the scalar path on AMD, mirroring the non-MoE dispatch in `ggml_cuda_mul_mat_tq`; TQ3_1S stays scalar everywhere. AMD is unaffected at runtime.

> **Note:** commit 3 is compile-verified (gfx1100) but has **not** been numerically validated on NVIDIA hardware -- I don't have an NVIDIA GPU. It reuses the proven `dp4a_multi` inner loop and the (bit-identical-validated) MoE routing, but the dp4a MoE path itself wants an Ampere/Ada sanity check before merge. @seanrasch if you have a moment on real hardware.

## Validation (commits 1-2)

- **Correctness:** TQ MoE output is bit-identical to the host-sync fallback (greedy, 128 tokens), and identical graphs-on vs graphs-off. gemma-4 runs under graph capture where it previously aborted.
- **Builds clean** for gfx1100 under `-Werror` (0 warnings on the touched files).
- **Decode -- Qwen3.6-35B-A3B TQ3_1S (base, greedy, `-fa on`, `q8_0` K):**

| GPU | fallback | fused (graphs off) | fused (graphs on) | fused vs fallback | + graphs |
|---|---|---|---|---|---|
| RX 7900 XTX (gfx1100) | 13.7 t/s | 26.0 t/s | 26.1 t/s | 1.90x | +0.4% |
| PRO V620 (gfx1030) | 26.4 t/s | 54.5 t/s | 59.7 t/s | 2.06x | +9.5% |

The fused-kernel win is hardware-independent; the graph-capture gain shows up where the CPU is launch-bound (V620 + Ryzen 5 8500G). End-to-end this carries to a live TurboQuant service: the 35B-A3B tagger went 59 -> 111 t/s (1.9x) with recall unchanged.
