### PR TITLE
server: bound the 'unlimited' prompt cache by free host memory and log its size

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1665,7 +1665,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_env("LLAMA_ARG_CHECKPOINT_MIN_SPACING_NT").set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
         {"-cram", "--cache-ram"}, "N",
-        string_format("set the maximum cache size in MiB (default: %d, -1 - no limit, 0 - disable)"
+        string_format("set the maximum cache size in MiB (default: %d, -1 - half of the free host memory at startup, 0 - disable)"
             "[(more info)](https://github.com/ggml-org/llama.cpp/pull/16391)", params.cache_ram_mib),
         [](common_params & params, int value) {
             params.cache_ram_mib = value;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1689,14 +1689,25 @@ private:
         }
 
         if (params_base.cache_ram_mib != 0) {
-            if (params_base.cache_ram_mib < 0) {
-                SRV_TRC("prompt cache is enabled, size limit: %s\n", "no limit");
+            int32_t cache_ram_mib = params_base.cache_ram_mib;
+            if (cache_ram_mib < 0) {
+                // "no limit" must still be bounded by the machine: every cached prompt is a full copy of a
+                // sequence's KV state in host memory (14 GiB for a 220k-token f16 cache on a 27B model),
+                // and an unbounded cache swaps the box to death long before it helps anyone.
+                // Take half of what the host has free when the server starts.
+                size_t free_host = 0, total_host = 0;
+                if (auto * cpu_dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU)) {
+                    ggml_backend_dev_memory(cpu_dev, &free_host, &total_host);
+                }
+                cache_ram_mib = free_host > 0 ? (int32_t) std::min<size_t>(free_host / 2 / (1024*1024), INT32_MAX) : 8192;
+                SRV_INF("prompt cache is enabled with no explicit limit, bounding it to %d MiB (half of the %.1f GiB of free host memory)\n",
+                        cache_ram_mib, free_host / (1024.0*1024.0*1024.0));
             } else {
-                SRV_TRC("prompt cache is enabled, size limit: %d MiB\n", params_base.cache_ram_mib);
+                SRV_INF("prompt cache is enabled, size limit: %d MiB\n", cache_ram_mib);
             }
             SRV_TRC("%s", "use `--cache-ram 0` to disable the prompt cache\n");
 
-            prompt_cache = std::make_unique<server_prompt_cache>(params_base.cache_ram_mib, n_ctx);
+            prompt_cache = std::make_unique<server_prompt_cache>(cache_ram_mib, n_ctx);
         } else {
             SRV_TRC("%s", "prompt cache is disabled - use `--cache-ram N` to enable it\n");
         }

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1844,8 +1844,10 @@ void server_prompt_cache::update() {
         }
     }
 
-    SRV_TRC(" - cache state: %zu prompts, %.3f MiB (limits: %.3f MiB, %zu tokens, %zu est)\n",
-            states.size(), size() / (1024.0 * 1024.0), limit_size / (1024.0 * 1024.0), limit_tokens, limit_tokens_cur);
+    // one line per update at info level: the cache is the largest host allocation the server makes,
+    // and its size has to be visible in ordinary logs
+    SRV_INF("prompt cache: %zu prompts, %.1f MiB (limit %.1f MiB, %zu tokens)\n",
+            states.size(), size() / (1024.0 * 1024.0), limit_size / (1024.0 * 1024.0), limit_tokens);
 
     for (const auto & state : states) {
         SRV_TRC("   - prompt %p: %7d tokens, checkpoints: %2zu, %9.3f MiB\n",


### PR DESCRIPTION
## What

`--cache-ram -1` ("no limit") now means half of the free host memory at server start, and the prompt cache prints one info line per update with its entry count and size.

## Why

Every cached prompt is a full copy of a sequence's KV state in host memory. For a 220k-token f16 cache on Qwen3.8-27B that is 14 GiB per entry. LocalAI's llama.cpp backend passes `-1` by default, so on a single-slot server every request that displaces a long session (OpenCode's title and summary calls, for example) saves another 14 GiB copy and nothing ever evicts it. On a 60 GB box the backend reached 59.7 GB resident plus 5 GB of swap within an hour; from that point every new GPU process on the machine died with `amdgpu: SVM mapping failed, exceeds resident system memory limit`, and the session itself fell back to full re-prefills of 220k tokens (seven minutes each).

The cache state was only logged at trace level, which is how this went unnoticed; it is now an info line.

## Behaviour

- explicit `--cache-ram N`: unchanged
- `--cache-ram 0`: unchanged, disabled
- `--cache-ram -1`: bounded to `free_host / 2` (falls back to 8192 MiB when the host memory cannot be read); the chosen bound is logged at startup

## Test

Production, before (bigtime, MI210, Qwen3.8-27B with a 220k-token OpenCode session, `cache_ram=-1` via LocalAI): backend at 59.7 GB RSS + 5 GB swap after ~1 h; two 14.2 GB and one 26.5 GB anonymous mappings (full KV copies of the session); 10 LRU slot selections in 2 h; every new HIP process on the box failed with `SVM mapping failed`.

Standalone, after (moonage, CPU backend to stay off the production GPUs, qwen2.5-coder-14b, `-c 8192`, a 2.8k-token session interleaved with four unrelated short requests):

| setting | startup log | behaviour |
|---|---|---|
| `--cache-ram -1` | `bounding it to 32103 MiB (half of the 62.7 GiB of free host memory)` | cache holds one entry at a time (~550 MiB); each return of the session restores it and processes 15-19 tokens; RSS flat at 8.8 GB across 9 requests |
| `--cache-ram 64` | `size limit: 64 MiB` | every save skipped (`prompt state size 552 MiB exceeds cache size limit`), each return re-prefills ~2.8k tokens: the failure mode the bound prevents at scale |

The per-update line reads e.g. `prompt cache: 1 prompts, 552.0 MiB (limit 32103.0 MiB, 8192 tokens)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxP6x5bmUDYFvmouceN2mR
