### PR TITLE
perplexity: respect explicit -np instead of silently overriding it

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2507,6 +2507,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             string_format("number of parallel sequences to decode (default: %d)", params.n_parallel),
             [](common_params & params, int value) {
                 params.n_parallel = value;
+                params.n_parallel_explicit = true;
             }
         ).set_env("LLAMA_ARG_N_PARALLEL"));
     }

--- a/common/common.h
+++ b/common/common.h
@@ -470,6 +470,7 @@ struct common_params {
     int32_t n_keep                =     0; // number of tokens to keep from initial prompt
     int32_t n_chunks              =    -1; // max number of chunks to process (-1 = unlimited)
     int32_t n_parallel            =     1; // number of parallel sequences to decode
+    bool    n_parallel_explicit   = false; // true if -np/--parallel was passed on the command line
     int32_t n_sequences           =     1; // number of sequences to decode
     int32_t n_outputs_max         =     0; // max outputs in a batch (0 = n_batch)
     bool    gdn_replay            = false; // DRC: ingredient-replay rollback for GDN models instead of full K-snapshots [EXPERIMENTAL]

--- a/tools/perplexity/perplexity.cpp
+++ b/tools/perplexity/perplexity.cpp
@@ -2032,7 +2032,7 @@ int llama_perplexity(int argc, char ** argv) {
     if (params.hellaswag || params.winogrande || params.multiple_choice) {
         params.n_parallel = std::max(4, params.n_parallel);
         params.kv_unified = true;
-    } else { // Perplexity & KL divergence
+    } else if (!params.n_parallel_explicit) { // Perplexity & KL divergence
         params.n_parallel = std::max(1, params.n_batch / n_ctx);
     }
     params.n_ctx = params.n_parallel * n_ctx;


### PR DESCRIPTION
## Summary

Split out of #326 per review comment: https://github.com/TheTom/llama-cpp-turboquant/pull/326#issuecomment-5547922381

The plain-PPL/KLD path in `tools/perplexity/perplexity.cpp` computed `n_parallel = max(1, n_batch / n_ctx)` unconditionally, discarding whatever `-np`/`--parallel` was passed on the command line — including an explicit `-np 1` needed to satisfy `--kv-stream`'s single-sequence gate.

- Added `n_parallel_explicit` tracking (same pattern as the existing `moe_cache.mode_explicit` field) so an explicit `-np` now sticks.
- The auto-batching heuristic still applies unchanged when `-np` isn't passed.

## Test plan

- [x] Builds clean (`llama-perplexity` target)
- [x] No behavior change when `-np` is omitted (heuristic path untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)