### PR TITLE
fix: three correctness bugs in --gdn-replay

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -374,6 +374,8 @@ void llm_graph_input_rs::set_input(const llama_ubatch * ubatch) {
             data[i] = mctx->s_copy(i);
         }
     }
+
+    mctx->consume_replay_len();
 }
 
 bool llm_graph_input_rs::can_reuse(const llm_graph_params & params) {
@@ -1129,6 +1131,8 @@ void llm_graph_input_mem_hybrid::set_input(const llama_ubatch * ubatch) {
             data[i] = mctx->get_recr()->s_copy(i);
         }
     }
+
+    mctx->get_recr()->consume_replay_len();
 }
 
 bool llm_graph_input_mem_hybrid::can_reuse(const llm_graph_params & params) {
@@ -1150,6 +1154,10 @@ bool llm_graph_input_mem_hybrid::can_reuse(const llm_graph_params & params) {
 
     res &= inp_rs->head == mctx->get_recr()->get_head();
     res &= inp_rs->rs_z == mctx->get_recr()->get_rs_z();
+
+    // DRC phase 2: same guard as llm_graph_input_rs::can_reuse -- a changed replay length means a
+    // differently-shaped reconstruction subtree, which reused topology cannot express.
+    res &= inp_rs->replay_len == mctx->get_recr()->get_replay_len();
 
     return res;
 }
@@ -1173,6 +1181,8 @@ void llm_graph_input_mem_hybrid_k::set_input(const llama_ubatch * ubatch) {
             data[i] = mctx->get_recr()->s_copy(i);
         }
     }
+
+    mctx->get_recr()->consume_replay_len();
 }
 
 bool llm_graph_input_mem_hybrid_k::can_reuse(const llm_graph_params & params) {
@@ -1193,6 +1203,10 @@ bool llm_graph_input_mem_hybrid_k::can_reuse(const llm_graph_params & params) {
 
     res &= inp_rs->head == mctx->get_recr()->get_head();
     res &= inp_rs->rs_z == mctx->get_recr()->get_rs_z();
+
+    // DRC phase 2: same guard as llm_graph_input_rs::can_reuse -- a changed replay length means a
+    // differently-shaped reconstruction subtree, which reused topology cannot express.
+    res &= inp_rs->replay_len == mctx->get_recr()->get_replay_len();
 
     return res;
 }
@@ -1247,6 +1261,8 @@ void llm_graph_input_mem_hybrid_iswa::set_input(const llama_ubatch * ubatch) {
             data[i] = mctx->get_recr()->s_copy(i);
         }
     }
+
+    mctx->get_recr()->consume_replay_len();
 }
 
 bool llm_graph_input_mem_hybrid_iswa::can_reuse(const llm_graph_params & params) {
@@ -1281,6 +1297,10 @@ bool llm_graph_input_mem_hybrid_iswa::can_reuse(const llm_graph_params & params)
 
     res &= inp_rs->head == mctx->get_recr()->get_head();
     res &= inp_rs->rs_z == mctx->get_recr()->get_rs_z();
+
+    // DRC phase 2: same guard as llm_graph_input_rs::can_reuse -- a changed replay length means a
+    // differently-shaped reconstruction subtree, which reused topology cannot express.
+    res &= inp_rs->replay_len == mctx->get_recr()->get_replay_len();
 
     return res;
 }

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -1378,6 +1378,19 @@ uint32_t llama_memory_recurrent_context::get_replay_len() const {
     return m;
 }
 
+void llama_memory_recurrent_context::consume_replay_len() const {
+    if (!mem->gdn_replay || is_full) {
+        return;
+    }
+    const llama_ubatch & ubatch = get_ubatch();
+    for (uint32_t i = 0; i < ubatch.n_seqs_unq; ++i) {
+        const llama_seq_id seq = ubatch.seq_id_unq[i];
+        if (seq >= 0 && (size_t) seq < mem->replay_len.size()) {
+            mem->replay_len[seq] = 0;
+        }
+    }
+}
+
 ggml_tensor * llama_memory_recurrent_context::get_p_l(int32_t il) const {
     return mem->p_l[il];
 }

--- a/src/llama-memory-recurrent.h
+++ b/src/llama-memory-recurrent.h
@@ -206,6 +206,13 @@ public:
     // in the current ubatch, or 0 if none. Used by can_reuse() and the graph builder.
     uint32_t get_replay_len() const;
 
+    // DRC phase 2: mark the pending replay as consumed. Called exactly once per decode, after the
+    // graph has been built (every GDN layer reads get_replay_len() during build). Mirrors
+    // s_copy_idx()'s consume-and-clear of rs_idx: without it the first partial rejection latches a
+    // rollback that is re-applied on every later decode, so the recurrent state permanently trails
+    // the token stream.
+    void consume_replay_len() const;
+
 private:
     const llama_memory_status status;
 

--- a/src/models/delta-net-base.cpp
+++ b/src/models/delta-net-base.cpp
@@ -460,7 +460,26 @@ ggml_tensor * llm_build_delta_net_base::build_conv_state(
 
     const int64_t n_seqs = ubatch.n_seqs;
 
-    ggml_tensor * conv_states = build_rs(inp, conv_states_all, hparams.n_embd_r(), n_seqs);
+    // gdn_replay rolls the GDN recurrent state back by replaying ingredients, so seq_rm records
+    // replay_len INSTEAD of calling set_rs_idx (llama-memory-recurrent.cpp) -- rs_idx stays pinned
+    // at 0 for the whole run. The conv state has no replay path: it still keeps its (1 + n_rs_seq)
+    // rollback groups and is selected purely by rs_idx through s_copy_idx(). With rs_idx stuck at
+    // 0, build_rs would always hand back the OPTIMISTIC group 0, i.e. a convolution window that
+    // still contains the rejected draft tokens, while the recurrent state around it was correctly
+    // rewound. The wanted depth is the very same `rollback` value seq_rm saw, so select the group
+    // explicitly here.
+    ggml_tensor * conv_src = conv_states_all;
+
+    const uint32_t conv_rollback = mctx_cur->get_replay_len();
+    if (conv_rollback > 0) {
+        GGML_ASSERT((uint32_t) conv_states_all->ne[1] >= (conv_rollback + 1) * mem_size);
+        conv_src = ggml_view_2d(ctx0, conv_states_all,
+                conv_states_all->ne[0], mem_size,
+                conv_states_all->nb[1],
+                (size_t) conv_rollback * mem_size * conv_states_all->nb[1]);
+    }
+
+    ggml_tensor * conv_states = build_rs(inp, conv_src, hparams.n_embd_r(), n_seqs);
     cb(conv_states, "conv_states", il);
 
     conv_states = ggml_reshape_3d(ctx0, conv_states, conv_kernel_size - 1, conv_channels, n_seqs);
@@ -747,6 +766,24 @@ ggml_tensor * llm_build_delta_net_base::build_recurrent_attn(
             ggml_cpy(ctx0, ggml_reshape_2d(ctx0, new_ckpt, hparams.n_embd_s(), n_seqs), ckpt_dst));
     } else {
         // batch shorter than the retained window: base_state itself is still "before the window".
+        //
+        // CBA: that claim only holds when n_seq_tokens == n_rs_seq. For a strictly shorter batch
+        // base_state is the state at (end - n_seq_tokens), i.e. INSIDE the uncertain window, so a
+        // later rollback deeper than n_seq_tokens would replay from a too-recent checkpoint and
+        // there is no way to recover the true one (the ingredient ring only retains the last
+        // n_rs_seq steps, and delta-net's rank-1 update has no inverse). Unreachable with the
+        // current verify-batch shape (n_draft + 1 > n_draft == n_rs_seq); the one-shot warning is
+        // here to catch it if that ever stops being true. Upgrade path: refuse a rollback deeper
+        // than the checkpoint's actual age instead of silently returning a wrong state.
+        if (n_seq_tokens < (int64_t) n_rs_seq) {
+            static bool warned = false;
+            if (!warned) {
+                warned = true;
+                LLAMA_LOG_WARN("%s: gdn_replay: checkpoint taken with n_seq_tokens (%d) < n_rs_seq (%u); "
+                               "a rollback deeper than %d tokens would be incorrect\n",
+                               __func__, (int) n_seq_tokens, n_rs_seq, (int) n_seq_tokens);
+            }
+        }
         ggml_tensor * ckpt_dst = ggml_view_2d(ctx0, ckpt_all, hparams.n_embd_s(), n_seqs,
             ckpt_all->nb[1], (size_t) kv_head * state_row_size_bytes);
         ggml_build_forward_expand(gf,


### PR DESCRIPTION
`--gdn-replay` corrupts generation on qwen35 (tested on RVN-IQ4_NL-multilingual-mtp, 27B, sm_86). Three independent bugs, all in the DRC phase 2 path. With the three fixed, greedy decoding is byte-identical to a run without the flag over 300 tokens, during which 117 draft tokens were rejected, so the replay path was exercised continuously rather than sitting idle.

**replay_len is never consumed.** `get_replay_len()` reads it and the only writers are `seq_rm` (setting it) and full sequence removal (zeroing it). The classic path does a consume-and-clear of `rs_idx` in `s_copy_idx()`, src/llama-memory-recurrent.cpp:1397. Without the equivalent, the first partial rejection latches a rollback that is then re-applied on every later decode, so the recurrent state permanently trails the token stream. Fixed with a `consume_replay_len()` called once per decode at the end of `set_input`, after every GDN layer has read the value during graph build.

**The hybrid can_reuse variants ignore replay_len.** `llm_graph_input_rs::can_reuse` checks it at src/llama-graph.cpp:396, but `llm_graph_input_mem_hybrid::can_reuse` (:1134) and its `_k` and `_iswa` siblings do not. qwen35 goes through `build_inp_mem_hybrid()`, so the guard never fired for it, and a changed replay length means a differently shaped reconstruction subtree that reused topology cannot express. Upstream keeps the two bodies in sync, the divergence came in with the replay_len check.

**The conv state is never rolled back.** `seq_rm` records `replay_len` instead of calling `set_rs_idx` (src/llama-memory-recurrent.cpp:239-243), so `rs_idx` stays 0 for the whole run. But `rs_idx` is the only rollback group selector, and the conv state keeps its `(1 + n_rs_seq)` layout: `build_conv_state` writes all K snapshots every decode (src/models/delta-net-base.cpp:502-520, `s_slot = K - t`) and then always reads back group 0, the optimistic one. So the recurrent state was correctly rewound while the convolution window still held the rejected draft tokens, which is what produced the short range damage in the output (`LeNorvégien` with no space, `habveut`, `117.`) around otherwise coherent text. The wanted depth is the same `rollback` value `seq_rm` saw, so `build_conv_state` now selects the group explicitly.

There is a fourth thing I did not fix, only flagged with a one-shot warning. The `else` branch of the checkpoint update assumes `base_state` is still before the retained window, which only holds when `n_seq_tokens == n_rs_seq`. For a strictly shorter batch the checkpoint lands inside the uncertain window, and since the ingredient ring only retains the last `n_rs_seq` steps there is no way to recover the true one. It looks unreachable with the current verify batch shape (`n_draft + 1 > n_draft`) and the warning never fired in my runs, so I left the behaviour alone.

On the cost, in case you want it in the flag's help text: measured on a 3090 with the einstein logic prompt, 1200 tokens, fixed seed, `--spec-draft-n-max 3`, acceptance is identical with and without the flag (0.60976 both, and the greedy output matches byte for byte), throughput goes from 64.0 to 57.1 t/s, and VRAM drops by 108 MiB. The replay is exact but costs about 11 percent, and the saving is on per sequence SSM state so it does not grow with context length.

The default path should be untouched: `get_replay_len()` returns 0 when `gdn_replay` is off, so `consume_replay_len()` early-returns, the conv view is not taken, and the new can_reuse comparison is 0 == 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
