### PR TITLE
cuda: fix MSVC duplicate-COMDAT link failure from twice-nested retired_buf

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1453,6 +1453,11 @@ struct ggml_backend_cuda_context {
     // the same graph eval with identical layout. Stream ordering makes overwrite safe (all
     // consumers of the previous entry are already enqueued before the next quantize runs),
     // and the buffer only grows on shape changes, which force a CUDA-graph re-capture anyway.
+    // Retired (outgrown) device buffers, freed at teardown. Named at class scope: MSVC mangles
+    // a type nested in an unnamed struct as <unnamed-tag>, so two identical nested copies
+    // collide into one decorated name and the linker rejects the object (LNK1179).
+    struct retired_buf { char * ptr; size_t cap; int dev; };
+
     struct {
         char *              ptr  = nullptr;      // raw device memory (not pool), grow-only
         size_t              cap  = 0;            // usable bytes
@@ -1463,7 +1468,6 @@ struct ggml_backend_cuda_context {
         size_t              size = 0;            // quantized bytes
         int64_t             ne10_padded = 0;     // layout keys
         ggml_type           type = GGML_TYPE_COUNT;
-        struct retired_buf { char * ptr; size_t cap; int dev; };
         std::vector<retired_buf> retired;        // outgrown buffers, freed at teardown (captured graphs may still use them)
     } q8_cache;
 
@@ -1478,7 +1482,6 @@ struct ggml_backend_cuda_context {
         const void *        data = nullptr;
         uint64_t            epoch = 0;
         size_t              size = 0;
-        struct retired_buf { char * ptr; size_t cap; int dev; };
         std::vector<retired_buf> retired;        // outgrown buffers, freed at teardown (captured graphs may still use them)
     } tq_rot_cache;
 


### PR DESCRIPTION
## What

`feature/turboquant-kv-cache` at `80007e715` does not link on Windows/MSVC. `q8_cache` and
`tq_rot_cache` are unnamed member structs of `ggml_backend_cuda_context`, and each nested its own
identical `struct retired_buf`:

```cpp
    struct {
        ...
        struct retired_buf { char * ptr; size_t cap; int dev; };
        std::vector<retired_buf> retired;
    } q8_cache;

    struct {
        ...
        struct retired_buf { char * ptr; size_t cap; int dev; };   // same again
        std::vector<retired_buf> retired;
    } tq_rot_cache;
```

MSVC decorates a type nested in an unnamed struct as `<unnamed-tag>`, so both nested types mangle
to the same decorated name. The two `std::vector<retired_buf>` instantiations then emit COMDAT
sections with identical names into a single `ggml-cuda.cu.obj`, and `link.exe` rejects the object:

```
ggml-cuda.cu.obj : fatal error LNK1179: invalid or corrupt file: duplicate COMDAT
'??$?0$$V@?$_Compressed_pair@V?$allocator@Uretired_buf@<unnamed-tag>@ggml_backend_cuda_context@@@std@@
V?$_Vector_val@U?$_Simple_types@Uretired_buf@<unnamed-tag>@ggml_backend_cuda_context@@@std@@@2@$00@std@@
QEAA@U_Zero_then_variadic_args_t@1@@Z'
```

Because ninja deletes the target before linking, a failed build also leaves the tree without
`ggml-cuda.dll`, so an incremental rebuild on Windows takes the previously working binary with it.

## Fix

The two definitions are identical, so hoist a single `retired_buf` to class scope. As a member of
a named class it mangles unambiguously, and the duplication goes away as a side effect. Every use
is either `auto` or braced initialisation (`ggml-cuda.cu:751-762`, `mmvq.cu:1300`,
`mmvq-tq.cu:927`), so no call site changes.

## Who introduced it

Neither parent is at fault alone: `767b6278e` added the q8 quantize cache and `3df06b110` the TQ
rotation cache, each with its own nested copy. The collision only exists once both are in the same
translation unit.

## Verification

Windows 11, MSVC 14.51, CUDA sm_120 (RTX 5090 Laptop), Ninja, Release, `BUILD_SHARED_LIBS=ON`,
`CMAKE_CUDA_ARCHITECTURES=120-real`:

- `80007e715` unmodified: `FAILED: bin/ggml-cuda.dll`, LNK1179 as above
- `80007e715` + this commit: full `cmake --build` completes, 0 errors, `ggml-cuda.dll` produced

Non-MSVC toolchains were not affected to begin with — GCC and Clang give the nested types distinct
mangled names — so this should be a no-op there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
