### PR TITLE
cuda: recover batched decode on AMD by keeping narrow weights off the GEMM

### DIFF
--- a/ggml/src/ggml-cuda/mmvf.cu
+++ b/ggml/src/ggml-cuda/mmvf.cu
@@ -2,6 +2,8 @@
 #include "common.cuh"
 #include "unary.cuh"
 #include "mmvf.cuh"
+
+#include <cstdlib>
 #include "convert.cuh"
 
 template <typename T, typename type_acc, int ncols_dst, int block_size, bool has_fusion = false, bool is_multi_token_id = false>
@@ -783,6 +785,15 @@ void ggml_cuda_op_mul_mat_vec_f(
     GGML_UNUSED_VARS(ctx, src1, dst, src1_ddq_i, src1_ncols, src1_padded_row_size);
 }
 
+// Widest src0_ne[1] for which the vector kernel still beats a GEMM above three columns on AMD
+// MFMA hardware. A GEMM whose output is a few columns wide is nearly all setup, which is ruinous
+// for narrow weights and fine for wide ones. Env-tunable while the crossover is being measured;
+// 0 restores the upstream behaviour of stopping at three columns whatever the width.
+static int64_t ggml_cuda_mmvf_narrow_max() {
+    static const int64_t v = getenv("GGML_MMVF_NARROW_MAX") ? atoll(getenv("GGML_MMVF_NARROW_MAX")) : 4096;
+    return v;
+}
+
 bool ggml_cuda_should_use_mmvf(enum ggml_type type, int cc, const int64_t * src0_ne, const size_t * src0_nb, int64_t ne11) {
     if (src0_ne[0] % 2 != 0) {
         return false;
@@ -812,6 +823,14 @@ bool ggml_cuda_should_use_mmvf(enum ggml_type type, int cc, const int64_t * src0
                 return ne11 <= 3;
             } else if (GGML_CUDA_CC_IS_AMD(cc)) {
                 if (fp32_mma_hardware_available(cc)) {
+                    // The MFMA GEMM only earns its setup on wide weights. qwen4exp puts narrow F32
+                    // matmuls on the hot path - the MoE router at [2560, 512], the hyper-connection
+                    // injects at [10240, 4], the SSM gates - and dropping those onto a GEMM at four
+                    // columns costs about 31 ms per decode step, against roughly 4 ms per added row
+                    // either side of the boundary. Keep the vector kernel for narrow weights.
+                    if (src0_ne[1] <= ggml_cuda_mmvf_narrow_max()) {
+                        return ne11 <= 8;
+                    }
                     return ne11 <= 3;
                 }
                 return ne11 <= 8;
@@ -858,6 +877,14 @@ bool ggml_cuda_should_use_mmvf(enum ggml_type type, int cc, const int64_t * src0
                 return ne11 <= 8;
             } else if (GGML_CUDA_CC_IS_AMD(cc)) {
                 if (bf16_mma_hardware_available(cc)) {
+                    // Same narrow-weight case as F32 above, and worse here: on CDNA2 mmf refuses
+                    // BF16 outright, so above this limit there is no vector path left and the op
+                    // lands on a cuBLAS GEMM with a bf16 conversion on each side. qwen4exp keeps
+                    // its structural tensors in BF16 - the hyper-connection injects at [10240, 4],
+                    // the SSM gates at [2560, 48] - and they are on every token's path.
+                    if (src0_ne[1] <= ggml_cuda_mmvf_narrow_max()) {
+                        return ne11 <= 8;
+                    }
                     return ne11 <= 3;
                 }
                 return ne11 <= 8;

--- a/ggml/src/ggml-cuda/mmvf.cu
+++ b/ggml/src/ggml-cuda/mmvf.cu
@@ -799,6 +799,14 @@ void ggml_cuda_op_mul_mat_vec_f(
 //   CDNA2  BF16     -90%   -86/-81  -84/-76   -83/-73   -54/-20   -49/-8    -17/+56   +13/+98
 //   RDNA3  F16      -86%   -86/-83  -50/-29   -25/+15   +43/+127  +58/+180  +116/+236 +119/+253
 //   RDNA3  BF16     -83%   -84/-79  -50/-41   -42/-1    +61/+114  +96/+144  +173/+248 +150/+242
+//   RDNA4  F16    -1/-96        -    -0/-91        -     -5/-56    +1/-19          -   +0/+8
+//   RDNA4  BF16  -96/-95        -   -91/-91        -    -65/-55   -41/-20          -   +1/+13
+//
+// RDNA4 measured on gfx1201 by @apollo-mg. It does not track RDNA3: its crossover is between 2048
+// and 4096 for both types, eight to sixteen times wider, and it wants no floor at all since the
+// vector kernel wins by 96% at four rows where CDNA F16 loses. Its F16 band only bites at n >= 6,
+// because RDNA4's own F16 limit already reaches five columns. RDNA3.5 is unmeasured and folded in
+// with RDNA3.
 //
 // The two batch widths disagree about where the edge is: n=4 keeps winning past the point where
 // n=8 has turned. These bands take the widest span that still wins at every n measured (3, 4 and
@@ -815,7 +823,9 @@ static mmvf_narrow_band ggml_cuda_mmvf_narrow_band(const int cc, const enum ggml
 
     if (GGML_CUDA_CC_IS_CDNA(cc)) {
         band = type == GGML_TYPE_F16 ? mmvf_narrow_band{ 8, 1024 } : mmvf_narrow_band{ 0, 2048 };
-    } else if (GGML_CUDA_CC_IS_RDNA3(cc) || GGML_CUDA_CC_IS_RDNA4(cc)) {
+    } else if (GGML_CUDA_CC_IS_RDNA4(cc)) {
+        band = { 0, 2048 };
+    } else if (GGML_CUDA_CC_IS_RDNA3(cc)) {
         band = type == GGML_TYPE_F16 ? mmvf_narrow_band{ 0, 128 } : mmvf_narrow_band{ 0, 256 };
     }
 

--- a/ggml/src/ggml-cuda/mmvf.cu
+++ b/ggml/src/ggml-cuda/mmvf.cu
@@ -785,34 +785,55 @@ void ggml_cuda_op_mul_mat_vec_f(
     GGML_UNUSED_VARS(ctx, src1, dst, src1_ddq_i, src1_ncols, src1_padded_row_size);
 }
 
-// Widest src0_ne[1] for which the vector kernel still beats a GEMM above three columns on AMD
-// MFMA hardware. A GEMM whose output is a few columns wide is nearly all setup, which is ruinous
-// for narrow weights and fine for wide ones.
+// The band of weight widths for which the vector kernel beats a GEMM above the per-architecture
+// column limit. A GEMM whose output is a few columns wide is nearly all setup, which is ruinous for
+// narrow weights and fine for wide ones, so there is an upper edge. F16 on CDNA also has a lower
+// edge: at the very narrowest widths the vector kernel loses there, which BF16 on the same hardware
+// does not do.
 //
-// Where that stops being true is a property of the hardware, not of the model, and the two
-// architectures measured here disagree by about a factor of four. Forcing each path with
-// GGML_MMVF_NARROW_MAX and comparing at k=10240, n=4 (negative means the vector kernel wins):
+// Measured by forcing each path and comparing, k=10240, n=4, negative meaning the vector kernel
+// wins. Widths not listed were not sampled.
 //
-//              m=320   m=1024   m=4096
-//   CDNA2       -81%     -56%     +12%     crossover between 1024 and 4096
-//   RDNA3       -22%     +64%    +137%     crossover between  320 and 1024
+//                     m=4    m=320   m=1024   m=4096   m=8192
+//   CDNA2  BF16      -90%     -81%     -56%     +12%     +62%
+//   CDNA2  F16       +41%     -80%     -56%     -43%     -38%
+//   RDNA3  BF16      -83%     -22%     +64%    +137%     +19%
+//   RDNA3  F16       -86%     -36%     +43%    +119%      -7%
 //
-// So a single value regresses one of them: 4096 costs RDNA3 up to +241% at n=8, and 512 gives up
-// CDNA2's -56% at m=1024. RDNA4 is not measured here and takes the RDNA3 value, which sits above
-// the width measured as a large win on gfx1201 and well below the one measured as a loss.
-// 0 restores the upstream behaviour of stopping at three columns whatever the width.
-static int64_t ggml_cuda_mmvf_narrow_max(const int cc) {
-    static const char * env = getenv("GGML_MMVF_NARROW_MAX");
-    if (env) {
-        return atoll(env);
-    }
+// So the edges differ by architecture and, on CDNA, by type. The lower edge for CDNA F16 is
+// bracketed between 4 and 320 and has not been bisected; 64 is a placeholder inside that bracket.
+// RDNA4 is not measured and takes the RDNA3 band. GGML_MMVF_NARROW_MIN and _MAX override both edges
+// for measurement; setting _MAX to 0 restores the upstream behaviour of stopping at the column
+// limit whatever the width.
+struct mmvf_narrow_band {
+    int64_t min;
+    int64_t max;
+};
+
+static mmvf_narrow_band ggml_cuda_mmvf_narrow_band(const int cc, const enum ggml_type type) {
+    mmvf_narrow_band band = { 0, 4096 };
+
     if (GGML_CUDA_CC_IS_CDNA(cc)) {
-        return 2048;
+        band = type == GGML_TYPE_F16 ? mmvf_narrow_band{ 64, 4096 } : mmvf_narrow_band{ 0, 2048 };
+    } else if (GGML_CUDA_CC_IS_RDNA3(cc) || GGML_CUDA_CC_IS_RDNA4(cc)) {
+        band = { 0, 512 };
     }
-    if (GGML_CUDA_CC_IS_RDNA3(cc) || GGML_CUDA_CC_IS_RDNA4(cc)) {
-        return 512;
+
+    static const char * env_min = getenv("GGML_MMVF_NARROW_MIN");
+    static const char * env_max = getenv("GGML_MMVF_NARROW_MAX");
+    if (env_min) {
+        band.min = atoll(env_min);
     }
-    return 4096;
+    if (env_max) {
+        band.max = atoll(env_max);
+    }
+
+    return band;
+}
+
+static bool ggml_cuda_mmvf_weight_is_narrow(const int cc, const enum ggml_type type, const int64_t ne01) {
+    const mmvf_narrow_band band = ggml_cuda_mmvf_narrow_band(cc, type);
+    return ne01 >= band.min && ne01 <= band.max;
 }
 
 bool ggml_cuda_should_use_mmvf(enum ggml_type type, int cc, const int64_t * src0_ne, const size_t * src0_nb, int64_t ne11) {
@@ -849,7 +870,7 @@ bool ggml_cuda_should_use_mmvf(enum ggml_type type, int cc, const int64_t * src0
                     // injects at [10240, 4], the SSM gates - and dropping those onto a GEMM at four
                     // columns costs about 31 ms per decode step, against roughly 4 ms per added row
                     // either side of the boundary. Keep the vector kernel for narrow weights.
-                    if (src0_ne[1] <= ggml_cuda_mmvf_narrow_max(cc)) {
+                    if (ggml_cuda_mmvf_weight_is_narrow(cc, GGML_TYPE_F32, src0_ne[1])) {
                         return ne11 <= 8;
                     }
                     return ne11 <= 3;
@@ -876,7 +897,7 @@ bool ggml_cuda_should_use_mmvf(enum ggml_type type, int cc, const int64_t * src0
                     // are tuned for weights wide enough to fill the GEMM; a narrow one has no rows
                     // to fill it with. CDNA reaches neither of them and stops at two columns, so it
                     // leaves the vector path earliest on exactly the tensors that need it most.
-                    if (src0_ne[1] <= ggml_cuda_mmvf_narrow_max(cc)) {
+                    if (ggml_cuda_mmvf_weight_is_narrow(cc, GGML_TYPE_F16, src0_ne[1])) {
                         return ne11 <= 8;
                     }
                     if (GGML_CUDA_CC_IS_RDNA3(cc)) {
@@ -910,7 +931,7 @@ bool ggml_cuda_should_use_mmvf(enum ggml_type type, int cc, const int64_t * src0
                     // lands on a cuBLAS GEMM with a bf16 conversion on each side. qwen4exp keeps
                     // its structural tensors in BF16 - the hyper-connection injects at [10240, 4],
                     // the SSM gates at [2560, 48] - and they are on every token's path.
-                    if (src0_ne[1] <= ggml_cuda_mmvf_narrow_max(cc)) {
+                    if (ggml_cuda_mmvf_weight_is_narrow(cc, GGML_TYPE_BF16, src0_ne[1])) {
                         return ne11 <= 8;
                     }
                     return ne11 <= 3;

--- a/ggml/src/ggml-cuda/mmvf.cu
+++ b/ggml/src/ggml-cuda/mmvf.cu
@@ -788,23 +788,23 @@ void ggml_cuda_op_mul_mat_vec_f(
 // The band of weight widths for which the vector kernel beats a GEMM above the per-architecture
 // column limit. A GEMM whose output is a few columns wide is nearly all setup, which is ruinous for
 // narrow weights and fine for wide ones, so there is an upper edge. F16 on CDNA also has a lower
-// edge: at the very narrowest widths the vector kernel loses there, which BF16 on the same hardware
-// does not do.
+// edge: at four rows the vector kernel loses there, which it does not at eight and which BF16 does
+// not do at all.
 //
-// Measured by forcing each path and comparing, k=10240, n=4, negative meaning the vector kernel
-// wins. Widths not listed were not sampled.
+// Measured by forcing each path and comparing, k=10240, negative meaning the vector kernel wins,
+// as n=4 / n=8:
 //
-//                     m=4    m=320   m=1024   m=4096   m=8192
-//   CDNA2  BF16      -90%     -81%     -56%     +12%     +62%
-//   CDNA2  F16       +41%     -80%     -56%     -43%     -38%
-//   RDNA3  BF16      -83%     -22%     +64%    +137%     +19%
-//   RDNA3  F16       -86%     -36%     +43%    +119%      -7%
+//                    m=4      m=8     m=128     m=256    m=1024    m=2048    m=3072    m=4096
+//   CDNA2  F16      +41%   -79/-70  -77/-61   -81/-71   -56/-24   -31/+25   -56/-20   -43/+2
+//   CDNA2  BF16     -90%   -86/-81  -84/-76   -83/-73   -54/-20   -49/-8    -17/+56   +13/+98
+//   RDNA3  F16      -86%   -86/-83  -50/-29   -25/+15   +43/+127  +58/+180  +116/+236 +119/+253
+//   RDNA3  BF16     -83%   -84/-79  -50/-41   -42/-1    +61/+114  +96/+144  +173/+248 +150/+242
 //
-// So the edges differ by architecture and, on CDNA, by type. The lower edge for CDNA F16 is
-// bracketed between 4 and 320 and has not been bisected; 64 is a placeholder inside that bracket.
-// RDNA4 is not measured and takes the RDNA3 band. GGML_MMVF_NARROW_MIN and _MAX override both edges
-// for measurement; setting _MAX to 0 restores the upstream behaviour of stopping at the column
-// limit whatever the width.
+// The two batch widths disagree about where the edge is: n=4 keeps winning past the point where
+// n=8 has turned. These bands take the widest span that still wins at every n measured (3, 4 and
+// 8), which costs some n=4 ground and avoids regressing n=8. RDNA4 is not measured and takes the
+// RDNA3 band. GGML_MMVF_NARROW_MIN and _MAX override both edges; setting _MAX to 0 restores the
+// upstream behaviour of stopping at the column limit whatever the width.
 struct mmvf_narrow_band {
     int64_t min;
     int64_t max;
@@ -814,9 +814,9 @@ static mmvf_narrow_band ggml_cuda_mmvf_narrow_band(const int cc, const enum ggml
     mmvf_narrow_band band = { 0, 4096 };
 
     if (GGML_CUDA_CC_IS_CDNA(cc)) {
-        band = type == GGML_TYPE_F16 ? mmvf_narrow_band{ 64, 4096 } : mmvf_narrow_band{ 0, 2048 };
+        band = type == GGML_TYPE_F16 ? mmvf_narrow_band{ 8, 1024 } : mmvf_narrow_band{ 0, 2048 };
     } else if (GGML_CUDA_CC_IS_RDNA3(cc) || GGML_CUDA_CC_IS_RDNA4(cc)) {
-        band = { 0, 512 };
+        band = type == GGML_TYPE_F16 ? mmvf_narrow_band{ 0, 128 } : mmvf_narrow_band{ 0, 256 };
     }
 
     static const char * env_min = getenv("GGML_MMVF_NARROW_MIN");

--- a/ggml/src/ggml-cuda/mmvf.cu
+++ b/ggml/src/ggml-cuda/mmvf.cu
@@ -787,11 +787,32 @@ void ggml_cuda_op_mul_mat_vec_f(
 
 // Widest src0_ne[1] for which the vector kernel still beats a GEMM above three columns on AMD
 // MFMA hardware. A GEMM whose output is a few columns wide is nearly all setup, which is ruinous
-// for narrow weights and fine for wide ones. Env-tunable while the crossover is being measured;
+// for narrow weights and fine for wide ones.
+//
+// Where that stops being true is a property of the hardware, not of the model, and the two
+// architectures measured here disagree by about a factor of four. Forcing each path with
+// GGML_MMVF_NARROW_MAX and comparing at k=10240, n=4 (negative means the vector kernel wins):
+//
+//              m=320   m=1024   m=4096
+//   CDNA2       -81%     -56%     +12%     crossover between 1024 and 4096
+//   RDNA3       -22%     +64%    +137%     crossover between  320 and 1024
+//
+// So a single value regresses one of them: 4096 costs RDNA3 up to +241% at n=8, and 512 gives up
+// CDNA2's -56% at m=1024. RDNA4 is not measured here and takes the RDNA3 value, which sits above
+// the width measured as a large win on gfx1201 and well below the one measured as a loss.
 // 0 restores the upstream behaviour of stopping at three columns whatever the width.
-static int64_t ggml_cuda_mmvf_narrow_max() {
-    static const int64_t v = getenv("GGML_MMVF_NARROW_MAX") ? atoll(getenv("GGML_MMVF_NARROW_MAX")) : 4096;
-    return v;
+static int64_t ggml_cuda_mmvf_narrow_max(const int cc) {
+    static const char * env = getenv("GGML_MMVF_NARROW_MAX");
+    if (env) {
+        return atoll(env);
+    }
+    if (GGML_CUDA_CC_IS_CDNA(cc)) {
+        return 2048;
+    }
+    if (GGML_CUDA_CC_IS_RDNA3(cc) || GGML_CUDA_CC_IS_RDNA4(cc)) {
+        return 512;
+    }
+    return 4096;
 }
 
 bool ggml_cuda_should_use_mmvf(enum ggml_type type, int cc, const int64_t * src0_ne, const size_t * src0_nb, int64_t ne11) {
@@ -828,7 +849,7 @@ bool ggml_cuda_should_use_mmvf(enum ggml_type type, int cc, const int64_t * src0
                     // injects at [10240, 4], the SSM gates - and dropping those onto a GEMM at four
                     // columns costs about 31 ms per decode step, against roughly 4 ms per added row
                     // either side of the boundary. Keep the vector kernel for narrow weights.
-                    if (src0_ne[1] <= ggml_cuda_mmvf_narrow_max()) {
+                    if (src0_ne[1] <= ggml_cuda_mmvf_narrow_max(cc)) {
                         return ne11 <= 8;
                     }
                     return ne11 <= 3;
@@ -851,6 +872,13 @@ bool ggml_cuda_should_use_mmvf(enum ggml_type type, int cc, const int64_t * src0
                 return ne11 <= 8;
             } else if (GGML_CUDA_CC_IS_AMD(cc)) {
                 if (fp16_mma_hardware_available(cc)) {
+                    // Same narrow-weight case as F32 and BF16. The per-architecture limits below
+                    // are tuned for weights wide enough to fill the GEMM; a narrow one has no rows
+                    // to fill it with. CDNA reaches neither of them and stops at two columns, so it
+                    // leaves the vector path earliest on exactly the tensors that need it most.
+                    if (src0_ne[1] <= ggml_cuda_mmvf_narrow_max(cc)) {
+                        return ne11 <= 8;
+                    }
                     if (GGML_CUDA_CC_IS_RDNA3(cc)) {
                         return ne11 <= 3;
                     }
@@ -882,7 +910,7 @@ bool ggml_cuda_should_use_mmvf(enum ggml_type type, int cc, const int64_t * src0
                     // lands on a cuBLAS GEMM with a bf16 conversion on each side. qwen4exp keeps
                     // its structural tensors in BF16 - the hyper-connection injects at [10240, 4],
                     // the SSM gates at [2560, 48] - and they are on every token's path.
-                    if (src0_ne[1] <= ggml_cuda_mmvf_narrow_max()) {
+                    if (src0_ne[1] <= ggml_cuda_mmvf_narrow_max(cc)) {
                         return ne11 <= 8;
                     }
                     return ne11 <= 3;


### PR DESCRIPTION
One patch, and not specific to any model or quantisation, though I found it
chasing a Qwen3.8-Flash-Next oddity: decode cost stepped by 32 ms per token
between three and four rows, against about 5 ms for every other added row.

`ggml_cuda_should_use_mmvf()` stops using the float vector kernels above three
columns on AMD hardware with the matching MFMA support, and the operation falls
through to a rocBLAS GEMM. BF16 fares worse than F32, because
`should_use_mmf()` refuses BF16 on CDNA2 outright with a TODO noting it is
untuned, so above three columns BF16 has no vector path and no tiled path at all.

That is a fair trade for wide weights and a poor one for narrow ones, where a GEMM
whose output is a few columns wide is nearly all setup. It costs any architecture
that puts narrow matmuls on the hot path. Qwen3.8-Flash-Next is one, with about
two hundred per token, but nothing here is particular to it.

Measured on this branch, MI210, milliseconds per decode step:

| batch | before | after |
| --- | --- | --- |
| 2 | 50.8 | 42.3 |
| 3 | 57.6 | 52.6 |
| **4** | **89.6** | **63.5** |
| 6 | 108.4 | 82.9 |

29% at four rows, 24% at six, nothing lost below four. A dense TQ4_1S 27B model is
unchanged. This is all batched decode, so parallel server slots gain as much as
speculative decoding does.

The width threshold is 4096, overridable with `GGML_MMVF_NARROW_MAX`. Values
between 512 and 16384 could not be told apart here: what looked like a difference
turned out to be a position effect, where the third and later runs in a sequence
are about 10% slower. A batch-size-1 control, which the change provably cannot
affect, tracked the apparent winner exactly and gave it away.

This is not TurboQuant-specific and belongs upstream. As discussed elsewhere, I
can't currently meet their requirements for commit log content being only written
by unassisted humans; I understand that their policy is to prevent vibe-coded slop
making it into their project but I would hope that the quality of this work will
speak for itself.

It is included here because I found and fixed it during the process of getting
qwen3.8-flash-next with the qwen4exp architecture to run on my (less than
enormous) research machines, and it's important enough that I would rather not sit
on it.
