### PR TITLE
cuda: TurboQuant TQ4_1S decode optimisations (TQ-only half of #338)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,9 +88,9 @@ A green run means the cases that ran passed, not that your change was exercised.
 - **Metal**: turbo kernels need their `[[host_name]]` instantiations; a missing one is a NULL-pipeline deref on the first turbo KV write.
 - **Vulkan**: SET_ROWS pipeline registration must include TURBO2_0/3_0/4_0 with `require_full_subgroups=true, subgroup_size=32`, or every turbo KV write aborts.
 - **CUDA dispatch**: TQ weights must be excluded from the mmvq path before the fused-TQ branch (`ggml_cuda_should_use_mmvq`), or `GGML_TQ_NATIVE=1` aborts.
-- **CUDA TQ4_1S decode**: the centroid LUT in `mmvq-tq.cu` must use plain shifts, not `__byte_perm` - constant selectors fold differently from runtime ones on some toolchains and silently produce garbage output (NMSE ~1.0). Comment in the file explains; do not "clean up" the shift code.
+- **CUDA TQ4_1S decode**: the centroid LUT in `mmvq-tq.cu` decodes through `get_int_from_table_16`, then re-interleaves even/odd bytes with constant selectors (`__byte_perm(v.x, v.y, 0x5140 / 0x7362)` on nvcc and MUSA, `__builtin_amdgcn_perm` on HIP), the same pattern `vecdotq.cuh` already uses. The old garbage output (NMSE ~1.0) came from the earlier permute chain, not from constant selectors. Verified numerically on GB10 (sm_121) and MI210 (gfx90a). Gate any change to this function on a CUDA-side `test-backend-ops -o MUL_MAT -p type_a=tq4_1s` run on an NVIDIA card plus the AMD run, not on a clean compile.
 - **DeepSeek/MLA**: K and V cache types must be identical; turbo FA auto-enable runs before upstream's quantized-V FA check.
-- **MoE models**: CUDA graphs are auto-disabled for TQ `MUL_MAT_ID`.
+- **MoE models**: the small-batch TQ `MUL_MAT_ID` path routes experts on device and stays CUDA-graph capturable (`[TAG_MUL_MAT_ID_CUDA_GRAPHS]` in `ggml-cuda.cu`); buffers it hands to kernels must outlive every captured graph, so caches retire outgrown buffers instead of freeing them. The large-batch path dequantizes to f16 cuBLAS and synchronizes the stream.
 - **gguf-py**: keep model constants deduplicated; stacked-duplicate merge artifacts crash `import gguf`.
 
 > [!IMPORTANT]

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1453,6 +1453,8 @@ struct ggml_backend_cuda_context {
         const void *        data = nullptr;
         uint64_t            epoch = 0;
         size_t              size = 0;
+        struct retired_buf { char * ptr; size_t cap; int dev; };
+        std::vector<retired_buf> retired;        // outgrown buffers, freed at teardown (captured graphs may still use them)
     } tq_rot_cache;
 
     uint64_t graph_epoch = 1;

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1442,6 +1442,21 @@ struct ggml_backend_cuda_context {
     // release-after-use path (avoids the legacy pool retaining the temp; ref llama.cpp #22107).
     bool fa_f16_use_pool = false;
 
+    // Same idea for the TQ activation pre-rotation (forward block WHT + q8_1 quantize): the MoE
+    // gate and up projections consume the same normed activation, so the rotation ran twice per
+    // layer. Keyed by tensor identity, data pointer, size and graph-eval epoch; main-stream only.
+    struct {
+        char *              ptr  = nullptr;
+        size_t              cap  = 0;
+        int                 dev  = -1;
+        const ggml_tensor * src1 = nullptr;
+        const void *        data = nullptr;
+        uint64_t            epoch = 0;
+        size_t              size = 0;
+    } tq_rot_cache;
+
+    uint64_t graph_epoch = 1;
+
 #ifdef USE_CUDA_GRAPH
     // Map from first_node_ptr to cuda_graph - allows multiple graphs per context
     // when the computation is split across CPU/GPU (e.g., with --n-cpu-moe)

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -736,6 +736,13 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {
     std::unique_lock<std::mutex> lock(ggml_cuda_lock);
     ggml_cuda_lock_cv.wait(lock, []{ return ggml_cuda_lock_counter.load(std::memory_order_relaxed) == 0; });
 
+    // Return the pre-rotation cache buffer before the pools are destroyed
+    // (the legacy pool asserts on outstanding allocations at teardown).
+    if (tq_rot_cache.ptr != nullptr) {
+        pool(tq_rot_cache.dev).free(tq_rot_cache.ptr, tq_rot_cache.cap);
+        tq_rot_cache.ptr = nullptr;
+    }
+
     if (copy_event != nullptr) {
         CUDA_CHECK(cudaEventDestroy(copy_event));
     }
@@ -4460,6 +4467,9 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend, 
     ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backend->context;
 
     ggml_cuda_set_device(cuda_ctx->device);
+
+    // New graph eval: invalidate the TQ pre-rotation cache (see tq_rot_cache in common.cuh).
+    cuda_ctx->graph_epoch++;
 
     bool use_cuda_graph             = false;
     bool cuda_graph_update_required = false;

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -736,12 +736,16 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {
     std::unique_lock<std::mutex> lock(ggml_cuda_lock);
     ggml_cuda_lock_cv.wait(lock, []{ return ggml_cuda_lock_counter.load(std::memory_order_relaxed) == 0; });
 
-    // Return the pre-rotation cache buffer before the pools are destroyed
+    // Return the pre-rotation cache buffers before the pools are destroyed
     // (the legacy pool asserts on outstanding allocations at teardown).
     if (tq_rot_cache.ptr != nullptr) {
         pool(tq_rot_cache.dev).free(tq_rot_cache.ptr, tq_rot_cache.cap);
         tq_rot_cache.ptr = nullptr;
     }
+    for (const auto & r : tq_rot_cache.retired) {
+        pool(r.dev).free(r.ptr, r.cap);
+    }
+    tq_rot_cache.retired.clear();
 
     if (copy_event != nullptr) {
         CUDA_CHECK(cudaEventDestroy(copy_event));

--- a/ggml/src/ggml-cuda/mmvq-tq.cu
+++ b/ggml/src/ggml-cuda/mmvq-tq.cu
@@ -903,7 +903,6 @@ static const block_q8_1 * tq_prerotate_q8_1_cached(ggml_backend_cuda_context & c
                                                    const float * src1_d,
                                                    int n_act_elements,
                                                    ggml_cuda_pool_alloc<block_q8_1> & fallback) {
-    const int    id       = ggml_cuda_get_device();
     cudaStream_t stream   = ctx.stream();
     const int    n_blocks = n_act_elements / 32;
     const size_t bytes    = (size_t) n_blocks * sizeof(block_q8_1);
@@ -921,11 +920,14 @@ static const block_q8_1 * tq_prerotate_q8_1_cached(ggml_backend_cuda_context & c
     block_q8_1 * dst = nullptr;
     if (cacheable) {
         if (rc.dev != ctx.device || rc.cap < bytes) {
-            if (rc.ptr != nullptr && rc.dev == ctx.device) {
-                ctx.pool(rc.dev).free(rc.ptr, rc.cap);
+            // Never free a buffer here: a CUDA graph captured earlier may still replay
+            // kernels that point at it (several graphs per context with --n-cpu-moe splits).
+            // Retire it and release everything at context teardown instead.
+            if (rc.ptr != nullptr) {
+                rc.retired.push_back({ rc.ptr, rc.cap, rc.dev });
             }
             size_t actual = 0;
-            rc.ptr = (char *) ctx.pool(id).alloc(bytes, &actual);
+            rc.ptr = (char *) ctx.pool().alloc(bytes, &actual);
             rc.cap = actual;
             rc.dev = ctx.device;
         }
@@ -943,6 +945,21 @@ static const block_q8_1 * tq_prerotate_q8_1_cached(ggml_backend_cuda_context & c
     const dim3 pgrid((n_blocks + wpb - 1) / wpb);
     tq_prerotate_q8_1<<<pgrid, pblock, 0, stream>>>(src1_d, dst, n_act_elements);
     return dst;
+}
+
+// GGML_TQ_LPR debug knob. Only 2/4/8/16/32 have a kernel instantiation, so any other value
+// sizes the grid for one lanes-per-row but launches the 32-lane kernel and leaves rows unwritten.
+static int tq_lpr_env() {
+    const char * env = getenv("GGML_TQ_LPR");
+    if (env == nullptr) {
+        return 0;
+    }
+    const int lpr = atoi(env);
+    if (lpr != 2 && lpr != 4 && lpr != 8 && lpr != 16 && lpr != 32) {
+        GGML_LOG_WARN("%s: ignoring invalid GGML_TQ_LPR=%s (want 2, 4, 8, 16 or 32)\n", __func__, env);
+        return 0;
+    }
+    return lpr;
 }
 
 // Small-batch (decode / light speculative) TQ MoE: single fused, graph-capturable launch.
@@ -1001,7 +1018,7 @@ void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx,
         // Pick lanes-per-row so every lane gets a useful number of blocks (>= 4) while keeping
         // the reduction short. GGML_TQ_LPR overrides for experiments.
         const int blocks_per_row_h = ncols_x / 32;
-        static const int lpr_env = getenv("GGML_TQ_LPR") ? atoi(getenv("GGML_TQ_LPR")) : 0;
+        static const int lpr_env = tq_lpr_env();
         int lpr = lpr_env;
         if (lpr == 0) {
             // 16 measured best on CDNA: 4 reduction rounds instead of 5, while the warp still
@@ -1010,7 +1027,7 @@ void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx,
             // on AMD, so NVIDIA keeps the previous 32. Never assign more lanes than there are
             // blocks, so no lane sits idle on narrow projections.
             lpr = GGML_CUDA_CC_IS_AMD(cc) ? 16 : 32;
-            while (lpr > 1 && blocks_per_row_h < lpr) {
+            while (lpr > 2 && blocks_per_row_h < lpr) {   // floor at 2: the switch below has no 1-lane kernel
                 lpr /= 2;
             }
         }

--- a/ggml/src/ggml-cuda/mmvq-tq.cu
+++ b/ggml/src/ggml-cuda/mmvq-tq.cu
@@ -993,7 +993,6 @@ void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx,
 
     if (use_dp4a) {
         // Pre-rotate activations to q8_1, contiguous [ncols_x, nchannels_y, n_tokens].
-        const int n_blocks_total = n_act_elements / 32;
         ggml_cuda_pool_alloc<block_q8_1> q8_buf(ctx.pool(id));
         const block_q8_1 * q8_act = tq_prerotate_q8_1_cached(ctx, src1, src1_d, n_act_elements, q8_buf);
         const int64_t stride_channel_y = ncols_x / 32;                           // q8_1 blocks to next y-channel

--- a/ggml/src/ggml-cuda/mmvq-tq.cu
+++ b/ggml/src/ggml-cuda/mmvq-tq.cu
@@ -816,6 +816,7 @@ static __global__ void mul_mat_tq4_1s_scalar_moe(
 // NVIDIA TQ4_1S dp4a MoE variant: same device-side ids routing as the scalar kernels above, but
 // the int8 dp4a inner loop of mul_mat_tq4_1s_dp4a_multi (warp-strided over blocks, q8_1 activations,
 // packed-centroid LUT). One dot product per (row, expert_slot, sample) output element.
+template <int LPR>   // lanes cooperating on one output row (must divide WARP_SIZE)
 static __global__ void mul_mat_tq4_1s_dp4a_moe(
         const void       * __restrict__ vx,
         const block_q8_1 * __restrict__ vy_q8,      // pre-rotated activations (q8_1)
@@ -831,7 +832,15 @@ static __global__ void mul_mat_tq4_1s_dp4a_moe(
         const int64_t stride_channel_dst,
         const int64_t stride_sample_dst) {
 
-    const int row = blockIdx.x * MMVQ_TQ_NWARPS + threadIdx.y;
+    // One row per LPR lanes: each lane covers blocks_per_row/LPR blocks and the cross-lane
+    // reduction is log2(LPR) rounds instead of 5. With LPR == WARP_SIZE this is the classic
+    // one-row-per-warp mapping.
+    constexpr int rows_per_warp = WARP_SIZE / LPR;
+
+    const int lane_in_row = threadIdx.x % LPR;
+    const int row_in_warp = threadIdx.x / LPR;
+
+    const int row = (blockIdx.x * MMVQ_TQ_NWARPS + threadIdx.y) * rows_per_warp + row_in_warp;
     if (row >= nrows_x) return;
 
     const int expert_slot = blockIdx.y;
@@ -839,7 +848,7 @@ static __global__ void mul_mat_tq4_1s_dp4a_moe(
     const int expert      = ids[sample * ids_stride + expert_slot];
     const int channel_y   = expert_slot % nchannels_y;
 
-    const int lane = threadIdx.x;
+    const int lane = lane_in_row;
     const int blocks_per_row = ncols_x / QK_TQ4_1S;
     const block_tq4_1s * x_row =
         (const block_tq4_1s *) ((const char *) vx + (int64_t) expert * nb_expert)
@@ -847,7 +856,7 @@ static __global__ void mul_mat_tq4_1s_dp4a_moe(
     const block_q8_1 * a_base = vy_q8 + sample * stride_sample_y + (int64_t) channel_y * stride_channel_y;
 
     float sumf = 0.0f;
-    for (int ib = lane; ib < blocks_per_row; ib += WARP_SIZE) {
+    for (int ib = lane; ib < blocks_per_row; ib += LPR) {
         const block_tq4_1s * blk = &x_row[ib];
         const float fd0 = __half2float(blk->d0);
         const float fd1 = __half2float(blk->d1);
@@ -875,8 +884,8 @@ static __global__ void mul_mat_tq4_1s_dp4a_moe(
 
     sumf *= TQ4_CENTROID_I8_RESCALE;
     #pragma unroll
-    for (int offset = 16; offset > 0; offset >>= 1) {
-        sumf += __shfl_xor_sync(0xffffffff, sumf, offset);
+    for (int offset = LPR / 2; offset > 0; offset >>= 1) {
+        sumf += __shfl_xor_sync(0xffffffff, sumf, offset, LPR);
     }
 
     if (lane == 0) {
@@ -989,10 +998,43 @@ void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx,
         const block_q8_1 * q8_act = tq_prerotate_q8_1_cached(ctx, src1, src1_d, n_act_elements, q8_buf);
         const int64_t stride_channel_y = ncols_x / 32;                           // q8_1 blocks to next y-channel
         const int64_t stride_sample_y  = (int64_t) nchannels_y * (ncols_x / 32); // q8_1 blocks to next token
-        mul_mat_tq4_1s_dp4a_moe<<<grid, block, 0, stream>>>(
-            src0->data, q8_act, dst_d, ids_d, ncols_x, nrows_x,
-            nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y,
-            stride_channel_dst, stride_sample_dst);
+
+        // Pick lanes-per-row so every lane gets a useful number of blocks (>= 4) while keeping
+        // the reduction short. GGML_TQ_LPR overrides for experiments.
+        const int blocks_per_row_h = ncols_x / 32;
+        static const int lpr_env = getenv("GGML_TQ_LPR") ? atoi(getenv("GGML_TQ_LPR")) : 0;
+        int lpr = lpr_env;
+        if (lpr == 0) {
+            // 16 measured best on CDNA: 4 reduction rounds instead of 5, while the warp still
+            // reads only two contiguous weight regions (smaller LPR scatters reads across more
+            // rows and loses more to coalescing than it saves on the reduction). Only measured
+            // on AMD, so NVIDIA keeps the previous 32. Never assign more lanes than there are
+            // blocks, so no lane sits idle on narrow projections.
+            lpr = GGML_CUDA_CC_IS_AMD(cc) ? 16 : 32;
+            while (lpr > 1 && blocks_per_row_h < lpr) {
+                lpr /= 2;
+            }
+        }
+
+        const int rows_per_warp_h = WARP_SIZE / lpr;
+        const int rows_per_wg     = MMVQ_TQ_NWARPS * rows_per_warp_h;
+        const dim3 grid_l((unsigned) ((nrows_x + rows_per_wg - 1) / rows_per_wg),
+                          (unsigned) n_expert_used, (unsigned) n_tokens);
+
+        #define TQ_LAUNCH_MOE(L) mul_mat_tq4_1s_dp4a_moe<L><<<grid_l, block, 0, stream>>>( \
+            src0->data, q8_act, dst_d, ids_d, ncols_x, nrows_x, \
+            nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y, \
+            stride_channel_dst, stride_sample_dst)
+
+        switch (lpr) {
+            case 32: TQ_LAUNCH_MOE(32); break;
+            case 16: TQ_LAUNCH_MOE(16); break;
+            case  8: TQ_LAUNCH_MOE( 8); break;
+            case  4: TQ_LAUNCH_MOE( 4); break;
+            case  2: TQ_LAUNCH_MOE( 2); break;
+            default: TQ_LAUNCH_MOE(32); break;
+        }
+        #undef TQ_LAUNCH_MOE
     } else {
         // Pre-rotate activations to float (WHT), contiguous [ncols_x, nchannels_y, n_tokens].
         ggml_cuda_pool_alloc<float> act_buf(ctx.pool(id), n_act_elements);

--- a/ggml/src/ggml-cuda/mmvq-tq.cu
+++ b/ggml/src/ggml-cuda/mmvq-tq.cu
@@ -890,6 +890,58 @@ static __global__ void mul_mat_tq4_1s_dp4a_moe(
     }
 }
 
+// Shared activation pre-rotation (forward block WHT -> q8_1). The MoE gate and up projections
+// consume the same normed activation, so without caching the rotation ran once per projection.
+// Keyed by tensor identity, data pointer, size and graph-eval epoch; main stream only (a sibling
+// stream could otherwise consume the buffer with no cross-stream ordering). Returns a device
+// pointer valid for the rest of this graph eval.
+static const block_q8_1 * tq_prerotate_q8_1_cached(ggml_backend_cuda_context & ctx,
+                                                   const ggml_tensor * src1,
+                                                   const float * src1_d,
+                                                   int n_act_elements,
+                                                   ggml_cuda_pool_alloc<block_q8_1> & fallback) {
+    const int    id       = ggml_cuda_get_device();
+    cudaStream_t stream   = ctx.stream();
+    const int    n_blocks = n_act_elements / 32;
+    const size_t bytes    = (size_t) n_blocks * sizeof(block_q8_1);
+
+    static const bool disabled = getenv("GGML_TQ_ROTCACHE") != nullptr && atoi(getenv("GGML_TQ_ROTCACHE")) == 0;
+
+    auto & rc = ctx.tq_rot_cache;
+    const bool cacheable = !disabled && ctx.curr_stream_no == 0 && bytes <= (1u << 20);
+
+    if (cacheable && rc.epoch == ctx.graph_epoch && rc.src1 == src1 && rc.data == src1->data &&
+        rc.size == bytes && rc.dev == ctx.device) {
+        return (const block_q8_1 *) rc.ptr;
+    }
+
+    block_q8_1 * dst = nullptr;
+    if (cacheable) {
+        if (rc.dev != ctx.device || rc.cap < bytes) {
+            if (rc.ptr != nullptr && rc.dev == ctx.device) {
+                ctx.pool(rc.dev).free(rc.ptr, rc.cap);
+            }
+            size_t actual = 0;
+            rc.ptr = (char *) ctx.pool(id).alloc(bytes, &actual);
+            rc.cap = actual;
+            rc.dev = ctx.device;
+        }
+        dst      = (block_q8_1 *) rc.ptr;
+        rc.src1  = src1;
+        rc.data  = src1->data;
+        rc.epoch = ctx.graph_epoch;
+        rc.size  = bytes;
+    } else {
+        dst = fallback.alloc(n_blocks);
+    }
+
+    const int  wpb = 4;
+    const dim3 pblock(32, wpb);
+    const dim3 pgrid((n_blocks + wpb - 1) / wpb);
+    tq_prerotate_q8_1<<<pgrid, pblock, 0, stream>>>(src1_d, dst, n_act_elements);
+    return dst;
+}
+
 // Small-batch (decode / light speculative) TQ MoE: single fused, graph-capturable launch.
 // Requires contiguous src1 (checked by the caller) so the flat WHT pre-rotation is valid.
 void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx,
@@ -939,17 +991,12 @@ void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx,
     if (use_dp4a) {
         // Pre-rotate activations to q8_1, contiguous [ncols_x, nchannels_y, n_tokens].
         const int n_blocks_total = n_act_elements / 32;
-        ggml_cuda_pool_alloc<block_q8_1> q8_buf(ctx.pool(id), n_blocks_total);
-        {
-            const int wpb = 4;
-            const dim3 pblock(32, wpb);
-            const dim3 pgrid((n_blocks_total + wpb - 1) / wpb);
-            tq_prerotate_q8_1<<<pgrid, pblock, 0, stream>>>(src1_d, q8_buf.get(), n_act_elements);
-        }
+        ggml_cuda_pool_alloc<block_q8_1> q8_buf(ctx.pool(id));
+        const block_q8_1 * q8_act = tq_prerotate_q8_1_cached(ctx, src1, src1_d, n_act_elements, q8_buf);
         const int64_t stride_channel_y = ncols_x / 32;                           // q8_1 blocks to next y-channel
         const int64_t stride_sample_y  = (int64_t) nchannels_y * (ncols_x / 32); // q8_1 blocks to next token
         mul_mat_tq4_1s_dp4a_moe<<<grid, block, 0, stream>>>(
-            src0->data, q8_buf.get(), dst_d, ids_d, ncols_x, nrows_x,
+            src0->data, q8_act, dst_d, ids_d, ncols_x, nrows_x,
             nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y,
             stride_channel_dst, stride_sample_dst);
     } else {

--- a/ggml/src/ggml-cuda/mmvq-tq.cu
+++ b/ggml/src/ggml-cuda/mmvq-tq.cu
@@ -93,8 +93,15 @@ __device__ __forceinline__ void tq4_cents8_reg(uint32_t four_bytes, int &c0, int
 
     // v.x = centroids for even elements (0,2,4,6), v.y = odd elements (1,3,5,7).
     // Interleave back to natural order: c0 = [e0,e1,e2,e3], c1 = [e4,e5,e6,e7].
+#if defined(GGML_USE_HIP)
     c0 = (int) __builtin_amdgcn_perm(v.y, v.x, 0x05010400);
     c1 = (int) __builtin_amdgcn_perm(v.y, v.x, 0x07030602);
+#else
+    // nvcc / MUSA: prmt selector nibbles pick bytes 0-3 from the first operand and 4-7 from
+    // the second. Same byte order as the HIP form above.
+    c0 = __byte_perm(v.x, v.y, 0x5140);
+    c1 = __byte_perm(v.x, v.y, 0x7362);
+#endif
 }
 
 // ============================================================================

--- a/ggml/src/ggml-cuda/mmvq-tq.cu
+++ b/ggml/src/ggml-cuda/mmvq-tq.cu
@@ -77,37 +77,24 @@ static constexpr float TQ4_CENTROID_I8_RESCALE = 2.733f / 127.0f;
 // Register-based centroid lookup: maps 4 qs bytes (1 uint32) to 2 packed 4× centroid_i8 for dp4a.
 // Processes a full uint32 at once, sharing nibble extraction across both byte pairs.
 __device__ __forceinline__ void tq4_cents8_reg(uint32_t four_bytes, int &c0, int &c1) {
-    // Centroid i8 values packed into 4 registers (little-endian byte order):
-    // [-127,-96,-75,-58] [-44,-31,-18,-6] [6,18,31,44] [58,75,96,127]
-    constexpr uint32_t CR03 = 0xC6B5A081u;
-    constexpr uint32_t CR47 = 0xFAEEE1D4u;
-    constexpr uint32_t CR8B = 0x2C1F1206u;
-    constexpr uint32_t CRCF = 0x7F604B3Au;
+    // 4 qs bytes -> 8 nibble indices -> 8 int8 centroids, in natural element order
+    // (element 2k = low nibble of byte k, element 2k+1 = high nibble of byte k).
+    //
+    // This uses the hardware byte-permute (v_perm_b32) through get_int_from_table_16, the same
+    // path IQ4_NL/MXFP4 use on ROCm. NOTE: do NOT express this with HIP's __byte_perm() wrapper
+    // -- with a runtime selector its generic fallback lowers through a dynamically indexed byte
+    // union that PromoteAlloca turns into a 32KB LDS staging area plus ds_read_u8 chains, which
+    // caps occupancy and costs ~3x. __builtin_amdgcn_perm maps 1:1 to the instruction.
+    //
+    // The previous shift-based fallback avoided that bug but cost ~100 ALU ops per call (~400
+    // per 32-weight block), which made the TQ decode kernels ALU-bound rather than
+    // bandwidth-bound on CDNA.
+    const int2 v = get_int_from_table_16((int) four_bytes, kvalues_tq4);
 
-    // element j: qs byte j/2, nibble (j&1) — even → low nibble, odd → high nibble
-    const uint32_t lo = four_bytes & 0x0F0F0F0Fu;
-    const uint32_t hi = (four_bytes >> 4) & 0x0F0F0F0Fu;
-
-    // Interleave: bytes 0-1 -> sel0 [n0,n1,n2,n3], bytes 2-3 -> sel1 [n4,n5,n6,n7].
-    // __byte_perm is NOT used for the interleave/LUT: its selector encoding is
-    // compiler-dependent (constant selectors fold differently from runtime ones),
-    // which silently broke the original permute chain on some toolchains.
-    // Plain shifts are deterministic.
-    uint32_t sel0 = (lo & 0xFFu) | ((hi & 0xFFu) << 8) | ((lo & 0xFF00u) << 8) | ((hi & 0xFF00u) << 16);
-    uint32_t sel1 = ((lo >> 16) & 0xFFu) | (((hi >> 16) & 0xFFu) << 8) | (((lo >> 24) & 0xFFu) << 16) | (((hi >> 24) & 0xFFu) << 24);
-
-    // nibble v in 0..15 -> centroid_i8 byte: v<8 selects CR03/CR47, v>=8 selects CR8B/CRCF,
-    // v&4 picks the second register of the pair, byte offset is v&3.
-    auto cent = [&](uint32_t v) -> uint32_t {
-        const uint32_t lo_reg = (v & 4u) ? CR47 : CR03;
-        const uint32_t hi_reg = (v & 4u) ? CRCF : CR8B;
-        return (((v & 8u) ? hi_reg : lo_reg) >> (8u * (v & 3u))) & 0xFFu;
-    };
-
-    c0 = (int)(cent(sel0 & 0xFFu) | (cent((sel0 >> 8) & 0xFFu) << 8)
-             | (cent((sel0 >> 16) & 0xFFu) << 16) | (cent((sel0 >> 24) & 0xFFu) << 24));
-    c1 = (int)(cent(sel1 & 0xFFu) | (cent((sel1 >> 8) & 0xFFu) << 8)
-             | (cent((sel1 >> 16) & 0xFFu) << 16) | (cent((sel1 >> 24) & 0xFFu) << 24));
+    // v.x = centroids for even elements (0,2,4,6), v.y = odd elements (1,3,5,7).
+    // Interleave back to natural order: c0 = [e0,e1,e2,e3], c1 = [e4,e5,e6,e7].
+    c0 = (int) __builtin_amdgcn_perm(v.y, v.x, 0x05010400);
+    c1 = (int) __builtin_amdgcn_perm(v.y, v.x, 0x07030602);
 }
 
 // ============================================================================

--- a/ggml/src/ggml-cuda/mmvq-tq.cu
+++ b/ggml/src/ggml-cuda/mmvq-tq.cu
@@ -932,7 +932,9 @@ void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx,
 
     // NVIDIA TQ4_1S: int8 dp4a path (matches the non-MoE dispatch in ggml_cuda_mul_mat_tq).
     // TQ3_1S (all vendors) + TQ4_1S on AMD: scalar float path (dp4a regresses on RDNA4; no dp4a TQ3).
-    const bool use_dp4a = !GGML_CUDA_CC_IS_AMD(cc) && src0->type == GGML_TYPE_TQ4_1S;
+    // CDNA (gfx90a) has proper v_dot4_i32_i8 throughput, unlike RDNA4 where dp4a regresses --
+    // so enable the int8 dp4a decode path on CDNA too, not just NVIDIA.
+    const bool use_dp4a = (!GGML_CUDA_CC_IS_AMD(cc) || GGML_CUDA_CC_IS_CDNA(cc)) && src0->type == GGML_TYPE_TQ4_1S;
 
     if (use_dp4a) {
         // Pre-rotate activations to q8_1, contiguous [ncols_x, nchannels_y, n_tokens].
@@ -998,7 +1000,9 @@ void ggml_cuda_mul_mat_tq(ggml_backend_cuda_context & ctx,
     const int id = ggml_cuda_get_device();
     const int cc = ggml_cuda_info().devices[id].cc;
     const int n_total_elements = ncols_x * ncols_dst;
-    const bool use_dp4a = !GGML_CUDA_CC_IS_AMD(cc) && src0->type == GGML_TYPE_TQ4_1S;
+    // CDNA (gfx90a) has proper v_dot4_i32_i8 throughput, unlike RDNA4 where dp4a regresses --
+    // so enable the int8 dp4a decode path on CDNA too, not just NVIDIA.
+    const bool use_dp4a = (!GGML_CUDA_CC_IS_AMD(cc) || GGML_CUDA_CC_IS_CDNA(cc)) && src0->type == GGML_TYPE_TQ4_1S;
 
     if (use_dp4a) {
         // NVIDIA TQ4_1S: dp4a int8 path (optimized for Turing+ dp4a throughput)


### PR DESCRIPTION
> This is the TQ-only half of #338, split as requested in review; the generic fusions are in the companion PR, which is stacked on this one. Based on the branch tip after #336 merged.

## Overview

Four patches on the TurboQuant decode path, all TQ4_1S-specific and all exercised by `test-backend-ops`:

| # (in #338) | patch | effect |
|---|---|---|
| 1 | enable the int8 dp4a decode path on CDNA | 94.3 → 95.4 t/s |
| 5 | cache the TQ activation pre-rotation across MoE projections | ~neutral, structural |
| 6 | decode TQ4 centroids with `v_perm_b32` instead of shift arithmetic | **+14%** |
| 8 | lanes-per-row mapping for the TQ4_1S MoE decode matvec | +3.1% |

Patch 2 of #338 (the deep TQ4_1S MoE down-proj + weighted-sum fuse) is dropped entirely: the generic reduce tail in the companion PR measured faster than it (100.0 vs 99.0 tg128), so there is no reason to carry the slower kernel behind a knob.

Changes relative to #338 from the review:

- Patch 5 now carries the per-eval epoch increment it relied on (in #338 that line lived in patch 3), and no longer touches the dropped deep-fuse kernel.
- Patch 8's lanes-per-row default of 16 is gated to AMD (`GGML_CUDA_CC_IS_AMD(cc) ? 16 : 32`), since every measurement behind it is MI210; NVIDIA keeps 32.
- The duplicated "16 measured best on CDNA" comment is gone.
- Tom's nvcc/MUSA guard for `tq4_cents8_reg()` (949de16b7) is carried over.

## Additional information

MI210 (gfx90a), ROCm 7.2.3, Qwen3.6-35B-A3B-TQ4max: numbers per patch are as measured in #338; the combined figures for this subset are in the first comment below once CI is green.

`test-backend-ops -o MUL_MAT -p type_a=tq4_1s` and `-o MUL_MAT_ID`: 149/149 and 38/38 on the MI210 (gfx90a, ROCm 7.2.3), with `GGML_TQ_MMQ=1` set so the native path is the one exercised. The full `-o MUL_MAT` suite is 1697/1697 on the final run of this branch; an earlier run showed the `q5_cr` ConvRot case flaking, as it does on the pristine base on random data.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — Claude Code was used throughout this series: profiling and diagnosis, the kernel work, commit messages, the review fixes and the verification runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxP6x5bmUDYFvmouceN2mR
