### PR TITLE
cuda: fusion hit counters, test guards and the #343 review follow-ups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ Any combination of `f16`/`q8_0`/`turbo2`/`turbo3`/`turbo4` for K and V is suppor
 | `TURBO_AUTO_ASYMMETRIC`     | `1`     | Auto-select asymmetric K/V types for large-GQA models |
 | `TURBO_SPARSE_V`            | `1`     | Sparse-V dequant skip in flash attention |
 | `GGML_TQ_NATIVE`            | unset    | `1` opts out of load-time TQ->q8_0 conversion, uses fused native TQ kernels (saves ~1.7x VRAM on decode-heavy workloads) |
+| `GGML_CUDA_FUSE_CHAIN`      | unset    | `0` disables the elementwise chain fusion (SILU/GELU/ADD/MUL/SCALE/CLAMP runs into one kernel, `ggml_cuda_fuse_elem_chain`) |
+| `GGML_CUDA_Q8CACHE`         | unset    | `0` disables the per-graph shared-quantize cache in mmvq (gate and up projections reuse one q8_1 copy of the activation) |
 | `LLAMA_ATTN_ROT_K/V_OVERRIDE` | off   | Optional upstream attention rotation (TurboQuant manages its own rotation) |
 
 ### Test gates (all must pass before touching quant/backend code)

--- a/ggml/include/ggml-cuda.h
+++ b/ggml/include/ggml-cuda.h
@@ -43,7 +43,8 @@ GGML_BACKEND_API void ggml_backend_cuda_unregister_host_buffer(void * buffer);
 GGML_BACKEND_API ggml_backend_reg_t ggml_backend_cuda_reg(void);
 
 // Number of times a graph-level fusion fired on this backend since it was created, or -1 for an
-// unknown name. Names: "elem_chain", "fused_binary", "q8_cache_hits". Also reachable through
+// unknown name. Names: "elem_chain", "fused_add", "fused_mul", "q8_cache_hits". Also reachable
+// through
 // ggml_backend_reg_get_proc_address(reg, "ggml_backend_cuda_fusion_count").
 GGML_BACKEND_API int64_t ggml_backend_cuda_fusion_count(ggml_backend_t backend, const char * name);
 

--- a/ggml/include/ggml-cuda.h
+++ b/ggml/include/ggml-cuda.h
@@ -42,6 +42,11 @@ GGML_BACKEND_API void ggml_backend_cuda_unregister_host_buffer(void * buffer);
 
 GGML_BACKEND_API ggml_backend_reg_t ggml_backend_cuda_reg(void);
 
+// Number of times a graph-level fusion fired on this backend since it was created, or -1 for an
+// unknown name. Names: "elem_chain", "fused_binary", "q8_cache_hits". Also reachable through
+// ggml_backend_reg_get_proc_address(reg, "ggml_backend_cuda_fusion_count").
+GGML_BACKEND_API int64_t ggml_backend_cuda_fusion_count(ggml_backend_t backend, const char * name);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1489,7 +1489,8 @@ struct ggml_backend_cuda_context {
     struct {
         int64_t elem_chain    = 0;   // elementwise chains launched (ggml_cuda_fuse_elem_chain)
         int64_t q8_cache_hits = 0;   // mmvq shared-quantize cache hits
-        int64_t fused_binary  = 0;   // tuned multi-ADD/MUL runs (ggml_cuda_op_fused_add/mul)
+        int64_t fused_add     = 0;   // tuned multi-ADD runs (ggml_cuda_op_fused_add)
+        int64_t fused_mul     = 0;   // tuned multi-MUL runs (ggml_cuda_op_fused_mul)
     } fusion_stats;
 
 #ifdef USE_CUDA_GRAPH

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1484,6 +1484,14 @@ struct ggml_backend_cuda_context {
 
     uint64_t graph_epoch = 1;
 
+    // Fusion hit counters. Read through ggml_backend_cuda_fusion_count(); test-backend-ops uses
+    // them to check that a fusion actually fired, not only that the fused result is right.
+    struct {
+        int64_t elem_chain    = 0;   // elementwise chains launched (ggml_cuda_fuse_elem_chain)
+        int64_t q8_cache_hits = 0;   // mmvq shared-quantize cache hits
+        int64_t fused_binary  = 0;   // tuned multi-ADD/MUL runs (ggml_cuda_op_fused_add/mul)
+    } fusion_stats;
+
 #ifdef USE_CUDA_GRAPH
     // Map from first_node_ptr to cuda_graph - allows multiple graphs per context
     // when the computation is split across CPU/GPU (e.g., with --n-cpu-moe)

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3905,10 +3905,11 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
                 fused_node.src[j + 2] = cgraph->nodes[i + j + 1]->src[1];
             }
             fused_node.data = cgraph->nodes[i + n_fuse - 1]->data;
-            cuda_ctx->fusion_stats.fused_binary++;
             if (node->op == GGML_OP_ADD) {
+                cuda_ctx->fusion_stats.fused_add++;
                 ggml_cuda_op_fused_add(*cuda_ctx, &fused_node, n_fuse);
             } else {
+                cuda_ctx->fusion_stats.fused_mul++;
                 ggml_cuda_op_fused_mul(*cuda_ctx, &fused_node, n_fuse);
             }
             return n_fuse - 1;
@@ -5908,8 +5909,11 @@ int64_t ggml_backend_cuda_fusion_count(ggml_backend_t backend, const char * name
     if (strcmp(name, "q8_cache_hits") == 0) {
         return ctx->fusion_stats.q8_cache_hits;
     }
-    if (strcmp(name, "fused_binary") == 0) {
-        return ctx->fusion_stats.fused_binary;
+    if (strcmp(name, "fused_add") == 0) {
+        return ctx->fusion_stats.fused_add;
+    }
+    if (strcmp(name, "fused_mul") == 0) {
+        return ctx->fusion_stats.fused_mul;
     }
     return -1;
 }

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1929,7 +1929,7 @@ static bool ggml_cuda_should_fuse_mul_mat_vec_q(const ggml_tensor * tensor) {
 // GGML_TQ_MMQ gates the native TQ MMQ prefill path. Read it once: getenv() is short-circuited
 // away on NVIDIA but is a libc call per mul_mat node on the AMD path.
 static bool ggml_cuda_tq_mmq_enabled() {
-    static const bool enabled = ggml_cuda_tq_mmq_enabled();
+    static const bool enabled = getenv("GGML_TQ_MMQ") != nullptr;
     return enabled;
 }
 

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3642,6 +3642,22 @@ static int ggml_cuda_fuse_elem_chain(ggml_backend_cuda_context & ctx, const ggml
         }
         const int out_ch[1] = { i + len - 1 };
 
+        // A run of same-op ADDs or MULs over same-layout operands, chained through src0, is what
+        // the tuned multi-ADD/MUL kernels in ggml_cuda_try_fuse() take, and they are a little
+        // faster than the chain kernel for it (MI210, four ADDs over 4096x64 f32: 3.75-3.96 us
+        // per run tuned vs 4.0 us chain). Leave that pattern to them.
+        {
+            bool pure_run = (ops_ch[0] == GGML_OP_ADD || ops_ch[0] == GGML_OP_MUL);
+            for (int k = 0; k < len && pure_run; ++k) {
+                const ggml_tensor * nd = cgraph->nodes[i + k];
+                pure_run = nd->op == ops_ch[0] && !desc.bcast[k] && (k == 0 || desc.chain_is_lhs[k]) &&
+                           ggml_are_same_layout(nd->src[1], cgraph->nodes[i]->src[1]);
+            }
+            if (pure_run) {
+                return -1;
+            }
+        }
+
         // Aliasing. ggml_cuda_check_fusion_memory_ranges() is not used here on purpose: it
         // vetoes any overlap between the output and an input, and exact in-place aliasing is
         // the common case for this pattern (galloc hands residual adds their input's buffer).
@@ -3685,6 +3701,7 @@ static int ggml_cuda_fuse_elem_chain(ggml_backend_cuda_context & ctx, const ggml
             ggml_can_fuse_subgraph(cgraph, i, len, ops_ch, out_ch, 1)) {
 
             desc.n_ops = len;
+            ctx.fusion_stats.elem_chain++;
             ggml_cuda_op_elem_chain(ctx, (const float *) head_src->data,
                                     (float *) out->data, ggml_nelements(out), desc);
             return len - 1;   // nodes consumed beyond this one
@@ -3794,7 +3811,10 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
         }
     }
 
-    // Elementwise chain ("midi-kernel"), see ggml_cuda_fuse_elem_chain().
+    // Elementwise chain ("midi-kernel"), see ggml_cuda_fuse_elem_chain(). It runs before the
+    // tuned fusions below (multi-ADD/MUL, unary+MUL, RELU+SQR) and covers a superset of their
+    // patterns; a pure same-layout ADD or MUL run is the one case it hands back to them, since
+    // their kernels are a little faster for it (numbers in ggml_cuda_fuse_elem_chain()).
     {
         const int n_fused = ggml_cuda_fuse_elem_chain(*cuda_ctx, cgraph, i);
         if (n_fused >= 0) {
@@ -3885,6 +3905,7 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
                 fused_node.src[j + 2] = cgraph->nodes[i + j + 1]->src[1];
             }
             fused_node.data = cgraph->nodes[i + n_fuse - 1]->data;
+            cuda_ctx->fusion_stats.fused_binary++;
             if (node->op == GGML_OP_ADD) {
                 ggml_cuda_op_fused_add(*cuda_ctx, &fused_node, n_fuse);
             } else {
@@ -5876,6 +5897,23 @@ static ggml_backend_dev_t ggml_backend_cuda_reg_get_device(ggml_backend_reg_t re
     return ctx->devices[index];
 }
 
+int64_t ggml_backend_cuda_fusion_count(ggml_backend_t backend, const char * name) {
+    if (!ggml_backend_is_cuda(backend) || name == nullptr) {
+        return -1;
+    }
+    const ggml_backend_cuda_context * ctx = (const ggml_backend_cuda_context *) backend->context;
+    if (strcmp(name, "elem_chain") == 0) {
+        return ctx->fusion_stats.elem_chain;
+    }
+    if (strcmp(name, "q8_cache_hits") == 0) {
+        return ctx->fusion_stats.q8_cache_hits;
+    }
+    if (strcmp(name, "fused_binary") == 0) {
+        return ctx->fusion_stats.fused_binary;
+    }
+    return -1;
+}
+
 static ggml_backend_feature * ggml_backend_cuda_get_features(ggml_backend_reg_t reg) {
     static std::vector<ggml_backend_feature> features = []() {
         std::vector<ggml_backend_feature> features;
@@ -5952,6 +5990,9 @@ static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, con
     }
     if (strcmp(name, "ggml_backend_get_features") == 0) {
         return (void *)ggml_backend_cuda_get_features;
+    }
+    if (strcmp(name, "ggml_backend_cuda_fusion_count") == 0) {
+        return (void *)ggml_backend_cuda_fusion_count;
     }
     return nullptr;
 }

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -1276,7 +1276,7 @@ void ggml_cuda_mul_mat_vec_q(
     // consumed again in this graph eval with the same layout (see q8_cache in common.cuh).
     // ConvRot types and MUL_MAT_ID stay uncached; oversized batches fall back too.
     auto & qc = ctx.q8_cache;
-    static const bool q8_cache_disabled = getenv("GGML_TQ_Q8CACHE") != nullptr && atoi(getenv("GGML_TQ_Q8CACHE")) == 0;
+    static const bool q8_cache_disabled = getenv("GGML_CUDA_Q8CACHE") != nullptr && atoi(getenv("GGML_CUDA_Q8CACHE")) == 0;
     // Main stream only: a sibling stream could consume the buffer with no cross-stream ordering.
     const bool q8_cacheable = !q8_cache_disabled && !convrot && ids == nullptr && q8_bytes <= (1u << 20) &&
                               ctx.curr_stream_no == 0;
@@ -1289,6 +1289,7 @@ void ggml_cuda_mul_mat_vec_q(
     char * src1_q8_1 = nullptr;
 
     if (q8_hit) {
+        ctx.fusion_stats.q8_cache_hits++;
         src1_q8_1 = qc.ptr;
     } else {
         if (q8_cacheable) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -968,8 +968,10 @@ struct console_printer : public printer {
 
         if (result.passed) {
             printf("\033[1;32mOK\033[0m\n");
-        } else {
+        } else if (result.error_message.empty()) {
             printf("\033[1;31mFAIL\033[0m\n");
+        } else {
+            printf("\033[1;31mFAIL\033[0m [%s]\n", result.error_message.c_str());
         }
     }
 
@@ -1511,11 +1513,19 @@ struct test_case {
             fused_nodes_to_verify.push_back(out);
         }
 
-        // optional guard that the fusion under test really fired on backend1
+        // optional guard that the fusion under test really fired on backend1.
+        // Skipped under the backend's global fusion kill switch, which is a normal thing to set
+        // while bisecting a numeric problem and would otherwise fail every guarded case.
+        static const bool fusion_off = [] {
+            const char * e = getenv("GGML_CUDA_DISABLE_FUSION");
+            return e != nullptr && atoi(e) != 0;
+        }();
+
         typedef int64_t (*fusion_count_t)(ggml_backend_t, const char *);
+        const char *   fusion        = fusion_off ? nullptr : required_fusion();
         fusion_count_t fusion_count  = nullptr;
         int64_t        fusion_before = -1;
-        if (const char * fusion = required_fusion()) {
+        if (fusion != nullptr) {
             ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(ggml_backend_get_device(backend1));
             if (reg != nullptr) {
                 fusion_count = (fusion_count_t) ggml_backend_reg_get_proc_address(reg, "ggml_backend_cuda_fusion_count");
@@ -1529,14 +1539,38 @@ struct test_case {
                                                                run_whole_graph() ? fused_nodes_to_verify.data() : nullptr,
                                                                fused_nodes_to_verify.size());
 
-        bool fusion_ok = true;
-        if (fusion_count != nullptr && fusion_before >= 0) {
-            fusion_ok = fusion_count(backend1, required_fusion()) > fusion_before;
+        bool        fusion_ok = true;
+        std::string fusion_err;
+        if (fusion_count != nullptr) {
+            if (fusion_before < 0) {
+                // the backend has the counters but does not know this name: a typo would otherwise
+                // disable the check silently, which defeats the point of having it
+                fusion_ok  = false;
+                fusion_err = std::string("unknown fusion counter '") + fusion + "'";
+            } else if (fusion_count(backend1, fusion) <= fusion_before) {
+                fusion_ok  = false;
+                fusion_err = std::string("fusion '") + fusion + "' did not fire";
+            }
         }
 
-        // Create test result
+        // Create test result. Every reason is reported: a numeric failure must stay visible even
+        // when the fusion guard trips as well.
         bool        test_passed = ud.ok && cmp_ok && fusion_ok;
-        std::string error_msg   = test_passed ? "" : (!cmp_ok ? "compare failed" : !fusion_ok ? "fusion did not fire" : "test failed");
+        std::string error_msg;
+        if (!test_passed) {
+            const auto add_reason = [&error_msg](const std::string & reason) {
+                error_msg += error_msg.empty() ? reason : ", " + reason;
+            };
+            if (!cmp_ok) {
+                add_reason("compare failed");
+            }
+            if (!ud.ok) {
+                add_reason("test failed");
+            }
+            if (!fusion_ok) {
+                add_reason(fusion_err);
+            }
+        }
         test_result result(ggml_backend_name(backend1), current_op_name, vars(), "test", supported, test_passed,
                            error_msg);
 
@@ -6553,11 +6587,14 @@ struct test_mul_mat_shared_src1 : public test_case {
     test_mul_mat_shared_src1(ggml_type type, int64_t m, int64_t n, int64_t k)
         : type(type), m(m), n(n), k(k) {}
 
-    // the shared-quantize cache lives on the mmvq path, which the CUDA backend takes for n <= 8;
-    // native TQ weights quantize their activation on their own path, so those cases are numeric-only
+    // The shared-quantize cache lives on the mmvq path, and ggml_cuda_should_use_mmvq picks that
+    // path from a per-architecture table: the lowest bound among the types tested here is ne11 <= 6
+    // (Q8_0 on CDNA1), so only n <= 4 is guaranteed to route to mmvq everywhere. Larger n stays
+    // numeric-only rather than reporting a missing fusion on a correct build. Native TQ weights
+    // quantize their activation on their own path, so those cases are numeric-only too.
     const char * required_fusion() override {
         const bool tq = type == GGML_TYPE_TQ4_1S || type == GGML_TYPE_TQ3_1S;
-        return n <= 8 && !tq ? "q8_cache_hits" : nullptr;
+        return n <= 4 && !tq ? "q8_cache_hits" : nullptr;
     }
 
     std::string vars() override {
@@ -6607,7 +6644,7 @@ struct test_elem_chain_fusion : public test_case {
         return VARS_TO_STR5(ne, with_gelu_softplus, self_mul, add_run, scale_bias);
     }
 
-    const char * required_fusion() override { return add_run ? "fused_binary" : "elem_chain"; }
+    const char * required_fusion() override { return add_run ? "fused_add" : "elem_chain"; }
 
     std::string op_desc(ggml_tensor * t) override {
         GGML_UNUSED(t);

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -1234,6 +1234,9 @@ struct test_case {
 
     virtual bool run_whole_graph() { return false; }
     virtual std::vector<ggml_tensor *> fusion_test_nodes() { return {}; }
+    // Name of a backend fusion counter (see ggml_backend_cuda_fusion_count) that must advance while
+    // the graph runs on the tested backend. Backends without the counter are not checked.
+    virtual const char * required_fusion() { return nullptr; }
     virtual bool use_weight_context() { return false; }
 
     ggml_cgraph * gf = nullptr;
@@ -1507,13 +1510,33 @@ struct test_case {
         if (fused_nodes_to_verify.size() == 0 && run_whole_graph()) {
             fused_nodes_to_verify.push_back(out);
         }
+
+        // optional guard that the fusion under test really fired on backend1
+        typedef int64_t (*fusion_count_t)(ggml_backend_t, const char *);
+        fusion_count_t fusion_count  = nullptr;
+        int64_t        fusion_before = -1;
+        if (const char * fusion = required_fusion()) {
+            ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(ggml_backend_get_device(backend1));
+            if (reg != nullptr) {
+                fusion_count = (fusion_count_t) ggml_backend_reg_get_proc_address(reg, "ggml_backend_cuda_fusion_count");
+            }
+            if (fusion_count != nullptr) {
+                fusion_before = fusion_count(backend1, fusion);
+            }
+        }
+
         const bool cmp_ok = ggml_backend_compare_graph_backend(backend1, backend2, gf, callback, &ud,
                                                                run_whole_graph() ? fused_nodes_to_verify.data() : nullptr,
                                                                fused_nodes_to_verify.size());
 
+        bool fusion_ok = true;
+        if (fusion_count != nullptr && fusion_before >= 0) {
+            fusion_ok = fusion_count(backend1, required_fusion()) > fusion_before;
+        }
+
         // Create test result
-        bool        test_passed = ud.ok && cmp_ok;
-        std::string error_msg   = test_passed ? "" : (!cmp_ok ? "compare failed" : "test failed");
+        bool        test_passed = ud.ok && cmp_ok && fusion_ok;
+        std::string error_msg   = test_passed ? "" : (!cmp_ok ? "compare failed" : !fusion_ok ? "fusion did not fire" : "test failed");
         test_result result(ggml_backend_name(backend1), current_op_name, vars(), "test", supported, test_passed,
                            error_msg);
 
@@ -6530,6 +6553,13 @@ struct test_mul_mat_shared_src1 : public test_case {
     test_mul_mat_shared_src1(ggml_type type, int64_t m, int64_t n, int64_t k)
         : type(type), m(m), n(n), k(k) {}
 
+    // the shared-quantize cache lives on the mmvq path, which the CUDA backend takes for n <= 8;
+    // native TQ weights quantize their activation on their own path, so those cases are numeric-only
+    const char * required_fusion() override {
+        const bool tq = type == GGML_TYPE_TQ4_1S || type == GGML_TYPE_TQ3_1S;
+        return n <= 8 && !tq ? "q8_cache_hits" : nullptr;
+    }
+
     std::string vars() override {
         return VARS_TO_STR4(type, m, n, k);
     }
@@ -6565,14 +6595,19 @@ struct test_mul_mat_shared_src1 : public test_case {
 struct test_elem_chain_fusion : public test_case {
     const std::array<int64_t, 4> ne;
     const bool with_gelu_softplus;
-    const bool self_mul;   // out = MUL(t0, t0) with t0 = SILU(x): t0 is an elided intermediate used twice
+    const bool self_mul;     // out = MUL(t0, t0) with t0 = SILU(x): t0 is an elided intermediate used twice
+    const bool add_run;      // out = x + o1 + o2 + o3 + o4: the chain hands this run to the tuned multi-ADD kernel
+    const float scale_bias;  // nonzero: SCALE carries a bias (ggml_scale_bias) instead of a plain scale
 
-    test_elem_chain_fusion(std::array<int64_t, 4> ne, bool with_gelu_softplus, bool self_mul = false)
-        : ne(ne), with_gelu_softplus(with_gelu_softplus), self_mul(self_mul) {}
+    test_elem_chain_fusion(std::array<int64_t, 4> ne, bool with_gelu_softplus, bool self_mul = false,
+                           bool add_run = false, float scale_bias = 0.0f)
+        : ne(ne), with_gelu_softplus(with_gelu_softplus), self_mul(self_mul), add_run(add_run), scale_bias(scale_bias) {}
 
     std::string vars() override {
-        return VARS_TO_STR3(ne, with_gelu_softplus, self_mul);
+        return VARS_TO_STR5(ne, with_gelu_softplus, self_mul, add_run, scale_bias);
     }
+
+    const char * required_fusion() override { return add_run ? "fused_binary" : "elem_chain"; }
 
     std::string op_desc(ggml_tensor * t) override {
         GGML_UNUSED(t);
@@ -6589,6 +6624,16 @@ struct test_elem_chain_fusion : public test_case {
         ggml_set_name(o1, "o1");
         ggml_set_name(s, "s");
 
+        if (add_run) {
+            ggml_tensor * cur = x;
+            for (int j = 0; j < 4; ++j) {
+                ggml_tensor * o = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne.data());
+                ggml_set_name(o, ("o" + std::to_string(j + 2)).c_str());
+                cur = ggml_add(ctx, cur, o);
+            }
+            ggml_set_name(cur, "out");
+            return cur;
+        }
         ggml_tensor * cur = ggml_silu(ctx, x);
         if (self_mul) {
             cur = ggml_mul(ctx, cur, cur);
@@ -6603,7 +6648,7 @@ struct test_elem_chain_fusion : public test_case {
             cur = ggml_gelu(ctx, cur);
             cur = ggml_softplus(ctx, cur);
         }
-        cur = ggml_scale(ctx, cur, 0.5f);
+        cur = scale_bias != 0.0f ? ggml_scale_bias(ctx, cur, 0.5f, scale_bias) : ggml_scale(ctx, cur, 0.5f);
         cur = ggml_clamp(ctx, cur, -4.0f, 4.0f);
         ggml_set_name(cur, "out");
         return cur;
@@ -6611,7 +6656,7 @@ struct test_elem_chain_fusion : public test_case {
 };
 
 // MUL_MAT_ID -> MUL(weights) -> PERMUTE -> CONT -> SUM_ROWS, the MoE expert-reduce tail as
-// llama.cpp builds it, compared against the CPU graph whether or not a backend fuses it.
+// llama.cpp builds it, compared against the CPU graph. Coverage of the tail, not of a fusion.
 struct test_moe_reduce_fusion : public test_case {
     const ggml_type type;
     const int64_t m;
@@ -6631,7 +6676,7 @@ struct test_moe_reduce_fusion : public test_case {
 
     std::string op_desc(ggml_tensor * t) override {
         GGML_UNUSED(t);
-        return "MOE_REDUCE_FUSION";
+        return "MUL_MAT_ID_REDUCE";
     }
 
     // the graph ends in a quantized matvec, so the same tolerance as test_mul_mat for quantized types
@@ -8701,6 +8746,8 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_elem_chain_fusion({256, 4, 2, 1}, false));
     test_cases.emplace_back(new test_elem_chain_fusion({256, 4, 2, 1}, true));
     test_cases.emplace_back(new test_elem_chain_fusion({256, 4, 2, 1}, false, true));
+    test_cases.emplace_back(new test_elem_chain_fusion({256, 4, 2, 1}, false, false, false, 0.25f));
+    test_cases.emplace_back(new test_elem_chain_fusion({4096, 64, 1, 1}, false, false, true));
     std::default_random_engine rng(0);
 
     // unary ops
@@ -10649,6 +10696,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
 // Test cases for performance evaluation: should be representative of real-world use cases
 static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     std::vector<std::unique_ptr<test_case>> test_cases;
+
+    // elementwise chain vs the tuned multi-ADD kernel (GGML_CUDA_FUSE_CHAIN=0 to compare)
+    test_cases.emplace_back(new test_elem_chain_fusion({4096, 64, 1, 1}, false, false, true));
+    test_cases.emplace_back(new test_elem_chain_fusion({4096, 64, 1, 1}, false, false, false, 0.25f));
 
     // Conv2d: K=CRS=NPQ=4096 matmul performance
     uint32_t                        iwh_idx  = 0;


### PR DESCRIPTION
Follow-up to #343, the non-blocking items from the review there.

## What changed

- **Fusion hit counters.** The CUDA context now counts elementwise chains launched, tuned multi-ADD/MUL runs, and shared-quantize cache hits. They are read through `ggml_backend_cuda_fusion_count(backend, name)`, also reachable via `ggml_backend_reg_get_proc_address(reg, "ggml_backend_cuda_fusion_count")` so test-backend-ops needs no CUDA header.
- **Tests guard the feature, not just the numbers.** `test_case` gets a `required_fusion()` hook; when the tested backend exposes the counter and it does not advance while the graph runs, the case fails with `fusion did not fire`. `ELEM_CHAIN_FUSION` requires the chain (the multi-ADD case requires the tuned kernel instead, see below), `MUL_MAT_SHARED_SRC1` requires a cache hit for the n <= 8 Q8_0/Q4_0 cases (the mmvq path; native TQ weights quantize their activation on their own path, so those stay numeric-only). Backends without the counter are unaffected. Sanity check below: with `GGML_CUDA_FUSE_CHAIN=0` the chain cases fail, with `GGML_CUDA_Q8CACHE=0` the eight Q8_0/Q4_0 cache cases fail.
- **New chain cases:** `SCALE` with a nonzero bias (`ggml_scale_bias`), and a pure run of four same-shape f32 `ADD`s, which is the pattern the tuned multi-ADD kernel also takes.
- **Precedence.** You were right to ask: the tuned multi-ADD kernel is a little faster than the chain kernel for a pure run of ADDs (numbers below), so the chain detector now hands a pure same-layout ADD or MUL run, chained through src0, back to `ggml_cuda_try_fuse()`'s tuned path and keeps everything else. Both call sites carry a comment saying so.
- **`MOE_REDUCE_FUSION` renamed to `MUL_MAT_ID_REDUCE`**, since it no longer tests a fusion.
- **Env vars:** `GGML_TQ_Q8CACHE` becomes `GGML_CUDA_Q8CACHE` (the cache is not TQ-specific), and both it and `GGML_CUDA_FUSE_CHAIN` are documented in the AGENTS.md table. **This is a breaking rename with no alias for the old name.** It is safe here only because the variable landed in #343 and has not been in a release; anyone who picked it up from that branch has to change the name.

## Second review round

- `MUL_MAT_SHARED_SRC1`'s guard is narrowed from `n <= 8` to `n <= 4`. `ggml_cuda_should_use_mmvq` picks the mmvq path from a per-architecture table whose lowest bound among the types registered here is `ne11 <= 6` (Q8_0 on CDNA1), so `n = 8` routes to MMQ there and the guard would have failed on a correct build.
- The guard is skipped when `GGML_CUDA_DISABLE_FUSION` is set and non-zero, matching the backend's own predicate, so the global kill switch stays usable while bisecting a numeric problem.
- An unknown counter name is now a hard failure rather than a silent pass, so a typo cannot disable the check, and `print_test_console` shows the failure reason: it was only reaching the CSV output, which left every failing case as a bare `FAIL`.
- `fused_binary` is split into `fused_add` and `fused_mul`, counted in their own branches; the multi-ADD case requires `fused_add`.
- `required_fusion()` is evaluated once, and every failure reason is reported so a numeric failure stays visible when the guard trips too.

## Test

MI210 (gfx90a), `GGML_TQ_MMQ=1 GGML_TQ_NATIVE=1`:

| suite | result |
|---|---|
| `-o ELEM_CHAIN_FUSION` (5 cases: base, gelu+softplus, self_mul, scale bias, add run) | 5/5 |
| `-o MUL_MAT_SHARED_SRC1` | 12/12 |
| `-o MUL_MAT_RESIDUAL_FUSION` | 24/24 |
| `-o MUL_MAT_ID_REDUCE` | 6/6 |
| `-o MUL_MAT -p type_a=tq4_1s` / `tq3_1s` | 149/149, 158/158 |
| guard check, `GGML_CUDA_FUSE_CHAIN=0 -o ELEM_CHAIN_FUSION` | 1/5 (only the add run, which the tuned kernel takes) |
| guard check, `GGML_CUDA_Q8CACHE=0 -o MUL_MAT_SHARED_SRC1` | 4/12 (only the TQ cases, which are numeric-only) |

The branch sits on top of #348, since the tq4 suites hang on the base without it.

## Timing, chain kernel vs tuned multi-ADD

`test-backend-ops perf -o ELEM_CHAIN_FUSION`, the `add_run=1` case ({4096, 64} f32, four ADDs, 3 MB moved per run), three runs each, before the yield was added:

| | us/run | GB/s |
|---|---|---|
| chain kernel (`GGML_CUDA_FUSE_CHAIN=1`, before the yield) | 3.99 / 4.01 / 4.00 | 733 |
| tuned `ggml_cuda_op_fused_add` (`GGML_CUDA_FUSE_CHAIN=0`) | 3.75 / 3.96 / 3.96 | 740-780 |
| chain enabled, with the yield (this branch) | 3.75 / 3.77 / 3.98 | 736-780 |

For a mixed chain (SILU, MUL, ADD, ADD, SCALE with bias, CLAMP over the same shape) the chain kernel is the faster one: 2.50 us/run vs 2.52-2.54 us/run with it disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxP6x5bmUDYFvmouceN2mR
