### PR TITLE
hip: add flash attention kernel A/B override

### DIFF
--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -768,6 +768,22 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
     const bool can_use_vector_kernel = Q->ne[0] <= 256 && Q->ne[0] % 64 == 0 && Q->ne[0] != 192 && K->ne[1] % FATTN_KQ_STRIDE == 0;
 
 #ifdef GGML_USE_HIP
+    // Diagnostic A/B for HIP flash-attention prefill regressions. This is intentionally
+    // opt-in so normal dispatch is unchanged. The MMA gate is limited to the symmetric
+    // head sizes with compiled instances.
+    if (const char * forced_kernel = getenv("GGML_HIP_FA_KERNEL")) {
+        if (strcmp(forced_kernel, "tile") == 0) {
+            return BEST_FATTN_KERNEL_TILE;
+        }
+
+        const bool mma_shape = V->ne[0] == Q->ne[0] &&
+            (Q->ne[0] == 64 || Q->ne[0] == 80 || Q->ne[0] == 96 ||
+             Q->ne[0] == 112 || Q->ne[0] == 128 || Q->ne[0] == 256);
+        if (strcmp(forced_kernel, "mma") == 0 && mma_shape) {
+            return BEST_FATTN_KERNEL_MMA_F16;
+        }
+    }
+
     // HIP/ROCm: the TILE/MMA/WMMA FA paths allocate large f16 temp buffers for
     // quantized KV types (K_f16, V_f16 in launch_fattn). For SMALL batches (decode)
     // the VEC kernel is preferred: it does inline dequant with zero temp buffer


### PR DESCRIPTION
Apollo isolated a large Qwen3.5 prefill regression on gfx1201 with ROCm 7.2. This adds one HIP-only diagnostic override so we can compare the tile and MMA flash-attention paths from the same build. Default dispatch is unchanged.

I reproduced the same model and command shape on the RX 9070 XT available here, but only with Vulkan. Warm-cache results do not reproduce the regression:

- f97400563: 794.92 pp512
- shared base 15586e2d7: 799.37 pp512
- current head 407f3237b: 796.93 pp512
- f97400563 with `-fa 0`: 788.39 pp512
- shared base with `-fa 0`: 788.82 pp512

The first cold Vulkan run was slower and recovered after pipeline compilation, so these are repeated warm-cache samples. Apollo's ROCm result remains the relevant oracle.

Apollo, please build this head for gfx1201 and run these three cases against each affected model:

```sh
env -u GGML_HIP_FA_KERNEL ./llama-bench -m <model> -ngl 99 -fa 1 -p 512 -n 128 -r 5 -o json
GGML_HIP_FA_KERNEL=tile ./llama-bench -m <model> -ngl 99 -fa 1 -p 512 -n 128 -r 5 -o json
GGML_HIP_FA_KERNEL=mma ./llama-bench -m <model> -ngl 99 -fa 1 -p 512 -n 128 -r 5 -o json
```

Please post the build commit and the five individual pp512 samples for each case. The 9B result is the most sensitive one, so start there. If one forced path recovers the upstream result, I will turn that into the narrow default-dispatch fix and keep the other path available as a fallback.

Local validation: `git diff --check`. HIP compile CI and the requested gfx1201 performance A/B are pending.