### PR TITLE
spec: keep the DFlash drafter working after an image in the prompt

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1058,14 +1058,20 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
             return true;
         }
 
-        // Target prefill may contain token IDs or multimodal embeddings. Both
-        // produce the target-layer features used to seed the draft KV cache, so
-        // skipping the embedding batches leaves a hole in the draft's cache and
-        // the next injection fails to initialize.
+        // Target prefill may contain token IDs or multimodal embeddings (image chunks).
+        // Image chunks are not mirrored into the draft: their target-layer features are
+        // vision states the draft was never trained on, and their M-RoPE positions collapse
+        // onto one temporal position, so injecting them poisons every draft after the
+        // image (acceptance fell from ~0.5 to ~0.03 for the rest of the conversation).
+        // Skipping them leaves a gap in the draft's cache between the text before and after
+        // the image; the draft keeps the target's positions, and the text tokens after the
+        // image carry the image's influence in their injected features. The gap is only
+        // legal with a full-size draft cache (the SWA ring cache cannot place tokens across
+        // it), which the server enables when a projector is loaded.
         // TODO: revisit after https://github.com/ggml-org/llama.cpp/pull/24669 is merged
         const bool has_tokens     = batch_in.token != nullptr;
         const bool has_embeddings = batch_in.embd  != nullptr;
-        if (has_tokens == has_embeddings) {
+        if (has_tokens == has_embeddings || has_embeddings) {
             return true;
         }
 
@@ -1200,7 +1206,13 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
 
             common_sampler_reset(smpls[seq_id].get());
 
-            const int32_t n = (int32_t) dp.n_past;
+            // dp.n_past is the slot's token count. For an M-RoPE target that is no longer the
+            // next position once an image has been in the prompt (image tokens advance the
+            // position by the grid size, not by their count), and a noise block placed at the
+            // token count sits hundreds of positions past the draft's own cache. Take the next
+            // position from the target's memory instead; without images the two are equal.
+            const llama_pos pos_max_tgt = llama_memory_seq_pos_max(llama_get_memory(params.ctx_tgt), seq_id);
+            const int32_t n = pos_max_tgt >= 0 ? (int32_t) pos_max_tgt + 1 : (int32_t) dp.n_past;
 
             const int32_t n_draft = params.n_max;
 

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1065,13 +1065,14 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         // image (acceptance fell from ~0.5 to ~0.03 for the rest of the conversation).
         // Skipping them leaves a gap in the draft's cache between the text before and after
         // the image; the draft keeps the target's positions, and the text tokens after the
-        // image carry the image's influence in their injected features. The gap is only
-        // legal with a full-size draft cache (the SWA ring cache cannot place tokens across
-        // it), which the server enables when a projector is loaded.
+        // image carry the image's influence in their injected features. The gap is fine for
+        // the default sliding-window draft cache: every batch it does see has consecutive
+        // positions, which is all find_slot requires (the crash was the image batch itself,
+        // whose tokens all carry one temporal position). No server-side change is involved.
         // TODO: revisit after https://github.com/ggml-org/llama.cpp/pull/24669 is merged
         const bool has_tokens     = batch_in.token != nullptr;
         const bool has_embeddings = batch_in.embd  != nullptr;
-        if (has_tokens == has_embeddings || has_embeddings) {
+        if (!has_tokens || has_embeddings) {
             return true;
         }
 


### PR DESCRIPTION
## Overview

With a DFlash drafter, any image in the prompt silently destroyed speculative decoding for the rest of the conversation: acceptance fell to ~0.03 and decode dropped below plain speed. With the default sliding-window draft cache it was worse, the server aborted on the image chunk (`llama_decode(ctx_dft) failed`, `failed to process image`).

Two faults, both only visible with M-RoPE targets and multimodal prompts:

1. **`draft()` placed the noise block at `dp.n_past`, the slot's token count.** After an image that is no longer the next position, because image tokens advance the position by the grid size rather than by their count, so the block landed hundreds of positions past the draft's own cache and every draft was rejected. The block now starts at the target's `llama_memory_seq_pos_max() + 1`; without images the two values are equal, so nothing changes for text-only use.
2. **`process()` mirrored image chunks into the draft**: vision-layer target states the draft was never trained on, all at one temporal position. The sliding-window cache could not even place them (`find_slot` failed). Embedding batches are now skipped; the draft keeps the target's positions across the gap, and the text after the image carries the image's influence in its injected features.

The TODO pointing at #24669 stays: a proper batch API would let the draft know about the chunk, but nothing here depends on it.

## Additional information

Qwen3.8-27B TQ3_1S + DFlash2 + `mmproj-F16` on an MI210 (ROCm 7.2.3), a 20 KB text prefix plus a 1024×768 image, then a text-only turn in the same conversation:

| | image turn | text turn after it |
|---|---|---|
| before | acceptance 0.013, 26.8 t/s | 0.026, 28.7 t/s |
| after | **0.34, 66.0 t/s** | **0.43, 78.0 t/s** |

Measured with the default draft cache. Mirroring the image chunks with only the position fix applied still crashes the ring cache, and a full-size draft cache (`--swa-full`) is not needed once they are skipped; both variants were run.

The same code and the same TODO exist on ggml-org master, so this applies there as well.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — Claude Code was used for the diagnosis (the bisection that separated positions from the chunk injection), the change, and the verification runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxP6x5bmUDYFvmouceN2mR
