### PR TITLE
[1/2] cuda: check mmvf applies before the AMD MUL_MAT_ID shortcut

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2166,7 +2166,13 @@ static void ggml_cuda_mul_mat_id(ggml_backend_cuda_context & ctx, ggml_tensor * 
                     return;
                 }
             } else if (!ggml_is_quantized(src0->type)) {
-                if (GGML_CUDA_CC_IS_AMD(cc)) {
+                // ggml_cuda_mul_mat_vec_f() needs an even column count and suitably aligned
+                // strides. ggml_cuda_should_use_mmvf() is exactly that predicate, and the
+                // non-id path above already consults it; this shortcut did not, so an expert
+                // matrix with an odd k reached the kernel and tripped its ncols assert.
+                // Declining here falls through to the sorted-routing path below.
+                if (GGML_CUDA_CC_IS_AMD(cc) &&
+                    ggml_cuda_should_use_mmvf(src0->type, cc, src0->ne, src0->nb, src1->ne[2])) {
                     ggml_cuda_mul_mat_vec_f(ctx, src0, src1, ids, dst);
                     return;
                 }


### PR DESCRIPTION
> **Series: MoE MUL_MAT_ID coverage on AMD — part 1/2**
>
> - **[1/2] this PR** — fix the crash that aborts the MUL_MAT_ID suite on AMD
> - [2/2] #335 — add TurboQuant MUL_MAT_ID coverage at real MoE model shapes (branched on this)
>
> This part stands alone and is worth merging on its own; #335 needs it to run at all.

## Overview

`ggml_cuda_mul_mat_id()` has an AMD-only shortcut that calls `ggml_cuda_mul_mat_vec_f()` directly for non-quantized experts. Unlike the non-id path (which reaches the kernel via `ggml_cuda_should_fuse_mul_mat_vec_f` → `ggml_cuda_should_use_mmvf`), this shortcut never consulted that predicate — and `ggml_cuda_should_use_mmvf()` is precisely what rejects the shapes the kernel cannot take: an odd column count (`src0_ne[0] % 2 != 0`) and strides not aligned to twice the type size.

An expert matrix with an odd `k` therefore reached the kernel and tripped `GGML_ASSERT(ncols % 2 == 0)` in `mmvf.cu`.

This is not hypothetical. `test-backend-ops -o MUL_MAT_ID` hits it in the `all_types` sweep at

```cpp
test_mul_mat_id(type_a, GGML_TYPE_F32, 4, 2, false, 64, 1, 3*ggml_blck_size(type_a))
```

where f32 gives `k = 3`. On an MI210 the suite dumps core after 11 cases, so every later type — including all of the TurboQuant MUL_MAT_ID coverage — never ran.

The fix consults the existing predicate, and falls through to the sorted-routing path below when it declines.

## Additional information

`test-backend-ops -o MUL_MAT_ID` on an MI210 (gfx90a), ROCm 7.2.3:

| | result |
|---|---|
| before | core dump after 11 cases |
| after | **967/967 tests passed** |

This is another instance of the pattern AGENTS.md already documents — *"A green run means the cases that ran passed, not that your change was exercised."* Here it is worse than a silent skip: the process aborts, so the TQ3_1S/TQ4_1S MUL_MAT_ID sweep has not been executing on AMD at all.

Found while validating TurboQuant MoE work across CDNA2 / RDNA3 / RDNA2. The fix itself is independent of TurboQuant and applies to any non-quantized MoE expert tensor with an odd `k` on an AMD backend.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — Claude Code (Opus 5) was used throughout: it diagnosed the crash from the `test-backend-ops` core dump, traced it to the missing `ggml_cuda_should_use_mmvf()` check, wrote this patch and its commit message, and ran the before/after verification on the MI210. I reviewed the change and am responsible for every line of it.  (I'm actually having surgery on my arm tomorrow;  after that and some recovery hopefully typing will be less of a problem and I won't need to lean so heavily on the mechanical assistance.)
