### PR TITLE
cuda: device-routed MoE prefill (on-device expert counting-sort)

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1,4 +1,5 @@
 #include "ggml-cuda.h"
+#include "moe-devsort.cuh"
 #include "ggml-impl.h"
 #include "ggml-backend-impl.h"
 
@@ -2199,41 +2200,60 @@ static void ggml_cuda_mul_mat_id(ggml_backend_cuda_context & ctx, ggml_tensor * 
     const int64_t n_expert_used = ids->ne[0];
     const int64_t ne_get_rows = ne12 * n_expert_used;
 
-    std::vector<int32_t> ids_to_sorted_host;
-    ids_to_sorted_host.reserve(2*ne_get_rows);
-    std::vector<int32_t> ids_from_sorted_host(ne_get_rows);
-
     ggml_cuda_pool_alloc<int32_t> ids_buf_dev(ctx.pool(), 2*ne_get_rows);
-
-    std::vector<int32_t> tokens_per_expert(ne02);
+    std::vector<int32_t> tokens_per_expert(ne02, 0);
 
     ggml_cuda_pool_alloc<char> src1_sorted(ctx.pool(), ne12*n_expert_used*ne10*ts_src1_sorted);
     ggml_cuda_pool_alloc<char>  dst_sorted(ctx.pool(), ne2 *n_expert_used* ne0*ts_dst_sorted);
 
-    std::vector<char> ids_host(ggml_nbytes(ids));
-    CUDA_CHECK(cudaMemcpyAsync(ids_host.data(), ids->data, ggml_nbytes(ids), cudaMemcpyDeviceToHost, stream));
-    CUDA_CHECK(cudaStreamSynchronize(stream));
+    // Build the expert routing: ids_to_sorted | ids_from_sorted packed into ids_buf_dev,
+    // plus tokens_per_expert. By default this is done on-device (a counting sort) so the
+    // GPU is not left idle copying ids to the host and sorting token-slots by expert on
+    // the CPU. Set GGML_MOE_HOST_ROUTE=1 to force the original host-side routing loop.
+    static const bool moe_host_route = (getenv("GGML_MOE_HOST_ROUTE") != nullptr);
+    if (!moe_host_route) {
+        ggml_cuda_pool_alloc<int32_t> tpe_dev(ctx.pool(), ne02);
+        ggml_cuda_pool_alloc<int32_t> off_dev(ctx.pool(), ne02);
+        ggml_cuda_pool_alloc<int32_t> fill_dev(ctx.pool(), ne02);
+        ggml_cuda_moe_build_sorted_ids(
+            ids->data, (int)ne12, (int)n_expert_used, (int)ne02, (int)ne11,
+            ids->nb[0], ids->nb[1],
+            ids_buf_dev.ptr, ids_buf_dev.ptr + ne_get_rows,
+            tpe_dev.ptr, off_dev.ptr, fill_dev.ptr, stream);
+        // Only tokens_per_expert (ne02 ints) needs to reach the host, for GEMM sizing.
+        CUDA_CHECK(cudaMemcpyAsync(tokens_per_expert.data(), tpe_dev.ptr, ne02*sizeof(int32_t), cudaMemcpyDeviceToHost, stream));
+        CUDA_CHECK(cudaStreamSynchronize(stream));
+    } else {
+        std::vector<int32_t> ids_to_sorted_host;
+        ids_to_sorted_host.reserve(2*ne_get_rows);
+        std::vector<int32_t> ids_from_sorted_host(ne_get_rows);
 
-    for (int64_t i02 = 0; i02 < ne02; ++i02) { // expert matrices
-        for (int64_t i12 = 0; i12 < ne12; ++i12) { // tokens
-            for (int64_t iex = 0; iex < n_expert_used; ++iex) {
-                const int32_t expert_to_use = *(const int32_t *)(ids_host.data() + i12*ids->nb[1] + iex*ids->nb[0]);
-                assert(expert_to_use >= 0 && expert_to_use < ne02);
-                if (expert_to_use == i02) {
-                    ids_from_sorted_host[i12*n_expert_used + iex] = ids_to_sorted_host.size();
-                    ids_to_sorted_host.push_back(i12*ne11 + iex % ne11);
-                    tokens_per_expert[i02]++;
-                    break;
+        std::vector<char> ids_host(ggml_nbytes(ids));
+        CUDA_CHECK(cudaMemcpyAsync(ids_host.data(), ids->data, ggml_nbytes(ids), cudaMemcpyDeviceToHost, stream));
+        CUDA_CHECK(cudaStreamSynchronize(stream));
+
+        for (int64_t i02 = 0; i02 < ne02; ++i02) { // expert matrices
+            for (int64_t i12 = 0; i12 < ne12; ++i12) { // tokens
+                for (int64_t iex = 0; iex < n_expert_used; ++iex) {
+                    const int32_t expert_to_use = *(const int32_t *)(ids_host.data() + i12*ids->nb[1] + iex*ids->nb[0]);
+                    assert(expert_to_use >= 0 && expert_to_use < ne02);
+                    if (expert_to_use == i02) {
+                        ids_from_sorted_host[i12*n_expert_used + iex] = ids_to_sorted_host.size();
+                        ids_to_sorted_host.push_back(i12*ne11 + iex % ne11);
+                        tokens_per_expert[i02]++;
+                        break;
+                    }
                 }
             }
         }
+
+        GGML_ASSERT(ids_to_sorted_host.size() == size_t(ne_get_rows));
+
+        ids_to_sorted_host.insert(ids_to_sorted_host.end(), ids_from_sorted_host.begin(), ids_from_sorted_host.end());
+
+        CUDA_CHECK(cudaMemcpyAsync(ids_buf_dev.ptr, ids_to_sorted_host.data(), 2*ne_get_rows*sizeof(int32_t), cudaMemcpyHostToDevice, stream));
+        CUDA_CHECK(cudaStreamSynchronize(stream));
     }
-    GGML_ASSERT(ids_to_sorted_host.size() == size_t(ne_get_rows));
-
-    ids_to_sorted_host.insert(ids_to_sorted_host.end(), ids_from_sorted_host.begin(), ids_from_sorted_host.end());
-
-    CUDA_CHECK(cudaMemcpyAsync(ids_buf_dev.ptr, ids_to_sorted_host.data(), 2*ne_get_rows*sizeof(int32_t), cudaMemcpyHostToDevice, stream));
-    CUDA_CHECK(cudaStreamSynchronize(stream));
 
     const int32_t * ids_to_sorted   = ids_buf_dev.ptr + 0*ne_get_rows;
     const int32_t * ids_from_sorted = ids_buf_dev.ptr + 1*ne_get_rows;

--- a/ggml/src/ggml-cuda/moe-devsort.cu
+++ b/ggml/src/ggml-cuda/moe-devsort.cu
@@ -7,17 +7,21 @@ static __global__ void k_moe_zero_i32(int32_t * p, int n) {
 }
 
 // One thread per (token, used) slot: atomically count tokens per expert.
-static __global__ void k_moe_hist(const char * __restrict__ ids, int n_slots, int n_used,
+static __global__ void k_moe_hist(const char * __restrict__ ids, int n_slots, int n_used, int n_experts,
                                   size_t nb0, size_t nb1, int32_t * __restrict__ tpe) {
     const int slot = blockIdx.x * blockDim.x + threadIdx.x;
     if (slot >= n_slots) return;
     const int i12 = slot / n_used;
     const int iex = slot % n_used;
     const int e = *(const int32_t *)(ids + (size_t)i12 * nb1 + (size_t)iex * nb0);
-    atomicAdd(&tpe[e], 1);
+    // Guard a malformed expert index: a device-side out-of-bounds atomicAdd is far worse
+    // than the host path's (release-stripped) assert. Well-formed ids never trip this.
+    if (e >= 0 && e < n_experts) atomicAdd(&tpe[e], 1);
 }
 
-// Single-thread exclusive prefix sum over ne02 experts (ne02 is small, ~<=256).
+// Exclusive prefix sum over the ne02 experts. Deliberately SINGLE-THREADED: ne02 is
+// small on today's MoE models (~<=256), so a parallel scan isn't worth the complexity.
+// Revisit (e.g. a Blelloch scan) if a model with a much higher expert count shows up.
 static __global__ void k_moe_excl_scan(const int32_t * __restrict__ in, int32_t * __restrict__ out, int n) {
     if (blockIdx.x == 0 && threadIdx.x == 0) {
         int32_t acc = 0;
@@ -28,7 +32,7 @@ static __global__ void k_moe_excl_scan(const int32_t * __restrict__ in, int32_t 
 // One thread per (token, used) slot: scatter each slot to its expert's contiguous
 // range at offsets[e] + running fill counter. Within-expert order is arbitrary
 // (the ids_from_sorted inverse restores each token's position after the GEMM).
-static __global__ void k_moe_scatter(const char * __restrict__ ids, int n_slots, int n_used, int ne11,
+static __global__ void k_moe_scatter(const char * __restrict__ ids, int n_slots, int n_used, int ne11, int n_experts,
                                      size_t nb0, size_t nb1,
                                      const int32_t * __restrict__ offsets, int32_t * __restrict__ fill,
                                      int32_t * __restrict__ to_sorted, int32_t * __restrict__ from_sorted) {
@@ -37,6 +41,9 @@ static __global__ void k_moe_scatter(const char * __restrict__ ids, int n_slots,
     const int i12 = slot / n_used;
     const int iex = slot % n_used;
     const int e = *(const int32_t *)(ids + (size_t)i12 * nb1 + (size_t)iex * nb0);
+    // Same OOB guard as the histogram: offsets[e]/fill[e] and the derived write would be
+    // out of bounds for a malformed expert index. Well-formed ids never trip this.
+    if (e < 0 || e >= n_experts) return;
     const int pos = offsets[e] + atomicAdd(&fill[e], 1);
     to_sorted[pos]    = i12 * ne11 + (iex % ne11);  // matches host: i12*ne11 + iex%ne11
     from_sorted[slot] = pos;
@@ -58,12 +65,12 @@ void ggml_cuda_moe_build_sorted_ids(
     k_moe_zero_i32<<<g_experts, TPB, 0, stream>>>(scratch_fill, ne02);
 
     k_moe_hist<<<g_slots, TPB, 0, stream>>>(
-        (const char *)ids, n_slots, n_expert_used, ids_nb0, ids_nb1, tokens_per_expert_dev);
+        (const char *)ids, n_slots, n_expert_used, ne02, ids_nb0, ids_nb1, tokens_per_expert_dev);
 
     k_moe_excl_scan<<<1, 1, 0, stream>>>(tokens_per_expert_dev, scratch_offsets, ne02);
 
     k_moe_scatter<<<g_slots, TPB, 0, stream>>>(
-        (const char *)ids, n_slots, n_expert_used, ne11, ids_nb0, ids_nb1,
+        (const char *)ids, n_slots, n_expert_used, ne11, ne02, ids_nb0, ids_nb1,
         scratch_offsets, scratch_fill, ids_to_sorted, ids_from_sorted);
 
     CUDA_CHECK(cudaGetLastError());

--- a/ggml/src/ggml-cuda/moe-devsort.cu
+++ b/ggml/src/ggml-cuda/moe-devsort.cu
@@ -1,0 +1,70 @@
+#include "moe-devsort.cuh"
+
+// One thread per expert-count slot: zero an int32 array.
+static __global__ void k_moe_zero_i32(int32_t * p, int n) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) p[i] = 0;
+}
+
+// One thread per (token, used) slot: atomically count tokens per expert.
+static __global__ void k_moe_hist(const char * __restrict__ ids, int n_slots, int n_used,
+                                  size_t nb0, size_t nb1, int32_t * __restrict__ tpe) {
+    const int slot = blockIdx.x * blockDim.x + threadIdx.x;
+    if (slot >= n_slots) return;
+    const int i12 = slot / n_used;
+    const int iex = slot % n_used;
+    const int e = *(const int32_t *)(ids + (size_t)i12 * nb1 + (size_t)iex * nb0);
+    atomicAdd(&tpe[e], 1);
+}
+
+// Single-thread exclusive prefix sum over ne02 experts (ne02 is small, ~<=256).
+static __global__ void k_moe_excl_scan(const int32_t * __restrict__ in, int32_t * __restrict__ out, int n) {
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        int32_t acc = 0;
+        for (int i = 0; i < n; i++) { out[i] = acc; acc += in[i]; }
+    }
+}
+
+// One thread per (token, used) slot: scatter each slot to its expert's contiguous
+// range at offsets[e] + running fill counter. Within-expert order is arbitrary
+// (the ids_from_sorted inverse restores each token's position after the GEMM).
+static __global__ void k_moe_scatter(const char * __restrict__ ids, int n_slots, int n_used, int ne11,
+                                     size_t nb0, size_t nb1,
+                                     const int32_t * __restrict__ offsets, int32_t * __restrict__ fill,
+                                     int32_t * __restrict__ to_sorted, int32_t * __restrict__ from_sorted) {
+    const int slot = blockIdx.x * blockDim.x + threadIdx.x;
+    if (slot >= n_slots) return;
+    const int i12 = slot / n_used;
+    const int iex = slot % n_used;
+    const int e = *(const int32_t *)(ids + (size_t)i12 * nb1 + (size_t)iex * nb0);
+    const int pos = offsets[e] + atomicAdd(&fill[e], 1);
+    to_sorted[pos]    = i12 * ne11 + (iex % ne11);  // matches host: i12*ne11 + iex%ne11
+    from_sorted[slot] = pos;
+}
+
+void ggml_cuda_moe_build_sorted_ids(
+        const void * ids, int ne12, int n_expert_used, int ne02, int ne11,
+        size_t ids_nb0, size_t ids_nb1,
+        int32_t * ids_to_sorted, int32_t * ids_from_sorted,
+        int32_t * tokens_per_expert_dev,
+        int32_t * scratch_offsets, int32_t * scratch_fill,
+        cudaStream_t stream) {
+    const int n_slots = ne12 * n_expert_used;
+    const int TPB = 256;
+    const dim3 g_experts((ne02 + TPB - 1) / TPB);
+    const dim3 g_slots((n_slots + TPB - 1) / TPB);
+
+    k_moe_zero_i32<<<g_experts, TPB, 0, stream>>>(tokens_per_expert_dev, ne02);
+    k_moe_zero_i32<<<g_experts, TPB, 0, stream>>>(scratch_fill, ne02);
+
+    k_moe_hist<<<g_slots, TPB, 0, stream>>>(
+        (const char *)ids, n_slots, n_expert_used, ids_nb0, ids_nb1, tokens_per_expert_dev);
+
+    k_moe_excl_scan<<<1, 1, 0, stream>>>(tokens_per_expert_dev, scratch_offsets, ne02);
+
+    k_moe_scatter<<<g_slots, TPB, 0, stream>>>(
+        (const char *)ids, n_slots, n_expert_used, ne11, ids_nb0, ids_nb1,
+        scratch_offsets, scratch_fill, ids_to_sorted, ids_from_sorted);
+
+    CUDA_CHECK(cudaGetLastError());
+}

--- a/ggml/src/ggml-cuda/moe-devsort.cuh
+++ b/ggml/src/ggml-cuda/moe-devsort.cuh
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "common.cuh"
+
+// Device-side expert counting-sort for the large-batch MoE (MUL_MAT_ID) path.
+// Replaces the host loop that copies ids to the host, sorts token-slots by expert
+// on the CPU (GPU idle), and uploads the result. Produces, entirely on-device:
+//   ids_to_sorted   [ne_get_rows]  gather index into src1 for each sorted slot
+//   ids_from_sorted [ne_get_rows]  sorted position for each original (token,used) slot
+//   tokens_per_expert_dev [ne02]   count per expert (caller D2Hs this for GEMM sizing)
+// scratch_offsets / scratch_fill are caller-provided device scratch of ne02 int32 each.
+//
+// ids layout matches the host reader: expert = *(int32_t*)(ids + i12*ids_nb1 + iex*ids_nb0).
+void ggml_cuda_moe_build_sorted_ids(
+    const void * ids, int ne12, int n_expert_used, int ne02, int ne11,
+    size_t ids_nb0, size_t ids_nb1,
+    int32_t * ids_to_sorted, int32_t * ids_from_sorted,
+    int32_t * tokens_per_expert_dev,
+    int32_t * scratch_offsets, int32_t * scratch_fill,
+    cudaStream_t stream);


### PR DESCRIPTION
## Summary

The large-batch `MUL_MAT_ID` (MoE) path currently routes experts on the **host**: it copies the `ids` tensor device→host, then runs a CPU loop over `experts × tokens × top-k` to group token-slots by expert, bracketed by two `cudaStreamSynchronize`s. The GPU sits idle through all of it.

For a 256-expert model that loop is `O(ne02 × ne12 × n_expert_used)` and grows **linearly with the ubatch size**, while the GEMM it feeds gets *more* efficient per token as the batch grows. So the fixed-per-token CPU routing becomes a larger and larger slice of prefill as ubatch increases.

Measured stall (`std::chrono` around the loop + syncs, Qwen3-MoE 35B-A3B on gfx1100):

| ubatch | host-routing stall as % of prefill |
|---|---|
| 512 | ~9.5% |
| 2048 | ~24.8% |

## What this changes

Replaces the host loop with an **on-device counting sort** (`ggml/src/ggml-cuda/moe-devsort.cu`): histogram of tokens per expert → exclusive scan → scatter. It writes `ids_to_sorted` / `ids_from_sorted` straight into the existing device buffer; only `tokens_per_expert` (one `int32` per expert) is copied back to the host, which is still needed to size the per-expert GEMMs.

- **Bit-exact.** The device sort produces the same routing as the host loop; it only changes the *order of rows within an expert*, which cannot change any per-token GEMM result. Verified: greedy `llama-cli` generation is token-for-token identical to the host path on TQ3 (gfx1100) and TQ4_1S (gfx1030).
- **Weight-type agnostic.** It sorts `ids`; it never touches weights. Helps every MoE model that reaches this path, not just the turbo types.
- **Arch-neutral.** Only `atomicAdd(int)` and a small serial scan — no warp/wave-size assumptions — so it also carries to CDNA/MFMA parts unchanged.
- **On by default**, with `GGML_MOE_HOST_ROUTE=1` to force the original host loop (kept intact as the `else` branch, `GGML_ASSERT` and all).

## Benchmarks

`llama-bench`, no draft model, Qwen3-MoE 35B-A3B, ubatch 2048:

| GPU | arch | quant | pp512 | pp2048 |
|---|---|---|---|---|
| RX 7900 XTX | gfx1100 / RDNA3 | TQ3_1S | 837 → **987** (+18%) | 1384 → **1925** (+39%) |
| Radeon PRO V620 | gfx1030 / RDNA2 | TQ4_1S | 415 → **438** (+5.5%) | 711 → **781** (+9.9%) |

(RDNA2's smaller gain is expected — no matrix cores, so its GEMM is ~2× slower and the fixed routing loop is a smaller fraction of the longer prefill.)

## Notes / scope

- Correctness was validated end-to-end (bit-identical generation) rather than via `test-backend-ops`, because its `MUL_MAT_ID` cases are absorbed by the mmq/mmf paths before reaching this host-routed fallthrough, so they don't exercise it. Happy to add a targeted test if you'd like one.
- The host loop assumes distinct experts per token (its existing `GGML_ASSERT` enforces this); the device path counts each `(token, slot)` once, which agrees for all valid top-k routing.
