### PR TITLE
cuda: disable elementwise chain fusion by default on RDNA4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Any combination of `f16`/`q8_0`/`turbo2`/`turbo3`/`turbo4` for K and V is suppor
 | `TURBO_AUTO_ASYMMETRIC`     | `1`     | Auto-select asymmetric K/V types for large-GQA models |
 | `TURBO_SPARSE_V`            | `1`     | Sparse-V dequant skip in flash attention |
 | `GGML_TQ_NATIVE`            | unset    | `1` opts out of load-time TQ->q8_0 conversion, uses fused native TQ kernels (saves ~1.7x VRAM on decode-heavy workloads) |
-| `GGML_CUDA_FUSE_CHAIN`      | unset    | `0` disables the elementwise chain fusion (SILU/GELU/ADD/MUL/SCALE/CLAMP runs into one kernel, `ggml_cuda_fuse_elem_chain`) |
+| `GGML_CUDA_FUSE_CHAIN`      | RDNA4 `0`, other GPUs `1` | Enables the elementwise chain fusion (SILU/GELU/ADD/MUL/SCALE/CLAMP runs into one kernel, `ggml_cuda_fuse_elem_chain`) |
 | `GGML_CUDA_Q8CACHE`         | unset    | `0` disables the per-graph shared-quantize cache in mmvq (gate and up projections reuse one q8_1 copy of the activation) |
 | `LLAMA_ATTN_ROT_K/V_OVERRIDE` | off   | Optional upstream attention rotation (TurboQuant manages its own rotation) |
 

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3570,7 +3570,18 @@ static int ggml_cuda_fuse_elem_chain(ggml_backend_cuda_context & ctx, const ggml
     if (i + 1 >= cgraph->n_nodes) {
         return -1;
     }
-    static bool disable_chain = getenv("GGML_CUDA_FUSE_CHAIN") != nullptr && std::atoi(getenv("GGML_CUDA_FUSE_CHAIN")) == 0;
+    static const int chain_mode = [] {
+        const char * value = getenv("GGML_CUDA_FUSE_CHAIN");
+        if (value != nullptr) {
+            return std::atoi(value) != 0 ? 1 : 0;
+        }
+        return -1;
+    }();
+#if defined(GGML_USE_HIP)
+    const bool disable_chain = chain_mode == 0 || (chain_mode < 0 && GGML_CUDA_CC_IS_RDNA4(ggml_cuda_info().devices[ctx.device].cc));
+#else
+    const bool disable_chain = chain_mode == 0;
+#endif
 
     auto chain_code = [](const ggml_tensor * t, int & code, float & p0, float & p1) -> bool {
         switch (t->op) {


### PR DESCRIPTION
Apollo isolated a large prefill regression on an RX 9070 XT (gfx1201), ROCm 7.2.53211:

- Qwen3.5 9B UD-Q2_K_XL: 318.94 vs 2450.99 pp512
- Qwen3.5 27B GSQ-RCO IQ3_S: 376.71 vs 961.10 pp512
- upstream also gets 975.50 pp512 on the 27B
- decode is unchanged
- dense Llama BF16 is unchanged
- GATED_DELTA_NET, SSM_CONV, and SSM_SCAN timings are within noise

Repro command:

```sh
llama-bench -m <model> -ngl 99 -fa 1 -p 512 -n 128 -r 5
```

All trees were Release builds targeted at gfx1201. This uses default f16 KV with no TurboQuant cache, VBR, or MTP. MMQ coverage, build configuration, VMM, and the SSM kernels have been ruled out.

The fork-only elementwise chain fusion was enabled after the common base. It fuses the F32 chains around the recurrent blocks, so its HIP cost is not visible in the individual SSM kernel timings. This keeps the existing default everywhere else and makes the fusion opt-in on RDNA4 with `GGML_CUDA_FUSE_CHAIN=1`.

Apollo: please rebuild this head and rerun the same pp512/decode commands for both Qwen models. If pp512 recovers, please also run one comparison with `GGML_CUDA_FUSE_CHAIN=1` to confirm the A/B directly. A quantized dense-model pp512 control would help separate the hybrid graph from general quantized matrix multiplication.

Local validation: `git diff --check`. HIP compile CI and hardware performance validation are pending.