### PR TITLE
cuda: shared-quantize cache, residual and elementwise-chain fusions (generic half of #338)

### DIFF
--- a/ggml/src/ggml-cuda/chain.cu
+++ b/ggml/src/ggml-cuda/chain.cu
@@ -1,0 +1,50 @@
+#include "chain.cuh"
+#include "unary.cuh"
+
+#define TQ_CHAIN_BLOCK 256
+
+// The op loop is uniform across threads (k is the same for every lane), so the switch costs a
+// few scalar instructions per op and never diverges. Everything between ops stays in a register.
+static __global__ void k_elem_chain(const float * __restrict__ src,
+                                    float * __restrict__ dst,
+                                    const tq_chain_desc desc,
+                                    const int64_t n) {
+    const int64_t i = (int64_t) blockIdx.x * TQ_CHAIN_BLOCK + threadIdx.x;
+    if (i >= n) {
+        return;
+    }
+
+    float v = src[i];
+
+#pragma unroll 1
+    for (int k = 0; k < desc.n_ops; ++k) {
+        const float * o_ptr = desc.other[k];
+        const float   o     = o_ptr ? (desc.bcast[k] ? o_ptr[0] : o_ptr[i]) : 0.0f;
+
+        switch (desc.code[k]) {
+            case TQ_CHAIN_ADD:      v = v + o; break;
+            case TQ_CHAIN_MUL:      v = v * o; break;
+            case TQ_CHAIN_DIV:      v = desc.chain_is_lhs[k] ? (v / o) : (o / v); break;
+            case TQ_CHAIN_SCALE:    v = v * desc.p0[k] + desc.p1[k]; break;
+            case TQ_CHAIN_CLAMP:    v = fminf(fmaxf(v, desc.p0[k]), desc.p1[k]); break;
+            case TQ_CHAIN_SILU:     v = v / (1.0f + expf(-v)); break;
+            case TQ_CHAIN_SIGMOID:  v = 1.0f / (1.0f + expf(-v)); break;
+            case TQ_CHAIN_SOFTPLUS: v = (v > 20.0f) ? v : logf(1.0f + expf(v)); break;  // same form as op_softplus
+            case TQ_CHAIN_GELU:     v = ggml_cuda_op_gelu_single(v); break;  // same form as op_gelu
+            case TQ_CHAIN_RELU:     v = fmaxf(v, 0.0f); break;
+            case TQ_CHAIN_NEG:      v = -v; break;
+            case TQ_CHAIN_SQR:      v = v * v; break;
+            default: break;
+        }
+    }
+
+    dst[i] = v;
+}
+
+void ggml_cuda_op_elem_chain(ggml_backend_cuda_context & ctx,
+                             const float * src, float * dst, int64_t n,
+                             const tq_chain_desc & desc) {
+    const int64_t nblocks = (n + TQ_CHAIN_BLOCK - 1) / TQ_CHAIN_BLOCK;
+    k_elem_chain<<<(unsigned) nblocks, TQ_CHAIN_BLOCK, 0, ctx.stream()>>>(src, dst, desc, n);
+    CUDA_CHECK(cudaGetLastError());
+}

--- a/ggml/src/ggml-cuda/chain.cuh
+++ b/ggml/src/ggml-cuda/chain.cuh
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "common.cuh"
+
+// Elementwise "midi-kernel": executes a run of consecutive elementwise ops in registers, so a
+// chain like SIGMOID -> MUL -> ADD -> ADD costs one dispatch and one round trip instead of four
+// of each. Detection lives in ggml-cuda.cu; this is the executor.
+
+#define TQ_CHAIN_MAX_OPS 8
+
+enum tq_chain_code {
+    TQ_CHAIN_ADD = 0,
+    TQ_CHAIN_MUL,
+    TQ_CHAIN_DIV,
+    TQ_CHAIN_SCALE,     // v*p0 + p1
+    TQ_CHAIN_CLAMP,     // clamp(v, p0, p1)
+    TQ_CHAIN_SILU,
+    TQ_CHAIN_SIGMOID,
+    TQ_CHAIN_SOFTPLUS,
+    TQ_CHAIN_GELU,
+    TQ_CHAIN_RELU,
+    TQ_CHAIN_NEG,
+    TQ_CHAIN_SQR,
+};
+
+struct tq_chain_desc {
+    int           n_ops;
+    int           code   [TQ_CHAIN_MAX_OPS];
+    const float * other  [TQ_CHAIN_MAX_OPS];   // binary operand, or nullptr for unary
+    int           chain_is_lhs[TQ_CHAIN_MAX_OPS]; // for non-commutative ops (DIV)
+    int           bcast  [TQ_CHAIN_MAX_OPS];   // operand is a single value broadcast over all elements
+    float         p0     [TQ_CHAIN_MAX_OPS];
+    float         p1     [TQ_CHAIN_MAX_OPS];
+};
+
+void ggml_cuda_op_elem_chain(ggml_backend_cuda_context & ctx,
+                             const float * src, float * dst, int64_t n,
+                             const tq_chain_desc & desc);

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1442,6 +1442,28 @@ struct ggml_backend_cuda_context {
     // release-after-use path (avoids the legacy pool retaining the temp; ref llama.cpp #22107).
     bool fa_f16_use_pool = false;
 
+    // Per-graph-eval shared-quantize cache for the mmvq path. Several matvecs in one decode
+    // layer consume the same normed activation (Q/V/K read attn_norm; the router, fused
+    // gate/up and shared-expert gate read attn_post_norm), and each used to re-quantize it to
+    // q8_1 — ~60% of all quantize launches were duplicates. The most recent quantization is
+    // kept in a persistent pool buffer and reused when the same src1 tensor is seen again in
+    // the same graph eval with identical layout. Stream ordering makes overwrite safe (all
+    // consumers of the previous entry are already enqueued before the next quantize runs),
+    // and the buffer only grows on shape changes, which force a CUDA-graph re-capture anyway.
+    struct {
+        char *              ptr  = nullptr;      // pool memory, grow-only
+        size_t              cap  = 0;            // actual allocated size
+        int                 dev  = -1;           // device the buffer was allocated on
+        const ggml_tensor * src1 = nullptr;      // key: tensor identity ...
+        const void *        data = nullptr;      // ... and its data pointer
+        uint64_t            epoch = 0;           // valid only within this graph eval
+        size_t              size = 0;            // quantized bytes
+        int64_t             ne10_padded = 0;     // layout keys
+        ggml_type           type = GGML_TYPE_COUNT;
+        struct retired_buf { char * ptr; size_t cap; int dev; };
+        std::vector<retired_buf> retired;        // outgrown buffers, freed at teardown (captured graphs may still use them)
+    } q8_cache;
+
     // Same idea for the TQ activation pre-rotation (forward block WHT + q8_1 quantize): the MoE
     // gate and up projections consume the same normed activation, so the rotation ran twice per
     // layer. Keyed by tensor identity, data pointer, size and graph-eval epoch; main-stream only.

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1176,6 +1176,9 @@ const ggml_cuda_device_info & ggml_cuda_info();
 void ggml_cuda_set_device(int device);
 int ggml_cuda_get_device();
 
+// raw device allocation, honors GGML_CUDA_ENABLE_UNIFIED_MEMORY. free with cudaFree
+cudaError_t ggml_cuda_device_malloc(void ** ptr, size_t size, int device);
+
 struct ggml_cuda_pool {
     virtual ~ggml_cuda_pool() = default;
 
@@ -1446,13 +1449,13 @@ struct ggml_backend_cuda_context {
     // layer consume the same normed activation (Q/V/K read attn_norm; the router, fused
     // gate/up and shared-expert gate read attn_post_norm), and each used to re-quantize it to
     // q8_1 — ~60% of all quantize launches were duplicates. The most recent quantization is
-    // kept in a persistent pool buffer and reused when the same src1 tensor is seen again in
+    // kept in a persistent device buffer and reused when the same src1 tensor is seen again in
     // the same graph eval with identical layout. Stream ordering makes overwrite safe (all
     // consumers of the previous entry are already enqueued before the next quantize runs),
     // and the buffer only grows on shape changes, which force a CUDA-graph re-capture anyway.
     struct {
-        char *              ptr  = nullptr;      // pool memory, grow-only
-        size_t              cap  = 0;            // actual allocated size
+        char *              ptr  = nullptr;      // raw device memory (not pool), grow-only
+        size_t              cap  = 0;            // usable bytes
         int                 dev  = -1;           // device the buffer was allocated on
         const ggml_tensor * src1 = nullptr;      // key: tensor identity ...
         const void *        data = nullptr;      // ... and its data pointer

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -739,21 +739,35 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {
 
     // Return the cache buffers before the pools are destroyed
     // (the legacy pool asserts on outstanding allocations at teardown).
-    if (q8_cache.ptr != nullptr) {
-        pool(q8_cache.dev).free(q8_cache.ptr, q8_cache.cap);
-        q8_cache.ptr = nullptr;
-    }
+    // The VMM pool also asserts strict LIFO free order, and the retire lists are chronological,
+    // so free every held buffer newest-first: per device the highest address is the newest one.
+    struct held_buf { char * ptr; size_t cap; int dev; };
+    std::vector<held_buf> held;
+    auto hold = [&held](char * ptr, size_t cap, int dev) {
+        if (ptr != nullptr) {
+            held.push_back({ ptr, cap, dev });
+        }
+    };
+
+    hold(q8_cache.ptr, q8_cache.cap, q8_cache.dev);
     for (const auto & r : q8_cache.retired) {
-        pool(r.dev).free(r.ptr, r.cap);
+        hold(r.ptr, r.cap, r.dev);
     }
-    q8_cache.retired.clear();
-    if (tq_rot_cache.ptr != nullptr) {
-        pool(tq_rot_cache.dev).free(tq_rot_cache.ptr, tq_rot_cache.cap);
-        tq_rot_cache.ptr = nullptr;
-    }
+    hold(tq_rot_cache.ptr, tq_rot_cache.cap, tq_rot_cache.dev);
     for (const auto & r : tq_rot_cache.retired) {
-        pool(r.dev).free(r.ptr, r.cap);
+        hold(r.ptr, r.cap, r.dev);
     }
+
+    std::sort(held.begin(), held.end(), [](const held_buf & a, const held_buf & b) {
+        return a.dev != b.dev ? a.dev < b.dev : a.ptr > b.ptr;
+    });
+    for (const auto & h : held) {
+        pool(h.dev).free(h.ptr, h.cap);
+    }
+
+    q8_cache.ptr = nullptr;
+    q8_cache.retired.clear();
+    tq_rot_cache.ptr = nullptr;
     tq_rot_cache.retired.clear();
 
     if (copy_event != nullptr) {

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -67,6 +67,7 @@
 #include "ggml-cuda/set-rows.cuh"
 #include "ggml-cuda/turbo-wht.cuh"
 #include "ggml-cuda/mmvq-tq.cuh"
+#include "ggml-cuda/chain.cuh"
 #include "ggml-cuda/pad_reflect_1d.cuh"
 #include "ggml-cuda/solve_tri.cuh"
 #include "ggml-cuda/tri.cuh"
@@ -3521,6 +3522,172 @@ static bool ggml_cuda_can_fuse(const struct ggml_cgraph *                cgraph,
     return false;
 }
 
+// Elementwise chain ("midi-kernel"): collapse a run of consecutive same-shape elementwise
+// ops into a single kernel that keeps the value in a register across the whole run. Saves a
+// dispatch AND a full HBM round trip per elided op. Typical runs on hybrid MoE graphs are
+// SIGMOID->MUL->ADD->ADD, ADD->SOFTPLUS->MUL, CLAMP->DIV, SILU->MUL.
+// Returns the number of extra nodes fused (len - 1) or -1 when nothing was fused. Lives in its
+// own function (not inline in ggml_cuda_try_fuse) so its locals do not add to that function's
+// frame; gcc 13 reported a stringop-overflow false positive in an unrelated fusion there once
+// the frame grew.
+static int ggml_cuda_fuse_elem_chain(ggml_backend_cuda_context & ctx, const ggml_cgraph * cgraph, int i) {
+    if (i + 1 >= cgraph->n_nodes) {
+        return -1;
+    }
+    static bool disable_chain = getenv("GGML_CUDA_FUSE_CHAIN") != nullptr && std::atoi(getenv("GGML_CUDA_FUSE_CHAIN")) == 0;
+
+    auto chain_code = [](const ggml_tensor * t, int & code, float & p0, float & p1) -> bool {
+        switch (t->op) {
+            case GGML_OP_ADD:   code = TQ_CHAIN_ADD;   return true;
+            case GGML_OP_MUL:   code = TQ_CHAIN_MUL;   return true;
+            case GGML_OP_DIV:   code = TQ_CHAIN_DIV;   return true;
+            case GGML_OP_SCALE: code = TQ_CHAIN_SCALE;
+                memcpy(&p0, (const char *) t->op_params + 0*sizeof(float), sizeof(float));
+                memcpy(&p1, (const char *) t->op_params + 1*sizeof(float), sizeof(float));
+                return true;
+            case GGML_OP_CLAMP: code = TQ_CHAIN_CLAMP;
+                memcpy(&p0, (const char *) t->op_params + 0*sizeof(float), sizeof(float));
+                memcpy(&p1, (const char *) t->op_params + 1*sizeof(float), sizeof(float));
+                return true;
+            case GGML_OP_SQR:   code = TQ_CHAIN_SQR;   return true;
+            case GGML_OP_UNARY:
+                switch (ggml_get_unary_op(t)) {
+                    case GGML_UNARY_OP_SILU:     code = TQ_CHAIN_SILU;     return true;
+                    case GGML_UNARY_OP_SIGMOID:  code = TQ_CHAIN_SIGMOID;  return true;
+                    case GGML_UNARY_OP_SOFTPLUS: code = TQ_CHAIN_SOFTPLUS; return true;
+                    case GGML_UNARY_OP_GELU:     code = TQ_CHAIN_GELU;     return true;
+                    case GGML_UNARY_OP_RELU:     code = TQ_CHAIN_RELU;     return true;
+                    case GGML_UNARY_OP_NEG:      code = TQ_CHAIN_NEG;      return true;
+                    default: return false;
+                }
+            default: return false;
+        }
+    };
+
+    auto chain_ok_tensor = [](const ggml_tensor * t) -> bool {
+        return t && t->type == GGML_TYPE_F32 && ggml_is_contiguous(t);
+    };
+
+    tq_chain_desc desc = {};
+    const ggml_tensor * head_src = nullptr;
+    int len = 0;
+
+    if (!disable_chain) {
+        const ggml_tensor * prev = nullptr;
+        for (int j = i; j < cgraph->n_nodes && len < TQ_CHAIN_MAX_OPS; ++j) {
+            ggml_tensor * nd = cgraph->nodes[j];
+            int code = 0; float p0 = 0.0f, p1 = 0.0f;
+
+            if (!chain_ok_tensor(nd) || !chain_code(nd, code, p0, p1)) break;
+            if (len > 0 && !ggml_are_same_shape(nd, cgraph->nodes[i])) break;
+
+            const bool binary = (nd->op == GGML_OP_ADD || nd->op == GGML_OP_MUL || nd->op == GGML_OP_DIV);
+            const ggml_tensor * a = nd->src[0];
+            const ggml_tensor * b = binary ? nd->src[1] : nullptr;
+
+            if (!chain_ok_tensor(a)) break;
+            if (binary && !chain_ok_tensor(b)) break;
+            // operand may be same-shape, or a single value broadcast over the run
+            const bool a_b = chain_ok_tensor(a) && (ggml_are_same_shape(a, nd) || ggml_nelements(a) == 1);
+            const bool b_b = !binary || (chain_ok_tensor(b) && (ggml_are_same_shape(b, nd) || ggml_nelements(b) == 1));
+            if (!a_b || !b_b) break;
+
+            const ggml_tensor * other = nullptr;
+            int chain_lhs = 1;
+
+            if (len == 0) {
+                // the value we carry must be a full-size tensor, not the broadcast scalar
+                if (ggml_nelements(a) != ggml_nelements(nd)) break;
+                head_src = a;
+                other    = b;
+            } else {
+                // must consume the previous node's output
+                if (a == prev)              { other = b; chain_lhs = 1; }
+                else if (binary && b == prev) { other = a; chain_lhs = 0; }
+                else break;
+            }
+
+            // The other operand must not be a node this chain elides: those are never written
+            // (e.g. t0 = SILU(x); out = MUL(t0, t0) passes the subgraph check because both uses
+            // are inside it, but t0->data would be read unset).
+            if (other) {
+                bool is_intermediate = false;
+                for (int k = i; k < j; ++k) {
+                    if (cgraph->nodes[k] == other) { is_intermediate = true; break; }
+                }
+                if (is_intermediate) break;
+            }
+
+            desc.bcast[len]         = other ? (ggml_nelements(other) == 1 ? 1 : 0) : 0;
+            desc.code[len]          = code;
+            desc.other[len]         = other ? (const float *) other->data : nullptr;
+            desc.chain_is_lhs[len]  = chain_lhs;
+            desc.p0[len]            = p0;
+            desc.p1[len]            = p1;
+            len++;
+            prev = nd;
+        }
+    }
+
+    if (len >= 2) {
+        ggml_tensor * out = cgraph->nodes[i + len - 1];
+        ggml_op ops_ch[TQ_CHAIN_MAX_OPS];
+        for (int k = 0; k < len; ++k) {
+            ops_ch[k] = cgraph->nodes[i + k]->op;
+        }
+        const int out_ch[1] = { i + len - 1 };
+
+        // Aliasing. ggml_cuda_check_fusion_memory_ranges() is not used here on purpose: it
+        // vetoes any overlap between the output and an input, and exact in-place aliasing is
+        // the common case for this pattern (galloc hands residual adds their input's buffer).
+        // Every same-shape operand is read at index i and dst is written at index i after
+        // that read, so an output that aliases an operand exactly is safe and must NOT be
+        // vetoed. Anything else
+        // that overlaps the output is not: a broadcast operand is read at index 0 by every
+        // thread, and a same-shape operand at a different offset is read at index i after
+        // another thread may already have written it.
+        bool alias_veto = false;
+        {
+            const char * db = (const char *) out->data;
+            const size_t dn = ggml_nbytes(out);
+            auto overlaps = [&](const void * ptr, size_t n) {
+                const char * ob = (const char *) ptr;
+                return ob < db + dn && db < ob + n;
+            };
+            auto exact = [&](const void * ptr, size_t n) {
+                return ptr == (const void *) db && n == dn;
+            };
+            if (overlaps(head_src->data, ggml_nbytes(head_src)) && !exact(head_src->data, ggml_nbytes(head_src))) {
+                alias_veto = true;
+            }
+            for (int k = 0; k < len && !alias_veto; ++k) {
+                if (!desc.other[k]) {
+                    continue;
+                }
+                const ggml_tensor * nd = cgraph->nodes[i + k];
+                const ggml_tensor * ot = desc.chain_is_lhs[k] ? nd->src[1] : nd->src[0];
+                const size_t on = ggml_nbytes(ot);
+                if (desc.bcast[k]) {
+                    alias_veto |= overlaps(ot->data, on);
+                } else {
+                    alias_veto |= overlaps(ot->data, on) && !exact(ot->data, on);
+                }
+            }
+        }
+
+        if (!alias_veto &&
+            ggml_are_same_shape(out, cgraph->nodes[i]) &&
+            ggml_can_fuse_subgraph(cgraph, i, len, ops_ch, out_ch, 1)) {
+
+            desc.n_ops = len;
+            ggml_cuda_op_elem_chain(ctx, (const float *) head_src->data,
+                                    (float *) out->data, ggml_nelements(out), desc);
+            return len - 1;   // nodes consumed beyond this one
+        }
+    }
+    return -1;
+}
+
 // try and fuse nodes and return the number of nodes to skip
 static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph * cgraph, int i) {
 
@@ -3551,6 +3718,7 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
         ggml_cuda_topk_moe_args args;
         const bool              can_fuse = ggml_cuda_topk_moe_fusion(cgraph, i, args);
         std::vector<ggml_op>    ops;
+        ops.reserve(16);   // gcc 13 -Werror=stringop-overflow trips on the insert() calls below otherwise
 
         if (can_fuse) {
             const ggml_tensor * logits  = node->src[0];
@@ -3618,6 +3786,14 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
                     return ops.size() - 1;
                 }
             }
+        }
+    }
+
+    // Elementwise chain ("midi-kernel"), see ggml_cuda_fuse_elem_chain().
+    {
+        const int n_fused = ggml_cuda_fuse_elem_chain(*cuda_ctx, cgraph, i);
+        if (n_fused >= 0) {
+            return n_fused;
         }
     }
 

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -736,8 +736,16 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {
     std::unique_lock<std::mutex> lock(ggml_cuda_lock);
     ggml_cuda_lock_cv.wait(lock, []{ return ggml_cuda_lock_counter.load(std::memory_order_relaxed) == 0; });
 
-    // Return the pre-rotation cache buffers before the pools are destroyed
+    // Return the cache buffers before the pools are destroyed
     // (the legacy pool asserts on outstanding allocations at teardown).
+    if (q8_cache.ptr != nullptr) {
+        pool(q8_cache.dev).free(q8_cache.ptr, q8_cache.cap);
+        q8_cache.ptr = nullptr;
+    }
+    for (const auto & r : q8_cache.retired) {
+        pool(r.dev).free(r.ptr, r.cap);
+    }
+    q8_cache.retired.clear();
     if (tq_rot_cache.ptr != nullptr) {
         pool(tq_rot_cache.dev).free(tq_rot_cache.ptr, tq_rot_cache.cap);
         tq_rot_cache.ptr = nullptr;
@@ -4479,7 +4487,8 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend, 
 
     ggml_cuda_set_device(cuda_ctx->device);
 
-    // New graph eval: invalidate the TQ pre-rotation cache (see tq_rot_cache in common.cuh).
+    // New graph eval: invalidate the shared-quantize and TQ pre-rotation caches (see q8_cache and
+    // tq_rot_cache in common.cuh).
     cuda_ctx->graph_epoch++;
 
     bool use_cuda_graph             = false;

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -144,7 +144,7 @@ int ggml_cuda_get_device() {
     return id;
 }
 
-static cudaError_t ggml_cuda_device_malloc(void ** ptr, size_t size, int device) {
+cudaError_t ggml_cuda_device_malloc(void ** ptr, size_t size, int device) {
     ggml_cuda_set_device(device);
     cudaError_t err;
     if (getenv("GGML_CUDA_ENABLE_UNIFIED_MEMORY") != nullptr) {
@@ -737,32 +737,23 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {
     std::unique_lock<std::mutex> lock(ggml_cuda_lock);
     ggml_cuda_lock_cv.wait(lock, []{ return ggml_cuda_lock_counter.load(std::memory_order_relaxed) == 0; });
 
-    // Return the cache buffers before the pools are destroyed
-    // (the legacy pool asserts on outstanding allocations at teardown).
-    // The VMM pool also asserts strict LIFO free order, and the retire lists are chronological,
-    // so free every held buffer newest-first: per device the highest address is the newest one.
-    struct held_buf { char * ptr; size_t cap; int dev; };
-    std::vector<held_buf> held;
-    auto hold = [&held](char * ptr, size_t cap, int dev) {
+    // The cache buffers are raw device allocations, not pool memory: the VMM pool frees strict
+    // LIFO and these are taken while transient pool allocations sit below them, so free order
+    // here does not matter.
+    auto free_buf = [](char * ptr, int dev) {
         if (ptr != nullptr) {
-            held.push_back({ ptr, cap, dev });
+            ggml_cuda_set_device(dev);
+            CUDA_CHECK(cudaFree(ptr));
         }
     };
 
-    hold(q8_cache.ptr, q8_cache.cap, q8_cache.dev);
+    free_buf(q8_cache.ptr, q8_cache.dev);
     for (const auto & r : q8_cache.retired) {
-        hold(r.ptr, r.cap, r.dev);
+        free_buf(r.ptr, r.dev);
     }
-    hold(tq_rot_cache.ptr, tq_rot_cache.cap, tq_rot_cache.dev);
+    free_buf(tq_rot_cache.ptr, tq_rot_cache.dev);
     for (const auto & r : tq_rot_cache.retired) {
-        hold(r.ptr, r.cap, r.dev);
-    }
-
-    std::sort(held.begin(), held.end(), [](const held_buf & a, const held_buf & b) {
-        return a.dev != b.dev ? a.dev < b.dev : a.ptr > b.ptr;
-    });
-    for (const auto & h : held) {
-        pool(h.dev).free(h.ptr, h.cap);
+        free_buf(r.ptr, r.dev);
     }
 
     q8_cache.ptr = nullptr;

--- a/ggml/src/ggml-cuda/mmvq-tq.cu
+++ b/ggml/src/ggml-cuda/mmvq-tq.cu
@@ -926,9 +926,11 @@ static const block_q8_1 * tq_prerotate_q8_1_cached(ggml_backend_cuda_context & c
             if (rc.ptr != nullptr) {
                 rc.retired.push_back({ rc.ptr, rc.cap, rc.dev });
             }
-            size_t actual = 0;
-            rc.ptr = (char *) ctx.pool().alloc(bytes, &actual);
-            rc.cap = actual;
+            // Plain device memory, not pool memory: the pool frees strict LIFO, and this
+            // buffer is taken while transient pool allocations sit below it. CUDA graph
+            // capture runs in relaxed mode, which allows cudaMalloc during capture.
+            CUDA_CHECK(ggml_cuda_device_malloc((void **) &rc.ptr, bytes, ctx.device));
+            rc.cap = bytes;
             rc.dev = ctx.device;
         }
         dst      = (block_q8_1 *) rc.ptr;

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -5,6 +5,7 @@
 #include "vecdotq.cuh"
 
 #include <cstdint>
+#include <cstdlib>
 #include <limits>
 
 typedef float (*vec_dot_q_cuda_t)(const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs);
@@ -1270,18 +1271,61 @@ void ggml_cuda_mul_mat_vec_q(
     }
 
     const int64_t ne10_padded = GGML_PAD(ne10, MATRIX_ROW_PADDING);
-    ggml_cuda_pool_alloc<char> src1_q8_1(ctx.pool(), ne13*ne12 * ne11*ne10_padded * sizeof(block_q8_1)/QK8_1);
-    {
+    const size_t  q8_bytes = ne13*ne12 * ne11*ne10_padded * sizeof(block_q8_1)/QK8_1;
+
+    // Shared-quantize cache: reuse the previous quantization when the same src1 tensor is
+    // consumed again in this graph eval with the same layout (see q8_cache in common.cuh).
+    // ConvRot types and MUL_MAT_ID stay uncached; oversized batches fall back too.
+    auto & qc = ctx.q8_cache;
+    static const bool q8_cache_disabled = getenv("GGML_TQ_Q8CACHE") != nullptr && atoi(getenv("GGML_TQ_Q8CACHE")) == 0;
+    // Main stream only: a sibling stream could consume the buffer with no cross-stream ordering.
+    const bool q8_cacheable = !q8_cache_disabled && !convrot && ids == nullptr && q8_bytes <= (1u << 20) &&
+                              ctx.curr_stream_no == 0;
+    const bool q8_hit = q8_cacheable && qc.epoch == ctx.graph_epoch && qc.src1 == src1 &&
+                        qc.data == src1->data && qc.size == q8_bytes &&
+                        qc.ne10_padded == ne10_padded && qc.type == src0->type &&
+                        qc.dev == ctx.device;
+
+    ggml_cuda_pool_alloc<char> src1_q8_1_local(ctx.pool());
+    char * src1_q8_1 = nullptr;
+
+    if (q8_hit) {
+        src1_q8_1 = qc.ptr;
+    } else {
+        if (q8_cacheable) {
+            if (qc.dev != ctx.device || qc.cap < q8_bytes) {
+                // Never free a buffer here: a CUDA graph captured earlier may still replay
+                // kernels that point at it (several graphs per context with --n-cpu-moe splits).
+                // Retire it and release everything at context teardown instead.
+                if (qc.ptr != nullptr) {
+                    qc.retired.push_back({ qc.ptr, qc.cap, qc.dev });
+                }
+                size_t actual = 0;
+                qc.ptr = (char *) ctx.pool().alloc(q8_bytes, &actual);
+                qc.cap = actual;
+                qc.dev = ctx.device;
+            }
+            src1_q8_1 = qc.ptr;
+            qc.src1        = src1;
+            qc.data        = src1->data;
+            qc.epoch       = ctx.graph_epoch;
+            qc.size        = q8_bytes;
+            qc.ne10_padded = ne10_padded;
+            qc.type        = src0->type;
+        } else {
+            src1_q8_1 = src1_q8_1_local.alloc(q8_bytes);
+        }
+
         const int64_t s11 = src1->nb[1] / ts_src1;
         const int64_t s12 = src1->nb[2] / ts_src1;
         const int64_t s13 = src1->nb[3] / ts_src1;
         if (convrot) {
             ggml_cuda_convrot_quantize_q8_1(
-                src1_d, src1_q8_1.get(), ne10, s11, s12, s13,
+                src1_d, src1_q8_1, ne10, s11, s12, s13,
                 ne10_padded, ne11, ne12, ne13, stream);
         } else {
             quantize_row_q8_1_cuda(
-                src1_d, nullptr, src1_q8_1.get(), src0->type, ne10, s11, s12, s13,
+                src1_d, nullptr, src1_q8_1, src0->type, ne10, s11, s12, s13,
                 ne10_padded, ne11, ne12, ne13, stream);
         }
     }
@@ -1309,7 +1353,7 @@ void ggml_cuda_mul_mat_vec_q(
     const int64_t ids_stride = ids ? ids->nb[1] / ggml_type_size(ids->type) : 0;
 
     mul_mat_vec_q_switch_type(
-        src0->data, src0->type, src1_q8_1.get(), ids_d, fusion_local, dst_d, ne00,
+        src0->data, src0->type, src1_q8_1, ids_d, fusion_local, dst_d, ne00,
         ne01,              ncols_dst,     s01, stride_col_y,     stride_col_dst,
         ne02, nchannels_y, nchannels_dst, s02, stride_channel_y, stride_channel_dst,
         ne03,              ne3,           s03, s13,              s3,               ids_stride, stream);

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -1299,9 +1299,11 @@ void ggml_cuda_mul_mat_vec_q(
                 if (qc.ptr != nullptr) {
                     qc.retired.push_back({ qc.ptr, qc.cap, qc.dev });
                 }
-                size_t actual = 0;
-                qc.ptr = (char *) ctx.pool().alloc(q8_bytes, &actual);
-                qc.cap = actual;
+                // Plain device memory, not pool memory: the pool frees strict LIFO, and this
+                // buffer is taken while transient pool allocations sit below it. CUDA graph
+                // capture runs in relaxed mode, which allows cudaMalloc during capture.
+                CUDA_CHECK(ggml_cuda_device_malloc((void **) &qc.ptr, q8_bytes, ctx.device));
+                qc.cap = q8_bytes;
                 qc.dev = ctx.device;
             }
             src1_q8_1 = qc.ptr;

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -5,7 +5,6 @@
 #include "vecdotq.cuh"
 
 #include <cstdint>
-#include <cstdlib>
 #include <limits>
 
 typedef float (*vec_dot_q_cuda_t)(const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs);

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -6476,6 +6476,213 @@ struct test_topk_moe : public test_case {
     }
 };
 
+// MUL_MAT -> ADD with a full same-shape residual (the bias-epilogue fusion). self_add builds
+// ADD(mm, mm): both inputs are the matmul output, which a fused kernel never materialises, so
+// the fusion must decline it.
+struct test_mul_mat_residual_fusion : public test_case {
+    const ggml_type type;
+    const int64_t m;
+    const int64_t n;
+    const int64_t k;
+    const bool self_add;
+
+    test_mul_mat_residual_fusion(ggml_type type, int64_t m, int64_t n, int64_t k, bool self_add)
+        : type(type), m(m), n(n), k(k), self_add(self_add) {}
+
+    std::string vars() override {
+        return VARS_TO_STR5(type, m, n, k, self_add);
+    }
+
+    std::string op_desc(ggml_tensor * t) override {
+        GGML_UNUSED(t);
+        return "MUL_MAT_RESIDUAL_FUSION";
+    }
+
+    // the graph ends in a quantized matvec, so the same tolerance as test_mul_mat for quantized types
+    double max_nmse_err() override {
+        return 5e-4;
+    }
+
+    bool run_whole_graph() override { return true; }
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * a = ggml_new_tensor_2d(ctx, type, k, m);
+        ggml_tensor * b = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, k, n);
+        ggml_set_name(a, "a");
+        ggml_set_name(b, "b");
+
+        ggml_tensor * mm  = ggml_mul_mat(ctx, a, b);
+        ggml_tensor * res = self_add ? mm : ggml_new_tensor_2d(ctx, GGML_TYPE_F32, m, n);
+        ggml_tensor * out = ggml_add(ctx, mm, res);
+        ggml_set_name(out, "out");
+        return out;
+    }
+};
+
+// Two quantized matvecs that consume the same activation in one graph: the second one must
+// hit the shared-quantize cache and still match the CPU result.
+struct test_mul_mat_shared_src1 : public test_case {
+    const ggml_type type;
+    const int64_t m;
+    const int64_t n;
+    const int64_t k;
+
+    test_mul_mat_shared_src1(ggml_type type, int64_t m, int64_t n, int64_t k)
+        : type(type), m(m), n(n), k(k) {}
+
+    std::string vars() override {
+        return VARS_TO_STR4(type, m, n, k);
+    }
+
+    std::string op_desc(ggml_tensor * t) override {
+        GGML_UNUSED(t);
+        return "MUL_MAT_SHARED_SRC1";
+    }
+
+    // the graph ends in a quantized matvec, so the same tolerance as test_mul_mat for quantized types
+    double max_nmse_err() override {
+        return 5e-4;
+    }
+
+    bool run_whole_graph() override { return true; }
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * a1 = ggml_new_tensor_2d(ctx, type, k, m);
+        ggml_tensor * a2 = ggml_new_tensor_2d(ctx, type, k, m);
+        ggml_tensor * b  = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, k, n);
+        ggml_set_name(a1, "a1");
+        ggml_set_name(a2, "a2");
+        ggml_set_name(b, "b");
+
+        ggml_tensor * out = ggml_add(ctx, ggml_mul_mat(ctx, a1, b), ggml_mul_mat(ctx, a2, b));
+        ggml_set_name(out, "out");
+        return out;
+    }
+};
+
+// A run of elementwise ops with same-shape and single-value operands, including the two
+// activations whose fused forms must round exactly like the unary kernels (GELU, SOFTPLUS).
+struct test_elem_chain_fusion : public test_case {
+    const std::array<int64_t, 4> ne;
+    const bool with_gelu_softplus;
+    const bool self_mul;   // out = MUL(t0, t0) with t0 = SILU(x): t0 is an elided intermediate used twice
+
+    test_elem_chain_fusion(std::array<int64_t, 4> ne, bool with_gelu_softplus, bool self_mul = false)
+        : ne(ne), with_gelu_softplus(with_gelu_softplus), self_mul(self_mul) {}
+
+    std::string vars() override {
+        return VARS_TO_STR3(ne, with_gelu_softplus, self_mul);
+    }
+
+    std::string op_desc(ggml_tensor * t) override {
+        GGML_UNUSED(t);
+        return "ELEM_CHAIN_FUSION";
+    }
+
+    bool run_whole_graph() override { return true; }
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * x  = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne.data());
+        ggml_tensor * o1 = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne.data());
+        ggml_tensor * s  = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 1);
+        ggml_set_name(x, "x");
+        ggml_set_name(o1, "o1");
+        ggml_set_name(s, "s");
+
+        ggml_tensor * cur = ggml_silu(ctx, x);
+        if (self_mul) {
+            cur = ggml_mul(ctx, cur, cur);
+            cur = ggml_add(ctx, cur, x);
+            ggml_set_name(cur, "out");
+            return cur;
+        }
+        cur = ggml_mul(ctx, cur, o1);
+        cur = ggml_add(ctx, cur, x);
+        cur = ggml_add(ctx, cur, s);
+        if (with_gelu_softplus) {
+            cur = ggml_gelu(ctx, cur);
+            cur = ggml_softplus(ctx, cur);
+        }
+        cur = ggml_scale(ctx, cur, 0.5f);
+        cur = ggml_clamp(ctx, cur, -4.0f, 4.0f);
+        ggml_set_name(cur, "out");
+        return cur;
+    }
+};
+
+// MUL_MAT_ID -> MUL(weights) -> PERMUTE -> CONT -> SUM_ROWS, the MoE expert-reduce tail as
+// llama.cpp builds it, compared against the CPU graph whether or not a backend fuses it.
+struct test_moe_reduce_fusion : public test_case {
+    const ggml_type type;
+    const int64_t m;
+    const int64_t k;
+    const int n_mats;
+    const int n_used;
+    const int64_t ntok;
+
+    test_moe_reduce_fusion(ggml_type type, int64_t m, int64_t k, int n_mats, int n_used, int64_t ntok)
+        : type(type), m(m), k(k), n_mats(n_mats), n_used(n_used), ntok(ntok) {
+        GGML_ASSERT(n_used <= n_mats);
+    }
+
+    std::string vars() override {
+        return VARS_TO_STR6(type, m, k, n_mats, n_used, ntok);
+    }
+
+    std::string op_desc(ggml_tensor * t) override {
+        GGML_UNUSED(t);
+        return "MOE_REDUCE_FUSION";
+    }
+
+    // the graph ends in a quantized matvec, so the same tolerance as test_mul_mat for quantized types
+    double max_nmse_err() override {
+        return 5e-4;
+    }
+
+    bool run_whole_graph() override { return true; }
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * as  = ggml_new_tensor_3d(ctx, type, k, m, n_mats);
+        ggml_tensor * ids = ggml_new_tensor_2d(ctx, GGML_TYPE_I32, n_used, ntok);
+        ggml_tensor * b   = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, k, 1, ntok);
+        ggml_tensor * w   = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, 1, n_used, ntok);
+        ggml_set_name(as, "as");
+        ggml_set_name(ids, "ids");
+        ggml_set_name(b, "b");
+        ggml_set_name(w, "w");
+
+        ggml_tensor * cur = ggml_mul_mat_id(ctx, as, b, ids);       // [m, n_used, ntok]
+        cur = ggml_mul(ctx, cur, w);
+        cur = ggml_permute(ctx, cur, 1, 0, 2, 3);                    // [n_used, m, ntok]
+        cur = ggml_cont(ctx, cur);
+        cur = ggml_sum_rows(ctx, cur);                               // [1, m, ntok]
+        ggml_set_name(cur, "out");
+        return cur;
+    }
+
+    void initialize_tensors(ggml_context * ctx) override {
+        std::random_device rd;
+        std::default_random_engine rng(rd());
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
+            if (t->type == GGML_TYPE_I32) {
+                if (ggml_is_view_op(t->op)) {
+                    continue;
+                }
+                for (int64_t r = 0; r < ggml_nrows(t); r++) {
+                    std::vector<int32_t> data(t->ne[0]);
+                    for (int i = 0; i < t->ne[0]; i++) {
+                        data[i] = i % n_mats;
+                    }
+                    std::shuffle(data.begin(), data.end(), rng);
+                    ggml_backend_tensor_set(t, data.data(), r * t->nb[1], t->ne[0] * sizeof(int32_t));
+                }
+            } else {
+                init_tensor_uniform(t);
+            }
+        }
+    }
+};
+
 struct test_mul_mat_vec_fusion : public test_case {
     const ggml_type type;
     const ggml_glu_op glu_op;
@@ -8479,6 +8686,21 @@ static const ggml_type other_types[] = {
 // Test cases for evaluation: should try to cover edge cases while using small input sizes to keep the runtime low
 static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     std::vector<std::unique_ptr<test_case>> test_cases;
+
+    // multi-node fusion coverage: residual epilogue, shared-quantize cache, elementwise chain, MoE reduce
+    for (ggml_type type : {GGML_TYPE_Q8_0, GGML_TYPE_Q4_0, GGML_TYPE_TQ4_1S}) {
+        for (int n : {1, 2, 4, 8}) {
+            test_cases.emplace_back(new test_mul_mat_residual_fusion(type, 64, n, 256, false));
+            test_cases.emplace_back(new test_mul_mat_residual_fusion(type, 64, n, 256, true));
+            test_cases.emplace_back(new test_mul_mat_shared_src1(type, 64, n, 256));
+        }
+        for (int ntok : {1, 4}) {
+            test_cases.emplace_back(new test_moe_reduce_fusion(type, 64, 256, 8, 4, ntok));
+        }
+    }
+    test_cases.emplace_back(new test_elem_chain_fusion({256, 4, 2, 1}, false));
+    test_cases.emplace_back(new test_elem_chain_fusion({256, 4, 2, 1}, true));
+    test_cases.emplace_back(new test_elem_chain_fusion({256, 4, 2, 1}, false, true));
     std::default_random_engine rng(0);
 
     // unary ops


### PR DESCRIPTION
> The generic half of #338, split as requested in review, with the fixes from that review folded into the patches they belong to. Rebased onto the branch tip after #342 merged.

## Overview

Two patches that are not TurboQuant-specific and help any quantized weight type:

| # (in #338) | patch | effect |
|---|---|---|
| 3 | per-graph-eval shared-quantize cache for mmvq | ~60% of quantize launches were duplicates |
| 9 | elementwise chain fusion (midi-kernel) | +2.3% |

plus one commit of `test-backend-ops` coverage. The MoE reduce-tail test is kept: it compares the tail against the CPU graph whether or not the backend fuses it.

### Review fixes, by point

1. **Patch 7 is dropped.** The base's bias fusion already takes a same-shape `ADD` after `MUL_MAT` (it checks `ggml_are_same_shape` on the ADD's inputs and goes through the n-uses check), so the residual case is covered without it; the earlier dispatch-count measurement predates the rebase that brought that fusion in. The residual test is kept and now exercises the base fusion, including `ADD(mm, mm)`.
2. **Patch 9, overlap rule, numerics, and the elided-intermediate hole.** An operand that is itself one of the nodes the chain elides is rejected (`t0 = SILU(x); out = MUL(t0, t0)` would otherwise read `t0` unset; covered by the new `self_mul` test). The detector is its own static function with a fixed op array, reads op params with `memcpy`, and emits `SQR`. The chain vetoes any operand that overlaps the output unless it aliases it exactly (same pointer and size); `ggml_cuda_check_fusion_memory_ranges` is deliberately not used because it would veto that exact in-place case, which is the normal one. Exact in-place aliasing is what galloc produces for residual adds and is safe, because every thread reads index `i` before writing index `i`; a partial overlap at a nonzero offset is not, and neither is a broadcast operand inside the output. GELU calls `ggml_cuda_op_gelu_single()` and softplus uses the `(x > 20) ? x : logf(1 + expf(x))` form, so fused and unfused paths agree bit for bit.
3. **Patch 4 is dropped.** Upstream merged `cuda: fuse MoE weighted expert reduction` (ggml-org/llama.cpp#25952) on 2026-09-01: any weight type, k = 2..15, allocator-integrated, with its own `test-backend-ops` coverage. It only touches the reduction, so it is independent of which matmul produced the experts and would cover the TurboQuant MoE path too. One caveat for the rebase: #25952 matches the add-chain aggregation master builds (`moe_out = ggml_add(moe_out, cur_experts[i])`), while this branch's `build_moe_ffn` emits the `PERMUTE -> CONT -> SUM_ROWS` form (`llama-graph.cpp:2287`) that our tail matched. Whichever shape survives the rebase, carrying a competing tail here makes no sense; if the SUM_ROWS form stays, I can re-send the tail as a follow-up against it. For the record, the measurement Tom asked for: on Qwen3-30B-A3B Q4_K_M the fused tail gave identical perplexity (6.7883 ± 0.1208 either way) and, forced on, was 3% slower than the existing `x_scale` epilogue fusion for standard types (48.3 vs 49.9 tg128, measured while the card was shared; the ratio held on an idle card); on the TQ4max MoE it was worth +3.9% (121.1 ± 0.3 vs 116.6 ± 0.2 tg128, idle MI210). #338's patch 2, the deep TQ4_1S fuse this tail had already beaten, is dropped for the same reason.
4. **Patch 3, cache lifetime.** The cache is main-stream only, keyed like the rotation cache, and an outgrown buffer is retired rather than freed, then released at context teardown: a CUDA graph captured earlier can keep replaying against its buffer.
5. **Patch 8** landed in #342.
6. **Coverage.** Whole-graph cases in `test-backend-ops`, compared against the CPU backend: `MUL_MAT -> ADD(residual)` including `ADD(mm, mm)`, two `MUL_MAT`s on one activation (the second quantize is a cache hit), `SILU -> MUL -> ADD -> ADD(scalar) [-> GELU -> SOFTPLUS] -> SCALE -> CLAMP`, and `MUL_MAT_ID -> MUL -> PERMUTE -> CONT -> SUM_ROWS`, for Q8_0, Q4_0 and TQ4_1S.

Nits: `mmvq.cu` includes `<cstdlib>`.

## Additional information

MI210 (gfx90a), ROCm 7.2.3, `GGML_TQ_MMQ=1 GGML_TQ_NATIVE=1`:

| suite | result |
|---|---|
| `-o MUL_MAT_RESIDUAL_FUSION` | 24/24 |
| `-o MUL_MAT_SHARED_SRC1` | 12/12 |
| `-o ELEM_CHAIN_FUSION` | 3/3 (incl. `MUL(SILU(x), SILU(x))`) |
| `-o MOE_REDUCE_FUSION` (unfused on this branch) | 6/6 |
| `-o MUL_MAT -p type_a=tq4_1s` | 149/149 |
| `-o MUL_MAT_ID -p type_a=tq4_1s` | 38/38 |
| `-o MUL_MAT` (all types) | 1697/1697 on the final run; earlier runs showed 1692–1695 with the `q5_cr` / `q8_cr` ConvRot cases that also flake on the pristine base |

The three quantized-graph tests use the same 5e-4 tolerance as `test_mul_mat` for quantized types; the f32 chain test keeps the default 1e-7, which is what proves the GELU and softplus forms now round like the unary kernels (they did not before the fix).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — Claude Code was used throughout this series: profiling and diagnosis, the kernel and fusion work, commit messages, the review fixes, the new tests and the verification runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxP6x5bmUDYFvmouceN2mR


## Note on the base branch

While checking upstream for this split I noticed `feature/turboquant-kv-cache` is at a 2026-08-06 merge-base, 477 commits behind master. Besides #25952, three landed changes bear directly on this decode work: `CUDA: extend MOE fusion to specdec` (41ef91f7c, the MoE GLU and top-k router fusions for more than one token, i.e. the speculative verify batches), `CUDA: switch points per HW and quant type for the mvq->MMQ decode crossover` (#26079), and `spec: fuse the DFlash encoder into the KV injection` (#27310). Your call when to rebase; happy to help carry the TQ-specific pieces across.
