### PR TITLE
cuda: wave64 (CDNA2 / gfx90a) correctness for turbo KV-cache + ConvRot

### DIFF
--- a/ggml/src/ggml-cuda/fattn-vec.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec.cuh
@@ -435,7 +435,7 @@ static __global__ void flash_attn_ext_vec(
 #pragma unroll
             for (int j = 0; j < ncols; ++j) {
                 if constexpr (V_is_turbo) {
-                    const float kq_val = __shfl_sync(0xFFFFFFFF, KQ_reg[j], k0 + (nthreads_V == WARP_SIZE ? 0 : threadIdx.x / nthreads_V));
+                    const float kq_val = __shfl_sync(0xFFFFFFFF, KQ_reg[j], k0 + (nthreads_V == WARP_SIZE ? 0 : threadIdx.x / nthreads_V), WARP_SIZE);
                     KQ_k[j] = make_half2(__float2half(kq_val), __float2half(kq_val));
                 } else {
                     KQ_k[j] = __half2half2(KQ[j*nthreads + k]);
@@ -483,7 +483,7 @@ static __global__ void flash_attn_ext_vec(
 #pragma unroll
             for (int j = 0; j < ncols; ++j) {
                 if constexpr (V_is_turbo) {
-                    KQ_k[j] = __shfl_sync(0xFFFFFFFF, KQ_reg[j], k0 + (nthreads_V == WARP_SIZE ? 0 : threadIdx.x / nthreads_V));
+                    KQ_k[j] = __shfl_sync(0xFFFFFFFF, KQ_reg[j], k0 + (nthreads_V == WARP_SIZE ? 0 : threadIdx.x / nthreads_V), WARP_SIZE);
                 } else {
                     KQ_k[j] = KQ[j*nthreads + k];
                 }

--- a/ggml/src/ggml-cuda/mmv-cr.cu
+++ b/ggml/src/ggml-cuda/mmv-cr.cu
@@ -91,10 +91,10 @@ static __device__ __forceinline__ void convrot_inverse_registers(
 #pragma unroll
         for (int component = 0; component < 4; ++component) {
             const float v = values.value[component];
-            const float a = __shfl_sync(0xffffffff, v, base + col);
-            const float b = __shfl_sync(0xffffffff, v, base + half + col);
-            const float c = __shfl_sync(0xffffffff, v, base + 2*half + col);
-            const float d = __shfl_sync(0xffffffff, v, base + 3*half + col);
+            const float a = __shfl_sync(0xffffffff, v, base + col,          WARP_SIZE);
+            const float b = __shfl_sync(0xffffffff, v, base + half + col,   WARP_SIZE);
+            const float c = __shfl_sync(0xffffffff, v, base + 2*half + col, WARP_SIZE);
+            const float d = __shfl_sync(0xffffffff, v, base + 3*half + col, WARP_SIZE);
             values.value[component] = cr_radix4(a, b, c, d, radix_row);
         }
     }
@@ -141,10 +141,10 @@ static __device__ __forceinline__ float convrot_inverse_group(
         const int base = lane & ~(len - 1);
         const int r = (lane/half) & 3;
         const int col = lane & (half - 1);
-        const float a = __shfl_sync(0xffffffff, v, base + col);
-        const float b = __shfl_sync(0xffffffff, v, base + half + col);
-        const float c = __shfl_sync(0xffffffff, v, base + 2*half + col);
-        const float d = __shfl_sync(0xffffffff, v, base + 3*half + col);
+        const float a = __shfl_sync(0xffffffff, v, base + col,          WARP_SIZE);
+        const float b = __shfl_sync(0xffffffff, v, base + half + col,   WARP_SIZE);
+        const float c = __shfl_sync(0xffffffff, v, base + 2*half + col, WARP_SIZE);
+        const float d = __shfl_sync(0xffffffff, v, base + 3*half + col, WARP_SIZE);
         v = r == 0 ?  a + b + c - d :
             r == 1 ?  a + b - c + d :
             r == 2 ?  a - b + c + d :
@@ -342,7 +342,7 @@ static __global__ void mul_mat_vec_cr_cooperative(
         row_sum += exchange[row_in_cta][p + 32];
 #pragma unroll
         for (int stride = 16; stride > 0; stride /= 2) {
-            row_sum += __shfl_down_sync(0xffffffff, row_sum, stride);
+            row_sum += __shfl_down_sync(0xffffffff, row_sum, stride, WARP_SIZE);
         }
         if (p == 0 && active_row) {
             y[token*m + row] = row_sum;

--- a/ggml/src/ggml-cuda/set-rows.cu
+++ b/ggml/src/ggml-cuda/set-rows.cu
@@ -384,17 +384,21 @@ static __global__ void k_set_rows_turbo3(
     uint8_t qs_byte = 0;
 #pragma unroll
     for (int k = 0; k < 4; k++) {
-        uint8_t contrib = __shfl_sync(0xffffffff, my_low2, (lane & ~3) + k);
+        uint8_t contrib = __shfl_sync(0xffffffff, my_low2, (lane & ~3) + k, WARP_SIZE);
         qs_byte |= contrib << (k * 2);
     }
     if (lane % 4 == 0) blk->qs[qs_byte_idx] = qs_byte;
 
-    // Pack signs: 8 elements per byte, 1 bit each.  __ballot_sync across warp.
-    // Ballot is per-warp (32 bits); extract local byte, write to global position in block.
-    const uint32_t ballot = __ballot_sync(0xffffffff, (idx >> 2) & 1);
-    const int local_signs_byte = lane / 8;             // byte within 32-bit ballot (0..3)
+    // Pack signs: 8 elements per byte, 1 bit each. Gather each 8-lane group's sign bits
+    // via a width-32 shuffle so the group is self-contained on wave64 (a __ballot_sync
+    // returns a 64-bit mask there and would truncate into uint32_t). Same idiom as qs.
+    const uint8_t my_sign = (idx >> 2) & 1;
     const int global_signs_byte = elem_in_block / 8;   // byte within block's signs array
-    const uint8_t signs_byte = (uint8_t)((ballot >> (local_signs_byte * 8)) & 0xFF);
+    uint8_t signs_byte = 0;
+#pragma unroll
+    for (int sb = 0; sb < 8; sb++) {
+        signs_byte |= (uint8_t)(__shfl_sync(0xffffffff, my_sign, (lane & ~7) + sb, WARP_SIZE) << sb);
+    }
     if (lane % 8 == 0) blk->signs[global_signs_byte] = signs_byte;
 
     // ---- Step 7: Reconstruction norm (parallel, same pattern as step 2) ----
@@ -513,14 +517,18 @@ static __global__ void k_set_rows_turbo3_tail(
     uint8_t qs_byte = 0;
 #pragma unroll
     for (int k = 0; k < 4; k++) {
-        uint8_t contrib = __shfl_sync(0xffffffff, my_low2, (lane & ~3) + k);
+        uint8_t contrib = __shfl_sync(0xffffffff, my_low2, (lane & ~3) + k, WARP_SIZE);
         qs_byte |= contrib << (k * 2);
     }
     if (lane % 4 == 0) blk->qs[lane / 4] = qs_byte;
 
-    const uint32_t ballot = __ballot_sync(0xffffffff, (idx >> 2) & 1);
+    const uint8_t my_sign = (idx >> 2) & 1;
     const int signs_byte_idx = lane / 8;
-    const uint8_t signs_byte = (uint8_t)((ballot >> (signs_byte_idx * 8)) & 0xFF);
+    uint8_t signs_byte = 0;
+#pragma unroll
+    for (int sb = 0; sb < 8; sb++) {
+        signs_byte |= (uint8_t)(__shfl_sync(0xffffffff, my_sign, (lane & ~7) + sb, WARP_SIZE) << sb);
+    }
     if (lane % 8 == 0) blk->signs[signs_byte_idx] = signs_byte;
 
     // ---- Reconstruction norm ----
@@ -763,7 +771,7 @@ static __global__ void k_set_rows_turbo2(
     uint8_t qs_byte = 0;
 #pragma unroll
     for (int k = 0; k < 4; k++) {
-        uint8_t contrib = __shfl_sync(0xffffffff, my_bits, (lane & ~3) + k);
+        uint8_t contrib = __shfl_sync(0xffffffff, my_bits, (lane & ~3) + k, WARP_SIZE);
         qs_byte |= contrib << (k * 2);
     }
     if (lane % 4 == 0) blk->qs[elem_in_block / 4] = qs_byte;
@@ -877,7 +885,7 @@ static __global__ void k_set_rows_turbo2_tail(
     uint8_t qs_byte = 0;
 #pragma unroll
     for (int k = 0; k < 4; k++) {
-        uint8_t contrib = __shfl_sync(0xffffffff, my_bits, (lane & ~3) + k);
+        uint8_t contrib = __shfl_sync(0xffffffff, my_bits, (lane & ~3) + k, WARP_SIZE);
         qs_byte |= contrib << (k * 2);
     }
     if (lane % 4 == 0) blk->qs[lane / 4] = qs_byte;
@@ -1104,7 +1112,7 @@ static __global__ void k_set_rows_turbo4(
     const uint8_t my_nibble = idx & 0xF;
     uint8_t qs_byte = 0;
     // Gather nibble from partner thread
-    uint8_t partner_nibble = __shfl_sync(0xffffffff, my_nibble, lane ^ 1);
+    uint8_t partner_nibble = __shfl_sync(0xffffffff, my_nibble, lane ^ 1, WARP_SIZE);
     if (j % 2 == 0) {
         qs_byte = my_nibble | (partner_nibble << 4);
         blk->qs[j / 2] = qs_byte;

--- a/ggml/src/ggml-cuda/set-rows.cu
+++ b/ggml/src/ggml-cuda/set-rows.cu
@@ -304,7 +304,7 @@ static __global__ void k_set_rows_turbo3(
     float v = x[j];
     float v2 = v * v;
     for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1)
-        v2 += __shfl_xor_sync(0xffffffff, v2, offset);
+        v2 += __shfl_xor_sync(0xffffffff, v2, offset, WARP_SIZE);
     if (j % WARP_SIZE == 0)
         warp_accum[j / WARP_SIZE] = v2;
     __syncthreads();
@@ -405,7 +405,7 @@ static __global__ void k_set_rows_turbo3(
     const float c = TURBO_CENTROIDS_3BIT[idx];
     float rc = c * c;
     for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1)
-        rc += __shfl_xor_sync(0xffffffff, rc, offset);
+        rc += __shfl_xor_sync(0xffffffff, rc, offset, WARP_SIZE);
     if (j % WARP_SIZE == 0)
         warp_accum[j / WARP_SIZE] = rc;
     __syncthreads();
@@ -490,7 +490,7 @@ static __global__ void k_set_rows_turbo3_tail(
     __shared__ float warp_accum[4];  // max 3 warps (tail ≤ 96)
     float v2 = val * val;
     for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1)
-        v2 += __shfl_xor_sync(0xffffffff, v2, offset);
+        v2 += __shfl_xor_sync(0xffffffff, v2, offset, WARP_SIZE);
     if (lane == 0) warp_accum[warp_id] = v2;
     __syncthreads();
 
@@ -535,7 +535,7 @@ static __global__ void k_set_rows_turbo3_tail(
     const float c = TURBO_CENTROIDS_3BIT[idx];
     float rc = c * c;
     for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1)
-        rc += __shfl_xor_sync(0xffffffff, rc, offset);
+        rc += __shfl_xor_sync(0xffffffff, rc, offset, WARP_SIZE);
     if (lane == 0) warp_accum[warp_id] = rc;
     __syncthreads();
 
@@ -693,7 +693,7 @@ static __global__ void k_set_rows_turbo2(
     float v = x[j];
     float v2 = v * v;
     for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1)
-        v2 += __shfl_xor_sync(0xffffffff, v2, offset);
+        v2 += __shfl_xor_sync(0xffffffff, v2, offset, WARP_SIZE);
     if (j % WARP_SIZE == 0)
         warp_accum[j / WARP_SIZE] = v2;
     __syncthreads();
@@ -782,7 +782,7 @@ static __global__ void k_set_rows_turbo2(
     const float c = TURBO_CENTROIDS_2BIT[idx];
     float rc = c * c;
     for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1)
-        rc += __shfl_xor_sync(0xffffffff, rc, offset);
+        rc += __shfl_xor_sync(0xffffffff, rc, offset, WARP_SIZE);
     if (j % WARP_SIZE == 0)
         warp_accum[j / WARP_SIZE] = rc;
     __syncthreads();
@@ -858,7 +858,7 @@ static __global__ void k_set_rows_turbo2_tail(
     __shared__ float warp_accum[4];
     float v2 = val * val;
     for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1)
-        v2 += __shfl_xor_sync(0xffffffff, v2, offset);
+        v2 += __shfl_xor_sync(0xffffffff, v2, offset, WARP_SIZE);
     if (lane == 0) warp_accum[warp_id] = v2;
     __syncthreads();
 
@@ -894,7 +894,7 @@ static __global__ void k_set_rows_turbo2_tail(
     const float c = TURBO_CENTROIDS_2BIT[idx];
     float rc = c * c;
     for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1)
-        rc += __shfl_xor_sync(0xffffffff, rc, offset);
+        rc += __shfl_xor_sync(0xffffffff, rc, offset, WARP_SIZE);
     if (lane == 0) warp_accum[warp_id] = rc;
     __syncthreads();
 
@@ -1049,7 +1049,7 @@ static __global__ void k_set_rows_turbo4(
     float v = x[j];
     float v2 = v * v;
     for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1)
-        v2 += __shfl_xor_sync(0xffffffff, v2, offset);
+        v2 += __shfl_xor_sync(0xffffffff, v2, offset, WARP_SIZE);
     if (j % WARP_SIZE == 0)
         warp_accum[j / WARP_SIZE] = v2;
     __syncthreads();
@@ -1122,7 +1122,7 @@ static __global__ void k_set_rows_turbo4(
     const float c = TURBO_CENTROIDS_4BIT[idx];
     float rc = c * c;
     for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1)
-        rc += __shfl_xor_sync(0xffffffff, rc, offset);
+        rc += __shfl_xor_sync(0xffffffff, rc, offset, WARP_SIZE);
     if (j % WARP_SIZE == 0)
         warp_accum[j / WARP_SIZE] = rc;
     __syncthreads();

--- a/ggml/src/ggml-cuda/turbo-wht.cu
+++ b/ggml/src/ggml-cuda/turbo-wht.cu
@@ -72,7 +72,7 @@ static __global__ void k_turbo_wht_f32(const float * __restrict__ src,
     // Intra-warp butterfly (h = 1, 2, 4, 8, 16)
 #pragma unroll
     for (int h = 1; h < 32; h <<= 1) {
-        float o = __shfl_xor_sync(0xffffffff, val, h);
+        float o = __shfl_xor_sync(0xffffffff, val, h, WARP_SIZE);
         val = (lane & h) ? (o - val) : (val + o);
     }
 


### PR DESCRIPTION
Makes the turbo KV-cache and ConvRot CR kernels correct on **wave64** (CDNA / gfx90a / MI210), which previously produced garbage there. Validated on an MI210 — this brings CDNA2 up as a working turbo target.

## Root cause

The turbo kernels compute a *logical* `lane = j % WARP_SIZE` (WARP_SIZE is the 32-lane tile width, not the physical wave) then call `__shfl_*_sync` with the width argument omitted, so on wave64 the shuffle spans the full 64-lane physical wave and reaches across the 32-lane logical-warp boundary. Fix = the explicit-width idiom already used correctly in these files (`convrot.cu`, `fwht.cu`, `fattn-vec.cuh:401`): pass `WARP_SIZE` as the shuffle width so each 32-lane subsection stays self-contained.

## Commits

1. **ConvRot CR mat-vec** (`mmv-cr.cu`) — the `convrot_inverse` butterflies + the cooperative-kernel reduction. Fixes the `q6_cr`/`q8_cr` MUL_MAT test-backend-ops failures on gfx90a (1694 → 1696/1697; the remaining CR fail is a pre-existing flaky on tiny random shapes, unrelated to wave size).
2. **Turbo KV write** (`set-rows.cu`) — the qs/nibble gathers in `k_set_rows_turbo2/3/4` (+tails). The `__ballot_sync` sign-packs are converted to the same width-32 shuffle-gather the qs packing uses (`__ballot_sync` returns a 64-bit mask on wave64 and was being truncated into a `uint32_t`).
3. **Turbo KV read** (`fattn-vec.cuh`) — the softmax-weight broadcast to the V-accumulation lanes (turbo-V only; non-turbo V spills KQ to shared memory). This was the root cause of turbo-V garbage.
4. **Hardening** — explicit `WARP_SIZE` width on the intra-warp XOR reductions (set-rows norm/recon + the turbo-wht butterfly). Correct today because their offsets are always < 32, so no functional change; this removes the latent wave64 fragility.

## Validation (MI210 / gfx90a)

- `test-backend-ops` MUL_MAT: `q6_cr`/`q8_cr` wave64 failures fixed.
- Turbo KV coherence (1253-token needle-in-haystack, `cache_type_k=turbo3` / `cache_type_v=turbo4`): output went from total garbage to coherent with the needle correctly recalled. Isolation (`f16`-K/`turbo4`-V vs `turbo3`-K/`f16`-V) confirmed the K and V turbo paths are each independently correct after the fixes.
