### PR TITLE
cuda: optimize WHT in set_rows turbo kernels with warp shuffles

### DIFF
--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -575,21 +575,32 @@ static __device__ __forceinline__ void flash_attn_ext_turbo3_load_tile(
             continue;
         }
         const char * row_ptr = KV_raw + (int64_t)row * stride_bytes;
-        for (int c = 0; c < D2; ++c) {
-            const int col   = col_offset + c;                // absolute half2 column
-            const int elem0 = col * 2;                       // even; elem0,elem0+1 share block/qs/signs
-            const int ib    = elem0 / QK_TURBO3;
-            const int j0    = elem0 % QK_TURBO3;
-            const block_turbo3_0 * blk = (const block_turbo3_0 *)(row_ptr) + ib;
-            const float   norm     = __half2float(blk->norm);
-            const uint8_t qs_byte  = blk->qs[j0 / 4];
-            const uint8_t sgn_byte = blk->signs[j0 / 8];
-            const int     shift    = (j0 % 4) * 2;
-            const uint8_t idx0 = ((qs_byte >> shift)     & 0x3) | (((sgn_byte >> (j0 % 8))     & 0x1) << 2);
-            const uint8_t idx1 = ((qs_byte >> (shift+2)) & 0x3) | (((sgn_byte >> (j0 % 8 + 1)) & 0x1) << 2);
-            const half lo = __float2half(TURBO_CENTROIDS_3BIT_FATTN[idx0] * norm);
-            const half hi = __float2half(TURBO_CENTROIDS_3BIT_FATTN[idx1] * norm);
-            tile_KV[row*stride_tile + c] = __halves2half2(lo, hi);
+        int c = 0;
+        while (c < D2) {
+            const int col         = col_offset + c;
+            const int blk_idx     = col / (QK_TURBO3 / 2);
+            const int blk_col_end = (blk_idx + 1) * (QK_TURBO3 / 2) - col_offset;
+            const int c_end       = min(D2, blk_col_end);
+
+            const block_turbo3_0 * blk = (const block_turbo3_0 *)(row_ptr) + blk_idx;
+            const float norm = __half2float(blk->norm);
+
+            half scaled[8];
+#pragma unroll
+            for (int i = 0; i < 8; ++i) {
+                scaled[i] = __float2half(TURBO_CENTROIDS_3BIT_FATTN[i] * norm);
+            }
+
+            for (; c < c_end; ++c) {
+                const int in_blk = (col_offset + c) % (QK_TURBO3 / 2);
+                const int j0     = in_blk * 2;
+                const uint8_t qs_byte  = blk->qs[j0 / 4];
+                const uint8_t sgn_byte = blk->signs[j0 / 8];
+                const int     shift    = (j0 % 4) * 2;
+                const uint8_t idx0 = ((qs_byte >> shift)     & 0x3) | (((sgn_byte >> (j0 % 8))     & 0x1) << 2);
+                const uint8_t idx1 = ((qs_byte >> (shift+2)) & 0x3) | (((sgn_byte >> (j0 % 8 + 1)) & 0x1) << 2);
+                tile_KV[row*stride_tile + c] = __halves2half2(scaled[idx0], scaled[idx1]);
+            }
         }
     }
 }
@@ -611,20 +622,31 @@ static __device__ __forceinline__ void flash_attn_ext_turbo2_load_tile(
             continue;
         }
         const char * row_ptr = KV_raw + (int64_t)row * stride_bytes;
-        for (int c = 0; c < D2; ++c) {
-            const int col   = col_offset + c;
-            const int elem0 = col * 2;
-            const int ib    = elem0 / QK_TURBO2;
-            const int j0    = elem0 % QK_TURBO2;
-            const block_turbo2_0 * blk = (const block_turbo2_0 *)(row_ptr) + ib;
-            const float   norm    = __half2float(blk->norm);
-            const uint8_t qs_byte = blk->qs[j0 / 4];
-            const int     shift   = (j0 % 4) * 2;
-            const uint8_t idx0 = (qs_byte >> shift)     & 0x3;
-            const uint8_t idx1 = (qs_byte >> (shift+2)) & 0x3;
-            const half lo = __float2half(TURBO_CENTROIDS_2BIT_FATTN[idx0] * norm);
-            const half hi = __float2half(TURBO_CENTROIDS_2BIT_FATTN[idx1] * norm);
-            tile_KV[row*stride_tile + c] = __halves2half2(lo, hi);
+        int c = 0;
+        while (c < D2) {
+            const int col         = col_offset + c;
+            const int blk_idx     = col / (QK_TURBO2 / 2);
+            const int blk_col_end = (blk_idx + 1) * (QK_TURBO2 / 2) - col_offset;
+            const int c_end       = min(D2, blk_col_end);
+
+            const block_turbo2_0 * blk = (const block_turbo2_0 *)(row_ptr) + blk_idx;
+            const float norm = __half2float(blk->norm);
+
+            half scaled[4];
+#pragma unroll
+            for (int i = 0; i < 4; ++i) {
+                scaled[i] = __float2half(TURBO_CENTROIDS_2BIT_FATTN[i] * norm);
+            }
+
+            for (; c < c_end; ++c) {
+                const int in_blk = (col_offset + c) % (QK_TURBO2 / 2);
+                const int j0     = in_blk * 2;
+                const uint8_t qs_byte = blk->qs[j0 / 4];
+                const int     shift   = (j0 % 4) * 2;
+                const uint8_t idx0 = (qs_byte >> shift)     & 0x3;
+                const uint8_t idx1 = (qs_byte >> (shift+2)) & 0x3;
+                tile_KV[row*stride_tile + c] = __halves2half2(scaled[idx0], scaled[idx1]);
+            }
         }
     }
 }

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -538,7 +538,11 @@ static __device__ __forceinline__ void flash_attn_ext_turbo4_load_tile(
             const int c_end       = min(D2, blk_col_end);
 
             const block_turbo4_0 * blk = (const block_turbo4_0 *)(row_ptr) + blk_idx;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+            const float norm = __half2float(__ldcs((const half *)&blk->norm));
+#else
             const float norm = __half2float(blk->norm);
+#endif
 
             half scaled[16];
 #pragma unroll
@@ -548,7 +552,11 @@ static __device__ __forceinline__ void flash_attn_ext_turbo4_load_tile(
 
             for (; c < c_end; ++c) {
                 const int in_blk = (col_offset + c) % (QK_TURBO4 / 2);
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+                const uint8_t byte = __ldcs(&blk->qs[in_blk]);
+#else
                 const uint8_t byte = blk->qs[in_blk];
+#endif
                 tile_KV[row*stride_tile + c] = __halves2half2(scaled[byte & 0xF], scaled[byte >> 4]);
             }
         }
@@ -583,7 +591,11 @@ static __device__ __forceinline__ void flash_attn_ext_turbo3_load_tile(
             const int c_end       = min(D2, blk_col_end);
 
             const block_turbo3_0 * blk = (const block_turbo3_0 *)(row_ptr) + blk_idx;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+            const float norm = __half2float(__ldcs((const half *)&blk->norm));
+#else
             const float norm = __half2float(blk->norm);
+#endif
 
             half scaled[8];
 #pragma unroll
@@ -594,8 +606,13 @@ static __device__ __forceinline__ void flash_attn_ext_turbo3_load_tile(
             for (; c < c_end; ++c) {
                 const int in_blk = (col_offset + c) % (QK_TURBO3 / 2);
                 const int j0     = in_blk * 2;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+                const uint8_t qs_byte  = __ldcs(&blk->qs[j0 / 4]);
+                const uint8_t sgn_byte = __ldcs(&blk->signs[j0 / 8]);
+#else
                 const uint8_t qs_byte  = blk->qs[j0 / 4];
                 const uint8_t sgn_byte = blk->signs[j0 / 8];
+#endif
                 const int     shift    = (j0 % 4) * 2;
                 const uint8_t idx0 = ((qs_byte >> shift)     & 0x3) | (((sgn_byte >> (j0 % 8))     & 0x1) << 2);
                 const uint8_t idx1 = ((qs_byte >> (shift+2)) & 0x3) | (((sgn_byte >> (j0 % 8 + 1)) & 0x1) << 2);
@@ -630,7 +647,11 @@ static __device__ __forceinline__ void flash_attn_ext_turbo2_load_tile(
             const int c_end       = min(D2, blk_col_end);
 
             const block_turbo2_0 * blk = (const block_turbo2_0 *)(row_ptr) + blk_idx;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+            const float norm = __half2float(__ldcs((const half *)&blk->norm));
+#else
             const float norm = __half2float(blk->norm);
+#endif
 
             half scaled[4];
 #pragma unroll
@@ -641,7 +662,11 @@ static __device__ __forceinline__ void flash_attn_ext_turbo2_load_tile(
             for (; c < c_end; ++c) {
                 const int in_blk = (col_offset + c) % (QK_TURBO2 / 2);
                 const int j0     = in_blk * 2;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+                const uint8_t qs_byte = __ldcs(&blk->qs[j0 / 4]);
+#else
                 const uint8_t qs_byte = blk->qs[j0 / 4];
+#endif
                 const int     shift   = (j0 % 4) * 2;
                 const uint8_t idx0 = (qs_byte >> shift)     & 0x3;
                 const uint8_t idx1 = (qs_byte >> (shift+2)) & 0x3;

--- a/ggml/src/ggml-cuda/set-rows.cu
+++ b/ggml/src/ggml-cuda/set-rows.cu
@@ -331,19 +331,33 @@ static __global__ void k_set_rows_turbo3(
     }
     __syncthreads();
 
-#define WHT_STAGE_SHARED(h) \
-    if (j % (2*(h)) < (h)) { float a = x[j], b = x[j+(h)]; x[j] = a+b; x[j+(h)] = a-b; } \
+    const int lane = j & 31;
+    float val = x[j];
+
+#pragma unroll
+    for (int h = 1; h < 32; h <<= 1) {
+        float o = __shfl_xor_sync(0xffffffff, val, h);
+        val = (lane & h) ? (o - val) : (val + o);
+    }
+
+    x[j] = val;
     __syncthreads();
 
-    // Butterfly stages: loop from h=1 to h<GROUP_SIZE, doubling each time
-    WHT_STAGE_SHARED(1)
-    WHT_STAGE_SHARED(2)
-    WHT_STAGE_SHARED(4)
-    WHT_STAGE_SHARED(8)
-    WHT_STAGE_SHARED(16)
-    WHT_STAGE_SHARED(32)
-    if (GROUP_SIZE == 128) { WHT_STAGE_SHARED(64) }
-#undef WHT_STAGE_SHARED
+    if (j % 64 < 32) {
+        float a = x[j], b = x[j + 32];
+        x[j] = a + b;
+        x[j + 32] = a - b;
+    }
+    __syncthreads();
+
+    if (GROUP_SIZE == 128) {
+        if (j % 128 < 64) {
+            float a = x[j], b = x[j + 64];
+            x[j] = a + b;
+            x[j + 64] = a - b;
+        }
+        __syncthreads();
+    }
 
     constexpr float inv_sqrt_group = (GROUP_SIZE == 128) ? 0.08838834764831845f : 0.125f;
     if (GROUP_SIZE == 128) {
@@ -360,7 +374,6 @@ static __global__ void k_set_rows_turbo3(
     // ---- Step 6: Pack qs and signs (warp-cooperative, no atomics) ----
     // Each warp handles 32 elements. With QK_TURBO3 > WARP_SIZE, multiple warps
     // share one block and write to different byte offsets within it.
-    const int lane    = j % WARP_SIZE;
     const int elem_in_block = j % QK_TURBO3;
     block_turbo3_0 * blk = blk_base + (j / QK_TURBO3);
 
@@ -699,18 +712,33 @@ static __global__ void k_set_rows_turbo2(
     }
     __syncthreads();
 
-#define WHT_STAGE_SHARED_T2(h) \
-    if (j % (2*(h)) < (h)) { float a = x[j], b = x[j+(h)]; x[j] = a+b; x[j+(h)] = a-b; } \
+    const int lane = j & 31;
+    float val = x[j];
+
+#pragma unroll
+    for (int h = 1; h < 32; h <<= 1) {
+        float o = __shfl_xor_sync(0xffffffff, val, h);
+        val = (lane & h) ? (o - val) : (val + o);
+    }
+
+    x[j] = val;
     __syncthreads();
 
-    WHT_STAGE_SHARED_T2(1)
-    WHT_STAGE_SHARED_T2(2)
-    WHT_STAGE_SHARED_T2(4)
-    WHT_STAGE_SHARED_T2(8)
-    WHT_STAGE_SHARED_T2(16)
-    WHT_STAGE_SHARED_T2(32)
-    if (GROUP_SIZE == 128) { WHT_STAGE_SHARED_T2(64) }
-#undef WHT_STAGE_SHARED_T2
+    if (j % 64 < 32) {
+        float a = x[j], b = x[j + 32];
+        x[j] = a + b;
+        x[j + 32] = a - b;
+    }
+    __syncthreads();
+
+    if (GROUP_SIZE == 128) {
+        if (j % 128 < 64) {
+            float a = x[j], b = x[j + 64];
+            x[j] = a + b;
+            x[j + 64] = a - b;
+        }
+        __syncthreads();
+    }
 
     constexpr float inv_sqrt_group = (GROUP_SIZE == 128) ? 0.08838834764831845f : 0.125f;
     if (GROUP_SIZE == 128) {
@@ -727,7 +755,6 @@ static __global__ void k_set_rows_turbo2(
     // ---- Step 6: Pack qs (warp-cooperative, no atomics) ----
     // Each warp handles 32 elements. With QK_TURBO2 > WARP_SIZE, multiple warps
     // share one block and write to different byte offsets within it.
-    const int lane    = j % WARP_SIZE;
     const int elem_in_block = j % QK_TURBO2;
     block_turbo2_0 * blk = blk_base + (j / QK_TURBO2);
 
@@ -1037,18 +1064,31 @@ static __global__ void k_set_rows_turbo4(
     x[j] *= TURBO_WHT_SIGNS1[j];
     __syncthreads();
 
-#define WHT_STAGE_SHARED_T4(h) \
-    if (j % (2*(h)) < (h)) { float a = x[j], b = x[j+(h)]; x[j] = a+b; x[j+(h)] = a-b; } \
+    const int lane = j & 31;
+    float val = x[j];
+
+#pragma unroll
+    for (int h = 1; h < 32; h <<= 1) {
+        float o = __shfl_xor_sync(0xffffffff, val, h);
+        val = (lane & h) ? (o - val) : (val + o);
+    }
+
+    x[j] = val;
     __syncthreads();
 
-    WHT_STAGE_SHARED_T4(1)
-    WHT_STAGE_SHARED_T4(2)
-    WHT_STAGE_SHARED_T4(4)
-    WHT_STAGE_SHARED_T4(8)
-    WHT_STAGE_SHARED_T4(16)
-    WHT_STAGE_SHARED_T4(32)
-    WHT_STAGE_SHARED_T4(64)
-#undef WHT_STAGE_SHARED_T4
+    if (j % 64 < 32) {
+        float a = x[j], b = x[j + 32];
+        x[j] = a + b;
+        x[j + 32] = a - b;
+    }
+    __syncthreads();
+
+    if (j % 128 < 64) {
+        float a = x[j], b = x[j + 64];
+        x[j] = a + b;
+        x[j + 64] = a - b;
+    }
+    __syncthreads();
 
     constexpr float inv_sqrt_128 = 0.08838834764831845f;
     x[j] = x[j] * inv_sqrt_128 * TURBO_WHT_SIGNS2[j];
@@ -1061,7 +1101,6 @@ static __global__ void k_set_rows_turbo4(
     // ---- Step 6: Pack qs (nibble packed, warp-cooperative) ----
     // 2 elements per byte, 4 bits each.
     // Thread pairs (j, j+1) share a qs byte.
-    const int lane = j % WARP_SIZE;
     const uint8_t my_nibble = idx & 0xF;
     uint8_t qs_byte = 0;
     // Gather nibble from partner thread

--- a/ggml/src/ggml-cuda/turbo-wht.cu
+++ b/ggml/src/ggml-cuda/turbo-wht.cu
@@ -66,18 +66,37 @@ static __global__ void k_turbo_wht_f32(const float * __restrict__ src,
     // In stage h, threads where (t % (2h)) < h read x[t] and x[t+h],
     // then write x[t] = a+b and x[t+h] = a-b.  Each active thread
     // owns a disjoint pair, so no intra-stage conflicts exist.
-#define WHT_STAGE(h) \
-    if (t % (2*(h)) < (h)) { float a = x[t], b = x[t+(h)]; x[t] = a+b; x[t+(h)] = a-b; } \
+    const int lane = t & 31;
+    float val = x[t];
+
+    // Intra-warp butterfly (h = 1, 2, 4, 8, 16)
+#pragma unroll
+    for (int h = 1; h < 32; h <<= 1) {
+        float o = __shfl_xor_sync(0xffffffff, val, h);
+        val = (lane & h) ? (o - val) : (val + o);
+    }
+
+    x[t] = val;
     __syncthreads();
 
-    WHT_STAGE(1)
-    WHT_STAGE(2)
-    WHT_STAGE(4)
-    WHT_STAGE(8)
-    WHT_STAGE(16)
-    if (group_size >= 64) { WHT_STAGE(32) }
-    if (group_size == 128) { WHT_STAGE(64) }
-#undef WHT_STAGE
+    // Inter-warp butterfly (h = 32, 64)
+    if (group_size >= 64) {
+        if (t % 64 < 32) {
+            float a = x[t], b = x[t + 32];
+            x[t] = a + b;
+            x[t + 32] = a - b;
+        }
+        __syncthreads();
+    }
+
+    if (group_size == 128) {
+        if (t % 128 < 64) {
+            float a = x[t], b = x[t + 64];
+            x[t] = a + b;
+            x[t + 64] = a - b;
+        }
+        __syncthreads();
+    }
 
     // Normalize and apply second sign array, write to output
     constexpr float inv_sqrt = (group_size == 128) ? 0.08838834764831845f :


### PR DESCRIPTION
### Summary
Replaces shared memory butterfly with __shfl_xor_sync for intra-warp stages h=1..16 in k_set_rows_turbo{2,3,4}. Eliminates 5 __syncthreads() barriers per block and reduces shared memory bank conflicts during KV cache writes.
Includes all optimizations from perf/cuda-wht-and-fa-loaders:
- WHT warp shuffles in turbo-wht.cu
- Precomputed scaled centroids in FA tile loaders
- __ldcs streaming loads for KV cache reads
### Validation
- test-turbo-quant: MSE=0, Cosine=1.0 (Passed)
- test-backend-ops: 7842/7842 passed (CUDA0)
### Performance (Qwen2.5-1.5B-Q4_K_M, RTX 3050 Laptop)
| Test | Baseline | Optimized | Delta |
|------|----------|-----------|-------|
| pp512 | 996.62 ± 6.14 | 1001.09 ± 4.50 | +4.47 t/s |
| pp2048 | 944.56 ± 0.67 | 947.95 ± 0.26 | +3.39 t/s, stddev reduced 2.6x |
| tg128 | 27.44 ± 0.14 | 27.46 ± 0.21 | parity (memory-bound) |
### Performance (Qwen2.5-1.5B-F16, RTX 3050 Laptop)
| Test | Baseline | Optimized | Delta |
|------|----------|-----------|-------|
| pp512 | 963.58 ± 8.25 | 991.73 ± 29.85 | +28.15 t/s |
| pp2048 | 914.87 ± 8.96 | 960.26 ± 3.80 | +45.39 t/s, stddev reduced 2.4x |
| tg128 | 12.21 ± 0.39 | 13.82 ± 0.30 | +13.18% |