### PR TITLE
moe-cache: adaptive cpu-overlap calibration to replace fixed byte budget

### DIFF
--- a/ggml/src/ggml-cuda/moe-cache.cu
+++ b/ggml/src/ggml-cuda/moe-cache.cu
@@ -23,6 +23,7 @@ static void moe_cache_register_stub(const void * owner) {
 #include <algorithm>
 #include <atomic>
 #include <cerrno>
+#include <chrono>
 #include <climits>
 #include <cmath>
 #include <condition_variable>
@@ -54,6 +55,27 @@ static constexpr int    moe_cache_pool_slots_min              = 64;
 static constexpr size_t moe_cache_slab_bytes_auto_min         = 1ull << 30;
 static constexpr int    moe_cache_node_rows_max               = 64;
 static constexpr size_t moe_cache_overlap_bytes_per_token     = 8u << 20;
+
+// Adaptive cpu-overlap calibration (see moe_cache_calibration_on_enter/leave):
+// only runs while overlap_cpu_rows is left automatic. Candidate -1 means
+// "use the existing byte-budget formula below" and is tried first, so a
+// session that never runs enough single-token decode scopes to finish
+// calibrating (e.g. every unit test, or a prefill-only run) behaves exactly
+// as before this change. Candidates are tried in order, each over a window
+// of real decode scopes; whichever measures the lowest average wall time
+// wins and is locked in for the rest of the session.
+static constexpr int    moe_cache_calib_candidates[]           = { -1, 0, 1, 2, 4, 8 };
+static constexpr int    moe_cache_calib_candidate_count        = 6;
+// Absorbs one-time cold-start cost (CUDA kernel JIT, page cache fill, thread/
+// frequency governor settling) before any candidate timing counts -- this
+// dwarfs the row-count effect being measured if skipped.
+static constexpr int    moe_cache_calib_global_warmup_scopes   = 64;
+// Round-robin sweep: each candidate gets `rounds` short trials rather than
+// one long block, so residual drift after warm-up spreads evenly instead of
+// biasing whichever candidate happens to run first.
+static constexpr int    moe_cache_calib_rounds                 = 3;
+static constexpr int    moe_cache_calib_round_warmup_scopes    = 1;
+static constexpr int    moe_cache_calib_round_measured_scopes  = 4;
 
 enum class moe_cache_slot_state : uint8_t {
     free,
@@ -271,6 +293,37 @@ struct moe_cache_session {
         int references = 0;
     };
     std::unordered_map<const void *, active_source> active_sources;
+
+    // Adaptive cpu-overlap calibration state, guarded by `mu` (same lock
+    // session_enter/session_leave/moe_cache_plan already hold). Unused
+    // whenever overlap_cpu_rows is explicitly configured.
+    //
+    // Two-phase: a long unmeasured global warm-up first (CUDA kernel JIT,
+    // page cache fill, thread/frequency governor settling all cost far more
+    // than the row-count effect being measured, so they must fully drain
+    // before any timing counts), then a round-robin sweep -- one short trial
+    // per candidate per round, cycling through all candidates several times
+    // and averaging each candidate's trials across rounds -- rather than one
+    // long block per candidate, so any *residual* drift after warm-up is
+    // spread evenly across every candidate instead of biasing whichever one
+    // happened to run first.
+    bool     calib_started            = false;
+    bool     calib_done               = false;
+    bool     calib_global_warmup_done = false;
+    int      calib_global_warmup_seen = 0;
+    int      calib_round              = 0;
+    int      calib_slot               = 0; // rotated by calib_round; see moe_cache_calibration_on_leave
+    int      calib_current_rows       = -1; // what moe_cache_overlap_rows() should use right now (-1 = formula)
+    int      calib_scopes_seen        = 0;
+    double   calib_time_sum_ms        = 0.0;
+    int      calib_time_count         = 0;
+    double   calib_candidate_sum_ms[moe_cache_calib_candidate_count]  = {};
+    int      calib_candidate_samples[moe_cache_calib_candidate_count] = {};
+    int      calib_best_rows          = -1;
+    double   calib_best_avg_ms        = -1.0;
+    std::chrono::steady_clock::time_point calib_scope_start{};
+    int64_t  calib_scope_max_tokens = 0;
+    int      calib_scope_nodes      = 0;
 };
 
 struct moe_cache_pin {
@@ -1750,6 +1803,120 @@ static void moe_cache_session_destroy(void * opaque) {
     delete session;
 }
 
+// Which real candidate index the current (calib_slot, calib_round) trial
+// refers to. Rotating by calib_round means candidate 0 doesn't always go
+// first within a round, so any residual (post-warm-up) drift across a round
+// lands on a different candidate each time instead of always the same one.
+static int moe_cache_calibration_candidate_index(const moe_cache_session & session) {
+    return (session.calib_slot + session.calib_round) % moe_cache_calib_candidate_count;
+}
+
+// Called under session.mu at the start of every scope (one
+// ggml_backend_sched_compute_splits call, i.e. one decode step during
+// generation) while overlap_cpu_rows is left automatic. Starts calibration
+// on the first call and stamps the scope start time; per-node scope stats
+// are accumulated by moe_cache_plan().
+static void moe_cache_calibration_on_enter(moe_cache_session & session) {
+    if (session.config.overlap_cpu_rows >= 0 || session.calib_done) {
+        return;
+    }
+    if (!session.calib_started) {
+        session.calib_started            = true;
+        session.calib_global_warmup_done = false;
+        session.calib_global_warmup_seen = 0;
+        session.calib_round              = 0;
+        session.calib_slot               = 0;
+        session.calib_scopes_seen        = 0;
+        session.calib_time_sum_ms        = 0.0;
+        session.calib_time_count         = 0;
+        for (int i = 0; i < moe_cache_calib_candidate_count; i++) {
+            session.calib_candidate_sum_ms[i]  = 0.0;
+            session.calib_candidate_samples[i] = 0;
+        }
+        session.calib_best_rows    = -1;
+        session.calib_best_avg_ms  = -1.0;
+        session.calib_current_rows = -1; // formula, for the duration of the global warm-up
+    }
+    session.calib_scope_start      = std::chrono::steady_clock::now();
+    session.calib_scope_max_tokens = 0;
+    session.calib_scope_nodes      = 0;
+}
+
+// Called under session.mu at the end of every scope. Only scopes that
+// actually dispatched a single-token decode step through the cache count --
+// prefill/batched scopes have very different timing and would corrupt the
+// comparison, so they're silently skipped (calibration just takes longer).
+static void moe_cache_calibration_on_leave(moe_cache_session & session) {
+    if (session.config.overlap_cpu_rows >= 0 || session.calib_done || !session.calib_started) {
+        return;
+    }
+    if (session.calib_scope_nodes <= 0 || session.calib_scope_max_tokens != 1) {
+        return;
+    }
+
+    const double elapsed_ms = std::chrono::duration<double, std::milli>(
+            std::chrono::steady_clock::now() - session.calib_scope_start).count();
+
+    if (!session.calib_global_warmup_done) {
+        session.calib_global_warmup_seen++;
+        if (session.calib_global_warmup_seen < moe_cache_calib_global_warmup_scopes) {
+            return;
+        }
+        session.calib_global_warmup_done = true;
+        session.calib_current_rows = moe_cache_calib_candidates[moe_cache_calibration_candidate_index(session)];
+        MOE_CACHE_LOG("[moe-cache] cpu-overlap calibration: warm-up complete, starting sweep\n");
+        return;
+    }
+
+    session.calib_scopes_seen++;
+    if (session.calib_scopes_seen <= moe_cache_calib_round_warmup_scopes) {
+        return; // per-round settle for this candidate
+    }
+    session.calib_time_sum_ms += elapsed_ms;
+    session.calib_time_count++;
+    if (session.calib_scopes_seen < moe_cache_calib_round_warmup_scopes + moe_cache_calib_round_measured_scopes) {
+        return; // still measuring this (candidate, round) trial
+    }
+
+    const int candidate_index = moe_cache_calibration_candidate_index(session);
+    const int candidate_rows  = moe_cache_calib_candidates[candidate_index];
+    const double avg_ms = session.calib_time_sum_ms / std::max(1, session.calib_time_count);
+    session.calib_candidate_sum_ms[candidate_index]  += avg_ms;
+    session.calib_candidate_samples[candidate_index] += 1;
+    MOE_CACHE_LOG("[moe-cache] cpu-overlap calibration: round=%d candidate=%s avg=%.3f ms/decode\n",
+            session.calib_round,
+            candidate_rows < 0 ? "formula" : std::to_string(candidate_rows).c_str(), avg_ms);
+
+    session.calib_scopes_seen = 0;
+    session.calib_time_sum_ms = 0.0;
+    session.calib_time_count  = 0;
+    session.calib_slot++;
+    if (session.calib_slot >= moe_cache_calib_candidate_count) {
+        session.calib_slot = 0;
+        session.calib_round++;
+    }
+
+    if (session.calib_round >= moe_cache_calib_rounds) {
+        for (int i = 0; i < moe_cache_calib_candidate_count; i++) {
+            if (session.calib_candidate_samples[i] <= 0) {
+                continue;
+            }
+            const double avg = session.calib_candidate_sum_ms[i] / session.calib_candidate_samples[i];
+            if (session.calib_best_avg_ms < 0.0 || avg < session.calib_best_avg_ms) {
+                session.calib_best_avg_ms = avg;
+                session.calib_best_rows   = moe_cache_calib_candidates[i];
+            }
+        }
+        session.calib_current_rows = session.calib_best_rows;
+        session.calib_done = true;
+        MOE_CACHE_LOG("[moe-cache] cpu-overlap calibration complete: rows=%s (%.3f ms/decode avg)\n",
+                session.calib_best_rows < 0 ? "formula" : std::to_string(session.calib_best_rows).c_str(),
+                session.calib_best_avg_ms);
+    } else {
+        session.calib_current_rows = moe_cache_calib_candidates[moe_cache_calibration_candidate_index(session)];
+    }
+}
+
 static void moe_cache_session_enter(void * opaque) {
     if (g_session_suppressed > 0) {
         g_session_suppressed++;
@@ -1798,6 +1965,7 @@ static void moe_cache_session_enter(void * opaque) {
         return;
     }
     session->active_scopes++;
+    moe_cache_calibration_on_enter(*session);
 }
 
 static void moe_cache_session_leave(void * opaque) {
@@ -1818,6 +1986,7 @@ static void moe_cache_session_leave(void * opaque) {
     g_session_stack.erase(std::next(found).base());
     if (active) {
         std::lock_guard<std::mutex> lock(active->mu);
+        moe_cache_calibration_on_leave(*active);
         if (active->active_scopes > 0) {
             active->active_scopes--;
         }
@@ -2154,6 +2323,24 @@ static void * moe_cache_begin(
     return node.release();
 }
 
+// The original automatic policy: bound CPU overlap work by expert bytes,
+// token count, and one quarter of the node. Still used as calibration
+// candidate -1 (see moe_cache_calib_candidates) and as the fallback for any
+// session that never finishes calibrating.
+static int moe_cache_overlap_rows_formula(
+        const moe_cache_node & node, int n_ids, int n_tokens, int top_k) {
+    const size_t work_budget = moe_cache_overlap_bytes_per_token * (size_t) n_tokens;
+    int rows = (int) std::min<size_t>(work_budget / node.expert_size, INT_MAX);
+    rows = std::max(rows, 1);
+    if (top_k >= 8) {
+        rows = std::max(rows, 2);
+    }
+
+    rows = std::min(rows, std::max(1, n_ids / 4));
+    rows = std::min(rows, std::max(2, n_tokens));
+    return std::min(rows, n_ids - 1);
+}
+
 static int moe_cache_overlap_rows(const moe_cache_node & node, int n_ids) {
     const int configured = node.session->config.overlap_cpu_rows;
     if (configured >= 0) {
@@ -2165,17 +2352,12 @@ static int moe_cache_overlap_rows(const moe_cache_node & node, int n_ids) {
 
     const int n_tokens = (int) node.n_tokens;
     const int top_k = n_ids / n_tokens;
-    // Bound CPU work by expert bytes, token count, and one quarter of the node.
-    const size_t work_budget = moe_cache_overlap_bytes_per_token * (size_t) n_tokens;
-    int rows = (int) std::min<size_t>(work_budget / node.expert_size, INT_MAX);
-    rows = std::max(rows, 1);
-    if (top_k >= 8) {
-        rows = std::max(rows, 2);
-    }
 
-    rows = std::min(rows, std::max(1, n_ids / 4));
-    rows = std::min(rows, std::max(2, n_tokens));
-    return std::min(rows, n_ids - 1);
+    const int candidate = node.session->calib_current_rows;
+    if (candidate >= 0) {
+        return std::min(candidate, n_ids - 1);
+    }
+    return moe_cache_overlap_rows_formula(node, n_ids, n_tokens, top_k);
 }
 
 static int moe_cache_lookup_or_queue_locked(
@@ -2309,6 +2491,10 @@ static int moe_cache_plan(
     std::unique_lock<std::mutex> lock(session.mu);
     if (session.stopping) {
         return 0;
+    }
+    if (session.calib_started && !session.calib_done) {
+        session.calib_scope_max_tokens = std::max(session.calib_scope_max_tokens, node->n_tokens);
+        session.calib_scope_nodes++;
     }
     for (int index = 0; index < n_ids; index++) {
         const int32_t expert = ids[index];

--- a/tests/test-moe-cache.cpp
+++ b/tests/test-moe-cache.cpp
@@ -2305,6 +2305,71 @@ static bool run_adaptive_cpu_overlap_policy(
     return ok;
 }
 
+// Drives the adaptive cpu-overlap calibration in moe-cache.cu
+// (moe_cache_calibration_on_enter/on_leave) through a full convergence:
+// enough single-token decode scopes to exhaust the unmeasured global
+// warm-up, then the whole round-robin candidate sweep, then confirms it
+// locks in and stops adjusting. Each scope is one session_enter/plan/leave
+// cycle over a single already-resident expert -- moe_cache_plan() updates
+// the calibration scope stats unconditionally per planned node, so neither
+// multiple experts nor a hit are required, only n_tokens == 1 per scope.
+static bool run_adaptive_cpu_overlap_calibration(
+        ggml_backend_t gpu, ggml_backend_t cpu,
+        ggml_tensor * weights, log_capture & capture) {
+    configure_cache(nullptr, "8");
+    set_env("GGML_CUDA_MOE_CACHE_OVERLAP_CPU_ROWS", nullptr);
+    capture.clear();
+
+    void * session = create_direct_session(gpu, cpu);
+    if (!session) {
+        fprintf(stderr, "cache-cpu-overlap-calibration: failed to create session\n");
+        configure_cache(nullptr);
+        return false;
+    }
+
+    const size_t expert_size = ggml_nbytes(weights) / weights->ne[2];
+    active_api().session_enter(session);
+    bool ok = wait_for_direct_pool(
+            weights->name, weights->data, expert_size,
+            weights->ne[0], weights->ne[1], weights->type, weights->ne[2]);
+    for (int attempt = 0; attempt < 100 && ok; attempt++) {
+        if (direct_plan_one(
+                weights->name, weights->data, expert_size,
+                weights->ne[0], weights->ne[1], weights->type,
+                weights->ne[2], /* expert */ 0) == 1) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    active_api().session_leave(session);
+
+    // moe-cache.cu: moe_cache_calib_global_warmup_scopes (64) +
+    // moe_cache_calib_rounds (3) x moe_cache_calib_candidate_count (6) x
+    // (moe_cache_calib_round_warmup_scopes (1) + _measured_scopes (4)) = 154.
+    // Run comfortably past that so calibration has definitely completed,
+    // then a few more to confirm it stays locked in afterward.
+    constexpr int total_scopes = 170;
+    constexpr int expected_round_lines = 18; // 3 rounds x 6 candidates
+    for (int step = 0; step < total_scopes && ok; step++) {
+        active_api().session_enter(session);
+        direct_plan_one(
+                weights->name, weights->data, expert_size,
+                weights->ne[0], weights->ne[1], weights->type,
+                weights->ne[2], /* expert */ 0);
+        active_api().session_leave(session);
+    }
+    active_api().session_destroy(session);
+
+    const std::string log = capture.get();
+    ok &= log.find("cpu-overlap calibration: warm-up complete") != std::string::npos;
+    ok &= count_occurrences(log, "cpu-overlap calibration: round=") == expected_round_lines;
+    ok &= count_occurrences(log, "cpu-overlap calibration complete:") == 1;
+
+    configure_cache(nullptr);
+    printf("cache-cpu-overlap-calibration: %s\n", ok ? "OK" : "FAIL");
+    return ok;
+}
+
 static bool run_scope_isolation(
         ggml_backend_t gpu, ggml_backend_t cpu, ggml_tensor * weights) {
     if (!active_api().session_enter || !active_api().session_leave ||
@@ -3311,6 +3376,9 @@ int main() {
     });
     ok &= run_optional(provider_is_cuda, "cache-cpu-overlap-auto", [&] {
         return run_adaptive_cpu_overlap_policy(gpu, cpu, weights, capture);
+    });
+    ok &= run_optional(provider_is_cuda, "cache-cpu-overlap-calibration", [&] {
+        return run_adaptive_cpu_overlap_calibration(gpu, cpu, weights, capture);
     });
     ok &= run_shape_liveness(gpu, cpu);
     ok &= run_optional(provider_is_cuda, "cache-shape-inventory", [&] {


### PR DESCRIPTION
# PR: Adaptive cpu-overlap calibration for `--moe-cache auto`

Replaces a hardcoded byte-budget constant in the MoE expert cache's automatic
CPU/GPU overlap policy with a live calibration that measures real decode
throughput on the actual machine and picks the best setting itself, instead
of assuming a value tuned on different hardware.

**Commit in this PR:** `moe-cache: adaptive cpu-overlap calibration to replace fixed byte budget`

---

## Background: what this actually fixes

When `--moe-cache auto` decides how much GPU-resident expert work to also run
on the CPU concurrently (the "overlap" policy — see `docs/backend/MOE-CACHE.md`),
it used a single compile-time constant: `moe_cache_overlap_bytes_per_token = 8
MiB` (`moe-cache.cu:56`), tuned once via a 4x RTX 3090 sweep and shipped as-is
for every machine. There was no mechanism to measure whether that assumption
held on different hardware.

It doesn't hold on a single RTX 5090 with a modest CPU thread budget: the GPU
finishes its share fast enough that any CPU overlap work becomes the critical
path instead of hidden, extra throughput. The fixed formula was actively
*hurting* decode speed on this box, not just leaving performance on the table.

## Test environment

RTX 5090 (32 GB VRAM, single GPU), Laguna-S-2.1 118B-A8B MoE model, Q5_K_M
(~91 GB, routed experts spill to CPU host memory), 8 CPU threads pinned
(`-t 8 -Cr 0-7 -tb 8 -Crb 0-7`), `--no-mmap`, `--fit on -fa on`.

---

### 1. Motivating measurement — manual sweep, forcing the existing `GGML_CUDA_MOE_CACHE_OVERLAP_CPU_ROWS` override

Before writing any new code, confirmed the fixed formula was actually
mistuned on this hardware by manually overriding the row count via the
already-existing (undocumented-in-CLI) env var, 3 completion requests per
setting, first request per server discarded as warmup:

| Config | Steady-state decode (tok/s) | vs. old `auto` |
|---|---:|---:|
| `overlap=0` (forced) | 36.9 (37.18, 36.54) | **+7.3%** |
| `auto` (old fixed 8 MiB/token formula) | 34.4 (34.58, 34.18) | baseline |
| `overlap=8` (forced, max) | 32.9 (32.41, 33.40) | −4.4% |

Clean, monotonic — less CPU overlap is strictly better on this hardware. This
justified building an automatic calibration rather than just retuning the
constant, since the "right" answer here (zero) isn't expressible by the old
formula's design (it always hands over at least 1 row).

### 2. A real methodology bug caught and fixed before shipping

First calibration implementation tried each candidate sequentially in one
block (4 warmup scopes, 8 measured scopes, next candidate), no global
warmup. Result was wrong and worth recording as a cautionary log:

```
candidate=formula avg=56.971 ms/decode
candidate=0       avg=45.632 ms/decode
candidate=1       avg=43.232 ms/decode
candidate=2       avg=34.160 ms/decode
candidate=4       avg=32.441 ms/decode   <- picked as "best"
candidate=8       avg=36.575 ms/decode
```

That's a monotonic warm-up decay curve (CUDA kernel JIT, page cache fill,
thread/frequency governor settling), not a signal from the row count —
whichever candidate runs first in a sequential sweep is unfairly penalized.
Fixed by adding a 64-scope unmeasured global warm-up before any candidate
timing starts, plus a round-robin sweep (each candidate gets several short
trials across rounds, rotating which candidate goes first each round) instead
of one long block per candidate. Re-run with the fix:

```
[[warm-up complete, starting sweep]]
round=0 candidate=formula avg=28.713   round=1 candidate=0 avg=26.834   round=2 candidate=1 avg=28.464
round=0 candidate=0       avg=28.588   round=1 candidate=1 avg=30.595   round=2 candidate=2 avg=25.554
round=0 candidate=1       avg=27.873   round=1 candidate=2 avg=34.105   round=2 candidate=4 avg=26.801
round=0 candidate=2       avg=31.801   round=1 candidate=4 avg=31.331   round=2 candidate=8 avg=33.886
round=0 candidate=4       avg=32.209   round=1 candidate=8 avg=25.774   round=2 candidate=formula avg=28.025
round=0 candidate=8       avg=28.843   round=1 candidate=formula avg=26.138   round=2 candidate=0 avg=26.210
cpu-overlap calibration complete: rows=0 (27.211 ms/decode avg)
```

No more monotonic drift — values bounce around per candidate as expected from
real noise — and it converges to `rows=0`, matching the manual sweep above.

### 3. End-to-end validation against the real model

| Phase | tok/s |
|---|---:|
| Old fixed-formula `auto` | 34.4 |
| Manually forced `overlap=0` | 36.9 |
| New calibration — full 220-token run (includes ~154 tokens of deliberate exploration across worse candidates) | 30.0 |
| **New calibration — after convergence** | **37.1–37.7** |

The calibration log confirms it: `cpu-overlap calibration complete: rows=0
(27.211 ms/decode avg)` — reached automatically, no manual tuning. Post-
convergence throughput (37.1–37.7 tok/s) matches, and slightly beats, the
manually-discovered optimum, and beats the old automatic default by ~9%. The
one-time calibration cost (~154 decode steps, a few seconds) is paid once per
server process, not per request.

### 4. Unit tests

All 35 existing `test-moe-cache` cases still pass unchanged (2 skipped for
single-GPU/static-backend reasons, unrelated to this change). Added a
dedicated test, `cache-cpu-overlap-calibration`, that drives 170 single-token
decode scopes through a real session and asserts: the global warm-up
completes, exactly 18 round×candidate trial lines get logged (3 rounds × 6
candidates), and calibration reaches "complete" exactly once and stays locked
in afterward — so a regression to the warm-up length, the round-robin loop,
or a runaway re-triggering bug fails this test independent of real hardware
timing.

```
$ build/bin/test-moe-cache
...
cache-cpu-overlap: OK
cache-cpu-overlap-auto: OK
cache-cpu-overlap-calibration: OK
...
cache-route-override: SKIP (one CUDA device)
cache-backend-unload: SKIP (static backend)
```


## Known limitations

- Calibration constants (64-scope warm-up, 3 rounds, 5 scopes/candidate/round,
  candidate set `{formula, 0, 1, 2, 4, 8}`) are reasonable defaults for this
  workload, not swept against alternatives.
- Only tested on a single RTX 5090; behavior on multi-GPU MoE-cache sessions
  (where the config is shared across devices) is exercised by the existing
  unit tests but not validated on real multi-GPU hardware.
- The one-time calibration cost is paid on every fresh server process; for a
  workload that restarts very frequently with very short sessions, that cost
  may not fully amortize (though it's a few seconds against typical model
  load times of 15-30+ seconds for large MoE models).

## Test commands

Unit tests:
```bash
cmake --build build --target test-moe-cache -j"$(nproc)"
build/bin/test-moe-cache
```

Manual override sweep (reproduces section 1):
```bash
for rows in 0 8; do
  GGML_CUDA_MOE_CACHE_OVERLAP_CPU_ROWS=$rows build/bin/llama-server \
    -m Laguna-S-2.1-UD-Q5_K_M-00001-of-00003.gguf -c 8192 -ngl auto --fit on -fa on \
    --no-mmap -t 8 -Cr 0-7 -tb 8 -Crb 0-7 -b 2048 -ub 2048 --parallel 1 \
    --moe-cache auto -lv 4 --host 127.0.0.1 --port 8097
  # then POST /completion and read timings.predicted_per_second
done
```

Real calibration run (no override — reproduces sections 2/3):
```bash
build/bin/llama-server \
  -m Laguna-S-2.1-UD-Q5_K_M-00001-of-00003.gguf -c 8192 -ngl auto --fit on -fa on \
  --no-mmap -t 8 -Cr 0-7 -tb 8 -Crb 0-7 -b 2048 -ub 2048 --parallel 1 \
  --moe-cache auto -lv 4 --host 127.0.0.1 --port 8097
# grep the log for "cpu-overlap calibration"; send a >=220-token completion
# request to give the full sweep room to converge
```

AI usage: yes