### PR TITLE
[2/2] test: cover TurboQuant MUL_MAT_ID at real MoE model shapes

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2166,7 +2166,13 @@ static void ggml_cuda_mul_mat_id(ggml_backend_cuda_context & ctx, ggml_tensor * 
                     return;
                 }
             } else if (!ggml_is_quantized(src0->type)) {
-                if (GGML_CUDA_CC_IS_AMD(cc)) {
+                // ggml_cuda_mul_mat_vec_f() needs an even column count and suitably aligned
+                // strides. ggml_cuda_should_use_mmvf() is exactly that predicate, and the
+                // non-id path above already consults it; this shortcut did not, so an expert
+                // matrix with an odd k reached the kernel and tripped its ncols assert.
+                // Declining here falls through to the sorted-routing path below.
+                if (GGML_CUDA_CC_IS_AMD(cc) &&
+                    ggml_cuda_should_use_mmvf(src0->type, cc, src0->ne, src0->nb, src1->ne[2])) {
                     ggml_cuda_mul_mat_vec_f(ctx, src0, src1, ids, dst);
                     return;
                 }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9693,6 +9693,19 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         }
     }
 
+    // TurboQuant MUL_MAT_ID at the shapes a real MoE model uses. The sweep above runs 4 experts
+    // with k=256, which is nothing like a real router: Qwen3.6-35B-A3B (qwen35moe) has 256
+    // experts with 8 used per token, gate/up of [2048 x 512] and down of [512 x 2048]. Expert
+    // counts in the hundreds change how the routing is built and how few slots each expert
+    // gets, and n spans both sides of MMVQ_MAX_BATCH_SIZE so this covers the decode matvec and
+    // the MMQ prefill path rather than only one of them.
+    for (ggml_type type_a : {GGML_TYPE_TQ3_1S, GGML_TYPE_TQ4_1S}) {
+        for (int n : {1, 9, 32}) {
+            test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 256, 8, false,  512, n, 2048)); // gate/up
+            test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 256, 8, false, 2048, n,  512)); // down
+        }
+    }
+
     for (ggml_type type_a : base_types) {
         for (ggml_type type_b : {GGML_TYPE_F32 /*, GGML_TYPE_F16 */}) {
             for (int n_mats : {4, 8}) {


### PR DESCRIPTION
> **Series: MoE MUL_MAT_ID coverage on AMD — part 2/2**
>
> - [1/2] #334 — `cuda: check mmvf applies before the AMD MUL_MAT_ID shortcut`
> - **[2/2] this PR** — add TurboQuant MUL_MAT_ID coverage at real MoE model shapes
>
> **Depends on #334**, and is branched on it. Without that fix `test-backend-ops -o MUL_MAT_ID` aborts after 11 cases on AMD, so none of the cases added here would execute.

## Overview

The existing TQ3_1S/TQ4_1S MUL_MAT_ID sweep runs 4 experts with `k=256`. That is nothing like a real router. Qwen3.6-35B-A3B (`qwen35moe`) has **256 experts with 8 used per token**, gate/up of `[2048 x 512]` and down of `[512 x 2048]`.

Expert counts in the hundreds change how the routing is built and how few slots each expert ends up with, and those are the dimensions the MoE decode matvec and the MMQ prefill path actually see in service. `n` spans both sides of `MMVQ_MAX_BATCH_SIZE` so both paths are covered rather than just one.

Adds 12 cases (2 types x 2 projections x n in {1, 9, 32}).

## Additional information

This closes a real gap rather than a theoretical one. AGENTS.md already records that the MUL_MAT_ID sweep used `n=16` only and so never touched MoE decode, and that a green run "means the cases that ran passed, not that your change was exercised". Between that and the abort fixed in #334, the TurboQuant MoE path has had effectively no exercised coverage at model scale on AMD — which matters because the MoE decode matvec is where most of the TurboQuant decode work lives.

Verified on an MI210 (gfx90a), ROCm 7.2.3, on top of #334: `test-backend-ops -o MUL_MAT_ID` gives **979/979 passing**, up from 967/967 with #334 alone. The suite takes about 47s.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — Claude Code (Opus 5) was used: it read the model's real MoE dimensions out of the GGUF, wrote these cases and the commit message, and ran the verification on the MI210. I reviewed the change and am responsible for every line of it.
