### PR TITLE
cuda: stream TurboQuant MoE experts from pinned host memory

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1513,6 +1513,29 @@ struct ggml_backend_cuda_context {
         int64_t fused_add     = 0;   // tuned multi-ADD runs (ggml_cuda_op_fused_add)
         int64_t fused_mul     = 0;   // tuned multi-MUL runs (ggml_cuda_op_fused_mul)
     } fusion_stats;
+    // Landing slots for paged-in experts. One slab per expert tensor, n_slots experts wide; the
+    // address table is pointed at a slot instead of at the expert's home address once it is copied.
+    struct moe_expert_slab {
+        const void * base = nullptr;
+        int64_t      nb_expert = 0;
+        int          n_slots = 0;
+        int          n_expert = 0;
+        int          n_routed = 0;
+        int          dev = -1;
+        void *       slab = nullptr;
+        // residency bookkeeping, all device-resident so the policy stays inside the graph
+        int32_t *    slot_expert = nullptr;   // n_slots,  expert in this slot or -1
+        int32_t *    claim       = nullptr;   // n_slots,  lowest routed index claiming it this call
+        int32_t *    hit         = nullptr;   // n_routed, already resident
+        int32_t *    won         = nullptr;   // n_routed, will read from a slot rather than in place
+        int32_t *    miss_expert = nullptr;   // n_routed
+        int32_t *    miss_slot   = nullptr;   // n_routed
+        int32_t *    n_miss      = nullptr;   // 1
+    };
+    std::vector<moe_expert_slab> moe_slabs;
+
+    moe_expert_slab * moe_expert_slab_get(const ggml_tensor * src0, int64_t nb_expert,
+                                          int n_expert, int n_routed, cudaStream_t stream);
 
 #ifdef USE_CUDA_GRAPH
     std::unordered_map<uint64_t, std::unique_ptr<ggml_cuda_graph>> cuda_graphs;

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1485,6 +1485,24 @@ struct ggml_backend_cuda_context {
         std::vector<retired_buf> retired;        // outgrown buffers, freed at teardown (captured graphs may still use them)
     } tq_rot_cache;
 
+    // Per-expert address tables for the MoE weight indirection (see tq_build_expert_table). One
+    // entry per expert tensor, built on first use and kept for the life of the context: a captured
+    // graph replays kernels that read this exact address, so it cannot be pool memory and cannot be
+    // freed early. Same discipline as the caches above.
+    struct moe_expert_table {
+        const void *  base      = nullptr;   // src0->data the table was built from
+        int64_t       nb_expert = 0;
+        int           n_expert  = 0;
+        int           dev       = -1;
+        const void ** ptr       = nullptr;   // device array of n_expert addresses
+    };
+    std::vector<moe_expert_table> moe_tables;
+    std::vector<retired_buf>      moe_tables_retired;
+
+    // The cached table for this expert tensor, built on first use. Stable across calls so a
+    // captured graph can keep referencing it.
+    const void ** moe_expert_table_get(const ggml_tensor * src0, int64_t nb_expert, cudaStream_t stream);
+
     uint64_t graph_epoch = 1;
 
     // Fusion hit counters. Read through ggml_backend_cuda_fusion_count(); test-backend-ops uses

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -755,6 +755,12 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {
     for (const auto & r : tq_rot_cache.retired) {
         free_buf(r.ptr, r.dev);
     }
+    for (const auto & t : moe_tables) {
+        free_buf((char *) t.ptr, t.dev);
+    }
+    for (const auto & r : moe_tables_retired) {
+        free_buf(r.ptr, r.dev);
+    }
 
     q8_cache.ptr = nullptr;
     q8_cache.retired.clear();

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1373,6 +1373,24 @@ static const char * ggml_backend_cuda_host_buffer_type_name(ggml_backend_buffer_
     GGML_UNUSED(buft);
 }
 
+// Whether a discrete device will accept a weight that stays in pinned host memory. Opt-in: the
+// hardware can address it under unified addressing, but reads run at PCIe speed, and on the models
+// measured so far leaving an embedding in plain CPU memory and gathering it there was slightly
+// faster than gathering it on the GPU across the bus. It pays when the tensor is large enough that
+// the VRAM matters and sparse enough that the reads do not.
+// Whether MoE expert weights may stay in pinned host memory and be read per expert. Separate from
+// the gather opt-in above because the cost model is different: a gather touches a few rows, while
+// an expert read moves megabytes, and is only affordable when most routed experts are cached.
+static bool ggml_cuda_moe_host_experts_enabled() {
+    static const bool enabled = getenv("GGML_MOE_HOST_EXPERTS") != nullptr;
+    return enabled;
+}
+
+static bool ggml_cuda_host_weights_enabled() {
+    static const bool enabled = getenv("GGML_CUDA_ALLOW_HOST_WEIGHTS") != nullptr;
+    return enabled;
+}
+
 static bool ggml_backend_buft_is_cuda_host(ggml_backend_buffer_type_t buft) {
     return buft->iface.get_name == ggml_backend_cuda_host_buffer_type_name;
 }
@@ -4644,12 +4662,14 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
                 // node's output on the host-visible buffer, which the compute path
                 // handles. Allow that here, mirroring the src-tensor check below.
                 assert(node->buffer->buft == ggml_backend_cuda_buffer_type(cuda_ctx->device) ||
-                       (integrated && ggml_backend_buft_is_cuda_host(node->buffer->buft)));
+                       ((integrated || ggml_cuda_host_weights_enabled()) &&
+                        ggml_backend_buft_is_cuda_host(node->buffer->buft)));
                 for (int j = 0; j < GGML_MAX_SRC; j++) {
                     if (node->src[j] != nullptr) {
                         assert(node->src[j]->buffer);
                         assert(node->src[j]->buffer->buft == ggml_backend_cuda_buffer_type(cuda_ctx->device) ||
-                               (integrated && ggml_backend_buft_is_cuda_host(node->src[j]->buffer->buft)));
+                               ((integrated || ggml_cuda_host_weights_enabled()) &&
+                                ggml_backend_buft_is_cuda_host(node->src[j]->buffer->buft)));
                     }
                 }
 #else
@@ -5366,6 +5386,32 @@ static ggml_backend_buffer_type_t ggml_backend_cuda_device_get_host_buffer_type(
 static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const ggml_tensor * op) {
     ggml_backend_cuda_device_context * dev_ctx = (ggml_backend_cuda_device_context *) dev->context;
 
+    // A source in pinned host memory is addressable but only at PCIe speed, measured here at
+    // 26 GB/s against roughly 1 TB/s from VRAM. That is affordable for a gather, which touches a
+    // few rows, and ruinous for anything that streams a whole tensor. Admit only the gather and
+    // let the scheduler keep the rest on the CPU, so enabling host weights cannot accidentally
+    // drag a matmul across the bus.
+    for (int i = 0; i < GGML_MAX_SRC; i++) {
+        const ggml_tensor * src = op->src[i];
+        if (src != nullptr && src->buffer != nullptr && ggml_backend_buft_is_cuda_host(src->buffer->buft)) {
+            if (op->op == GGML_OP_GET_ROWS) {
+                continue;
+            }
+            // A MoE expert stack is the one weight that is not really streamed: a token routes to
+            // a handful of experts out of hundreds, so the traffic is per-expert rather than the
+            // whole tensor. That is what makes it a candidate for living in host memory with only
+            // the hot experts cached in VRAM. Admitted only for the TQ expert path, which
+            // addresses experts through a table and so can be pointed at either place, and only
+            // when explicitly opted in.
+            if (op->op == GGML_OP_MUL_MAT_ID && i == 0 &&
+                (src->type == GGML_TYPE_TQ3_1S || src->type == GGML_TYPE_TQ4_1S) &&
+                ggml_cuda_moe_host_experts_enabled()) {
+                continue;
+            }
+            return false;
+        }
+    }
+
     // check if all the sources are allocated on this device
     for (int i = 0; i < GGML_MAX_SRC; i++) {
         if (op->src[i] && op->src[i]->buffer && ggml_backend_buft_is_cuda(op->src[i]->buffer->buft)) {
@@ -5841,7 +5887,18 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
 static bool ggml_backend_cuda_device_supports_buft(ggml_backend_dev_t dev, ggml_backend_buffer_type_t buft) {
     ggml_backend_cuda_device_context * dev_ctx = (ggml_backend_cuda_device_context *) dev->context;
     const bool integrated = ggml_cuda_info().devices[dev_ctx->device].integrated;
-    return (ggml_backend_buft_is_cuda(buft) && buft->device == dev) || (integrated && ggml_backend_buft_is_cuda_host(buft));
+
+    // Pinned host memory is device-addressable under unified addressing, so a discrete GPU can read
+    // a weight in place instead of needing it copied in. That is a poor trade for anything streamed:
+    // an expert matmul reads its weights at PCIe speed, measured 26 GB/s here against roughly 1 TB/s
+    // from VRAM. It is a good trade for a large tensor that is only gathered from. The per-layer
+    // n-gram table in qwen4exp is the motivating case: 25.6 GB of which a token reads about 1.25 KB,
+    // measured at 2.6 us per token from host memory against 1.9 us from VRAM.
+    //
+    // Off by default, because otherwise the scheduler is free to place any weight here, including
+    // the ones that would be ruinous. Select tensors deliberately with --override-tensor.
+    return (ggml_backend_buft_is_cuda(buft) && buft->device == dev)
+        || ((integrated || ggml_cuda_host_weights_enabled()) && ggml_backend_buft_is_cuda_host(buft));
 }
 
 static int64_t get_op_batch_size(const ggml_tensor * op) {

--- a/ggml/src/ggml-cuda/mmvq-tq.cu
+++ b/ggml/src/ggml-cuda/mmvq-tq.cu
@@ -123,6 +123,278 @@ __device__ __forceinline__ void tq4_cents8_reg(uint32_t four_bytes, int &c0, int
 // (the WHT butterfly itself was always computed in float registers; only
 // the final store truncated to half) removes this without touching the
 // weight-side quantization or the WHT math itself.
+// Fills a per-expert address table. Every entry is base + i*stride here, which reproduces the
+// contiguous layout exactly; the point is that an entry can instead be made to point at a VRAM
+// cache slot or at mapped host memory for an expert that is not resident, with the kernels none
+// the wiser. Built on the device so nothing is read back to the host, which would be illegal
+// inside a CUDA graph capture.
+static __global__ void tq_build_expert_table(
+        const char *  __restrict__ base,
+        const int64_t nb_expert,
+        const int     n_expert,
+        const void ** __restrict__ out) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n_expert) {
+        out[i] = base + (int64_t) i * nb_expert;
+    }
+}
+
+// Copy the experts this call routes to into VRAM slots and point the address table at the copies,
+// so the matmul only ever reads VRAM. This is what makes leaving the expert stack in host memory
+// affordable: measured on gfx90a, a coalesced copy reaches 27.6 GB/s against the 28.6 GB/s of a
+// bulk transfer, while the matmul dereferencing the same host memory in place manages only about
+// 2.7 GB/s. It has to be a kernel rather than a host-issued copy because a captured graph fixes
+// its addresses at capture time and the routing is not known until the graph runs; this reads the
+// routing itself. Decode only for now, and no reuse between calls: every routed expert is copied
+// on every call, which is the worst case the residency policy will improve on.
+static __global__ void tq_page_in_experts(
+        const char    * __restrict__ base,
+        const int64_t                nb_expert,
+        const int32_t * __restrict__ ids,
+        char          * __restrict__ slab,
+        const void   ** __restrict__ table,
+        const int64_t                n_vec) {
+    const int slot   = blockIdx.y;
+    const int expert = ids[slot];
+
+    const uint4 * __restrict__ src = (const uint4 *) (base + (int64_t) expert * nb_expert);
+    uint4       * __restrict__ dst = (uint4       *) (slab + (int64_t) slot   * nb_expert);
+
+    for (int64_t i = (int64_t) blockIdx.x * blockDim.x + threadIdx.x; i < n_vec;
+         i += (int64_t) gridDim.x * blockDim.x) {
+        dst[i] = src[i];
+    }
+
+    // safe to publish from any block: the matmul is a separate launch and cannot start until this
+    // kernel has fully retired
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        table[expert] = dst;
+    }
+}
+
+// Direct-mapped residency: expert e lives in slot e % n_slots, so deciding whether it is resident
+// is one comparison rather than a search. The first attempt used a true LRU with a scan over the
+// slots, which measured slower than not caching at all: a single thread walking device memory with
+// full latency, run before every offloaded expert matmul, cost more than the transfers it saved.
+//
+// Two routed experts can collide on a slot. The loser is not a problem: the address table can point
+// an expert at host memory just as well as at a slot, so a collision simply degrades that one
+// expert to being read in place, which is exactly what it would have cost with no cache at all.
+//
+// claim[] is reset each call and resolves collisions by lowest routed index, so the outcome does
+// not depend on thread scheduling.
+static __global__ void tq_cache_probe(
+        const int32_t * __restrict__ ids,
+        const int                    n_routed,
+        const int                    n_slots,
+        const int32_t * __restrict__ slot_expert,
+        int32_t       * __restrict__ claim,
+        int32_t       * __restrict__ hit) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n_routed) {
+        return;
+    }
+    const int e    = ids[i];
+    const int slot = e % n_slots;
+
+    if (slot_expert[slot] == e) {
+        hit[i] = 1;
+        // Reserve the slot. Without this, another routed expert mapping to the same slot could
+        // claim it and overwrite the contents in this very call, while this expert's table entry
+        // still points there - so it would silently read the other expert's weights. The output
+        // stays fluent, which is why only a byte-for-byte comparison catches it.
+        atomicMin(&claim[slot], -1);
+    } else {
+        hit[i] = 0;
+        atomicMin(&claim[slot], i);       // lowest routed index wins a free-to-take slot
+    }
+}
+
+// Award the claimed slots and build the miss list. One thread per routed expert, no search.
+static __global__ void tq_cache_award(
+        const int32_t * __restrict__ ids,
+        const int                    n_routed,
+        const int                    n_slots,
+        const int32_t * __restrict__ claim,
+        const int32_t * __restrict__ hit,
+        int32_t       * __restrict__ slot_expert,
+        int32_t       * __restrict__ miss_expert,
+        int32_t       * __restrict__ miss_slot,
+        int32_t       * __restrict__ n_miss,
+        int32_t       * __restrict__ won) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n_routed) {
+        return;
+    }
+    if (hit[i]) {
+        won[i] = 1;
+        return;
+    }
+    const int e    = ids[i];
+    const int slot = e % n_slots;
+
+    // claim[slot] == -1 means a hit reserved it, so no miss may take it this call
+    if (claim[slot] == i) {
+        slot_expert[slot] = e;
+        const int k = atomicAdd(n_miss, 1);
+        miss_expert[k] = e;
+        miss_slot[k]   = slot;
+        won[i] = 1;                       // will be resident once the copy runs
+    } else {
+        won[i] = 0;                       // reserved or lost the collision: read this one in place
+    }
+}
+
+// Copy only the experts the plan marked as missing.
+static __global__ void tq_page_in_misses(
+        const char    * __restrict__ base,
+        const int64_t                nb_expert,
+        const int32_t * __restrict__ miss_expert,
+        const int32_t * __restrict__ miss_slot,
+        const int32_t * __restrict__ n_miss,
+        char          * __restrict__ slab,
+        const int64_t                n_vec) {
+    if (blockIdx.y >= (unsigned) *n_miss) {
+        return;
+    }
+    const int expert = miss_expert[blockIdx.y];
+    const int slot   = miss_slot[blockIdx.y];
+
+    const uint4 * __restrict__ src = (const uint4 *) (base + (int64_t) expert * nb_expert);
+    uint4       * __restrict__ dst = (uint4       *) (slab + (int64_t) slot   * nb_expert);
+
+    for (int64_t i = (int64_t) blockIdx.x * blockDim.x + threadIdx.x; i < n_vec;
+         i += (int64_t) gridDim.x * blockDim.x) {
+        dst[i] = src[i];
+    }
+}
+
+// Point the table at the slots for everything this call routes to, hits included.
+static __global__ void tq_table_point(
+        const int32_t * __restrict__ ids,
+        const int                    n_routed,
+        const int                    n_slots,
+        const int32_t * __restrict__ won,
+        const char    * __restrict__ base,
+        char          * __restrict__ slab,
+        const int64_t                nb_expert,
+        const void   ** __restrict__ table) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n_routed) {
+        return;
+    }
+    const int e = ids[i];
+    // a slot if this expert is or is about to be resident, otherwise its home address
+    table[e] = won[i] ? (const void *) (slab + (int64_t) (e % n_slots) * nb_expert)
+                      : (const void *) (base + (int64_t) e * nb_expert);
+}
+
+ggml_backend_cuda_context::moe_expert_slab * ggml_backend_cuda_context::moe_expert_slab_get(
+        const ggml_tensor * src0, int64_t nb_expert, int n_expert, int n_routed, cudaStream_t stream) {
+    const int dev = device;
+
+    static const int n_slots = [] {
+        const char * env = getenv("GGML_MOE_PAGE_SLOTS");
+        const int    v   = env ? atoi(env) : 64;
+        return v > 0 ? v : 64;
+    }();
+
+    for (auto & s : moe_slabs) {
+        if (s.dev == dev && s.base == src0->data && s.nb_expert == nb_expert) {
+            return s.slab ? &s : nullptr;   // remembered as not worth paging
+        }
+    }
+
+    // Paging only makes sense for a tensor that is not already in VRAM. Reading a resident expert
+    // costs nothing, so copying it into a slot would spend VRAM and bandwidth to no purpose, and
+    // doing it for every expert tensor rather than the offloaded ones overflowed the card.
+    {
+#if defined(GGML_USE_HIP)
+        hipPointerAttribute_t attr = {};
+        const hipError_t err = hipPointerGetAttributes(&attr, src0->data);
+        const bool in_host = err == hipSuccess &&
+                             (attr.type == hipMemoryTypeHost || attr.type == hipMemoryTypeUnregistered);
+        (void) hipGetLastError();
+#else
+        cudaPointerAttributes attr = {};
+        const cudaError_t err = cudaPointerGetAttributes(&attr, src0->data);
+        const bool in_host = err == cudaSuccess &&
+                             (attr.type == cudaMemoryTypeHost || attr.type == cudaMemoryTypeUnregistered);
+        (void) cudaGetLastError();
+#endif
+        if (!in_host) {
+            moe_expert_slab skip;   // remember, so the query happens once per tensor
+            skip.base      = src0->data;
+            skip.nb_expert = nb_expert;
+            skip.dev       = dev;
+            skip.slab      = nullptr;
+            moe_slabs.push_back(skip);
+            return nullptr;
+        }
+    }
+
+    moe_expert_slab e;
+    e.base      = src0->data;
+    e.nb_expert = nb_expert;
+    e.n_slots   = n_slots < n_expert ? n_slots : n_expert;
+    e.n_expert  = n_expert;
+    e.n_routed  = n_routed;
+    e.dev       = dev;
+
+    auto alloc = [&](void ** p, size_t bytes) {
+        return ggml_cuda_device_malloc(p, bytes, dev) == cudaSuccess;
+    };
+    if (!alloc(&e.slab, (size_t) e.n_slots * nb_expert) ||
+        !alloc((void **) &e.slot_expert, (size_t) e.n_slots * sizeof(int32_t)) ||
+        !alloc((void **) &e.claim,       (size_t) e.n_slots * sizeof(int32_t)) ||
+        !alloc((void **) &e.hit,         (size_t) n_routed * sizeof(int32_t)) ||
+        !alloc((void **) &e.won,         (size_t) n_routed * sizeof(int32_t)) ||
+        !alloc((void **) &e.miss_expert, (size_t) n_routed * sizeof(int32_t)) ||
+        !alloc((void **) &e.miss_slot,   (size_t) n_routed * sizeof(int32_t)) ||
+        !alloc((void **) &e.n_miss,      sizeof(int32_t))) {
+        return nullptr;   // caller falls back to reading the experts where they live
+    }
+
+    // empty cache: every slot holds nothing
+    CUDA_CHECK(cudaMemsetAsync(e.slot_expert, 0xff, (size_t) e.n_slots * sizeof(int32_t), stream));
+
+    moe_slabs.push_back(e);
+    return &moe_slabs.back();
+}
+
+const void ** ggml_backend_cuda_context::moe_expert_table_get(
+        const ggml_tensor * src0, int64_t nb_expert, cudaStream_t stream) {
+    const int n_expert = (int) src0->ne[2];
+    const int dev      = device;
+
+    for (auto & t : moe_tables) {
+        if (t.dev == dev && t.base == src0->data && t.nb_expert == nb_expert && t.n_expert == n_expert) {
+            return t.ptr;
+        }
+        // same tensor, moved or resized: retire the old buffer rather than free it, since a
+        // captured graph may still reference the address
+        if (t.dev == dev && t.base != nullptr && t.base == src0->data) {
+            moe_tables_retired.push_back({ (char *) t.ptr,
+                    (size_t) t.n_expert * sizeof(const void *), t.dev });
+            t.base = nullptr;
+        }
+    }
+
+    moe_expert_table e;
+    e.base = src0->data;
+    e.nb_expert = nb_expert;
+    e.n_expert = n_expert;
+    e.dev = dev;
+    CUDA_CHECK(ggml_cuda_device_malloc((void **) &e.ptr, (size_t) n_expert * sizeof(const void *), dev));
+
+    const int threads = 64;
+    tq_build_expert_table<<<(n_expert + threads - 1) / threads, threads, 0, stream>>>(
+        (const char *) src0->data, nb_expert, n_expert, e.ptr);
+
+    moe_tables.push_back(e);
+    return e.ptr;
+}
+
 static __global__ void tq_prerotate_activation(
         const float * __restrict__ src,
         float       * __restrict__ dst,
@@ -704,49 +976,6 @@ static void launch_tq3_1s_wmma(
 // cache slot or at mapped host memory for an expert that is not resident, with the kernels none
 // the wiser. Built on the device so nothing is read back to the host, which would be illegal
 // inside a graph capture.
-static __global__ void tq_build_expert_table(
-        const char *  __restrict__ base,
-        const int64_t nb_expert,
-        const int     n_expert,
-        const void ** __restrict__ out) {
-    const int i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i < n_expert) {
-        out[i] = base + (int64_t) i * nb_expert;
-    }
-}
-
-const void ** ggml_backend_cuda_context::moe_expert_table_get(
-        const ggml_tensor * src0, int64_t nb_expert, cudaStream_t stream) {
-    const int n_expert = (int) src0->ne[2];
-    const int dev      = device;
-
-    for (auto & t : moe_tables) {
-        if (t.dev == dev && t.base == src0->data && t.nb_expert == nb_expert && t.n_expert == n_expert) {
-            return t.ptr;
-        }
-        // same weights at a new address or size: retire the old buffer rather than free it, since
-        // a captured graph may still reference it
-        if (t.dev == dev && t.base != nullptr && t.base == src0->data) {
-            moe_tables_retired.push_back({ (char *) t.ptr, (size_t) t.n_expert * sizeof(const void *), t.dev });
-            t.base = nullptr;
-        }
-    }
-
-    moe_expert_table e;
-    e.base      = src0->data;
-    e.nb_expert = nb_expert;
-    e.n_expert  = n_expert;
-    e.dev       = dev;
-    CUDA_CHECK(ggml_cuda_device_malloc((void **) &e.ptr, (size_t) n_expert * sizeof(const void *), dev));
-
-    const int nthr = 64;
-    tq_build_expert_table<<<(n_expert + nthr - 1) / nthr, nthr, 0, stream>>>(
-            (const char *) src0->data, nb_expert, n_expert, e.ptr);
-
-    moe_tables.push_back(e);
-    return e.ptr;
-}
-
 template <bool USE_TABLE>
 static __global__ void mul_mat_tq3_1s_moe(
         const void    * __restrict__ vx,       // all experts, base pointer
@@ -1062,6 +1291,40 @@ void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx,
     const void ** expert_tab = tq_use_expert_table
             ? ctx.moe_expert_table_get(src0, nb_expert, stream)
             : nullptr;
+
+    // Expert paging, off unless asked for. Requires the address table, since paging works by
+    // repointing table entries at the slots rather than by moving the tensor.
+    static const bool page_in_on = getenv("GGML_MOE_PAGE_IN") != nullptr;
+    if (page_in_on && expert_tab && n_tokens == 1 && nb_expert % (int64_t) sizeof(uint4) == 0) {
+        const int n_expert_total = (int) src0->ne[2];
+        auto * cache = ctx.moe_expert_slab_get(src0, nb_expert, n_expert_total, n_expert_used, stream);
+        if (cache) {
+            const int nthr = 64;
+            const int nblk = (n_expert_used + nthr - 1) / nthr;
+            CUDA_CHECK(cudaMemsetAsync(cache->claim, 0x7f, (size_t) cache->n_slots * sizeof(int32_t), stream));
+            CUDA_CHECK(cudaMemsetAsync(cache->n_miss, 0, sizeof(int32_t), stream));
+            tq_cache_probe<<<nblk, nthr, 0, stream>>>(
+                ids_d, n_expert_used, cache->n_slots, cache->slot_expert, cache->claim, cache->hit);
+            tq_cache_award<<<nblk, nthr, 0, stream>>>(
+                ids_d, n_expert_used, cache->n_slots, cache->claim, cache->hit,
+                cache->slot_expert, cache->miss_expert, cache->miss_slot, cache->n_miss, cache->won);
+
+            const int64_t n_vec  = nb_expert / (int64_t) sizeof(uint4);
+            const int     thr    = 256;
+            int64_t       blocks = (n_vec + thr - 1) / thr;
+            if (blocks > 64) {
+                blocks = 64;
+            }
+            tq_page_in_misses<<<dim3((unsigned) blocks, (unsigned) n_expert_used), thr, 0, stream>>>(
+                (const char *) src0->data, nb_expert,
+                cache->miss_expert, cache->miss_slot, cache->n_miss,
+                (char *) cache->slab, n_vec);
+
+            tq_table_point<<<nblk, nthr, 0, stream>>>(
+                ids_d, n_expert_used, cache->n_slots, cache->won,
+                (const char *) src0->data, (char *) cache->slab, nb_expert, expert_tab);
+        }
+    }
 
     const int n_act_elements = ncols_x * nchannels_y * n_tokens;
     const dim3 block(WARP_SIZE, MMVQ_TQ_NWARPS);

--- a/ggml/src/ggml-cuda/mmvq-tq.cu
+++ b/ggml/src/ggml-cuda/mmvq-tq.cu
@@ -699,6 +699,23 @@ static void launch_tq3_1s_wmma(
 //   grid.z = token/sample (ne2)            one dot product per (row, expert_slot, sample)
 // ============================================================================
 
+// Fills a per-expert address table. Every entry is base + i*nb_expert here, which reproduces the
+// contiguous layout exactly; the point is that an entry can instead be made to point at a VRAM
+// cache slot or at mapped host memory for an expert that is not resident, with the kernels none
+// the wiser. Built on the device so nothing is read back to the host, which would be illegal
+// inside a graph capture.
+static __global__ void tq_build_expert_table(
+        const char *  __restrict__ base,
+        const int64_t nb_expert,
+        const int     n_expert,
+        const void ** __restrict__ out) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n_expert) {
+        out[i] = base + (int64_t) i * nb_expert;
+    }
+}
+
+template <bool USE_TABLE>
 static __global__ void mul_mat_tq3_1s_moe(
         const void    * __restrict__ vx,       // all experts, base pointer
         const float   * __restrict__ vy_rot,   // pre-rotated activations
@@ -733,7 +750,8 @@ static __global__ void mul_mat_tq3_1s_moe(
     const int lane = threadIdx.x;
     const int blocks_per_row = ncols_x / QK_TQ3_0;
     const block_tq3_1s * x_row =
-        (const block_tq3_1s *) ((const char *) vx + (int64_t) expert * nb_expert)
+        (const block_tq3_1s *) (USE_TABLE ? (const char *) ((const void * const *) vx)[expert]
+                             : (const char *) vx + (int64_t) expert * nb_expert)
         + (int64_t) row * blocks_per_row;
     const float * act = vy_rot + sample * stride_sample_y + (int64_t) channel_y * stride_channel_y;
 
@@ -759,6 +777,7 @@ static __global__ void mul_mat_tq3_1s_moe(
     }
 }
 
+template <bool USE_TABLE>
 static __global__ void mul_mat_tq4_1s_scalar_moe(
         const void    * __restrict__ vx,
         const float   * __restrict__ vy_rot,
@@ -791,7 +810,8 @@ static __global__ void mul_mat_tq4_1s_scalar_moe(
     const int lane = threadIdx.x;
     const int blocks_per_row = ncols_x / QK_TQ4_1S;
     const block_tq4_1s * x_row =
-        (const block_tq4_1s *) ((const char *) vx + (int64_t) expert * nb_expert)
+        (const block_tq4_1s *) (USE_TABLE ? (const char *) ((const void * const *) vx)[expert]
+                             : (const char *) vx + (int64_t) expert * nb_expert)
         + (int64_t) row * blocks_per_row;
     const float * act = vy_rot + sample * stride_sample_y + (int64_t) channel_y * stride_channel_y;
 
@@ -816,7 +836,7 @@ static __global__ void mul_mat_tq4_1s_scalar_moe(
 // NVIDIA TQ4_1S dp4a MoE variant: same device-side ids routing as the scalar kernels above, but
 // the int8 dp4a inner loop of mul_mat_tq4_1s_dp4a_multi (warp-strided over blocks, q8_1 activations,
 // packed-centroid LUT). One dot product per (row, expert_slot, sample) output element.
-template <int LPR>   // lanes cooperating on one output row (must divide WARP_SIZE)
+template <int LPR, bool USE_TABLE>   // LPR: lanes cooperating on one output row (must divide WARP_SIZE)
 static __global__ void mul_mat_tq4_1s_dp4a_moe(
         const void       * __restrict__ vx,
         const block_q8_1 * __restrict__ vy_q8,      // pre-rotated activations (q8_1)
@@ -851,7 +871,8 @@ static __global__ void mul_mat_tq4_1s_dp4a_moe(
     const int lane = lane_in_row;
     const int blocks_per_row = ncols_x / QK_TQ4_1S;
     const block_tq4_1s * x_row =
-        (const block_tq4_1s *) ((const char *) vx + (int64_t) expert * nb_expert)
+        (const block_tq4_1s *) (USE_TABLE ? (const char *) ((const void * const *) vx)[expert]
+                             : (const char *) vx + (int64_t) expert * nb_expert)
         + (int64_t) row * blocks_per_row;
     const block_q8_1 * a_base = vy_q8 + sample * stride_sample_y + (int64_t) channel_y * stride_channel_y;
 
@@ -1000,6 +1021,21 @@ void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx,
     const int64_t stride_channel_dst = dst->nb[1] / ggml_type_size(dst->type);
     const int64_t stride_sample_dst  = dst->nb[2] / ggml_type_size(dst->type);
 
+    // Optional per-expert address table. Filled here to reproduce the contiguous layout exactly,
+    // so behaviour is unchanged; the point is that an entry can later be pointed at a VRAM cache
+    // slot or at mapped host memory for an expert that is not resident, without the kernels
+    // needing to know. Opt-in while this is being brought up.
+    static const bool tq_use_expert_table = getenv("GGML_MOE_EXPERT_TABLE") != nullptr;
+    const int n_expert_all = (int) ne02;
+    ggml_cuda_pool_alloc<const void *> expert_tab_buf(ctx.pool(id));
+    const void ** expert_tab = nullptr;
+    if (tq_use_expert_table) {
+        expert_tab = expert_tab_buf.alloc(n_expert_all);
+        const int nthr = 64;
+        tq_build_expert_table<<<(n_expert_all + nthr - 1) / nthr, nthr, 0, stream>>>(
+                (const char *) src0->data, nb_expert, n_expert_all, expert_tab);
+    }
+
     const int n_act_elements = ncols_x * nchannels_y * n_tokens;
     const dim3 block(WARP_SIZE, MMVQ_TQ_NWARPS);
     const dim3 grid((nrows_x + MMVQ_TQ_NWARPS - 1) / MMVQ_TQ_NWARPS, n_expert_used, n_tokens);
@@ -1039,10 +1075,19 @@ void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx,
         const dim3 grid_l((unsigned) ((nrows_x + rows_per_wg - 1) / rows_per_wg),
                           (unsigned) n_expert_used, (unsigned) n_tokens);
 
-        #define TQ_LAUNCH_MOE(L) mul_mat_tq4_1s_dp4a_moe<L><<<grid_l, block, 0, stream>>>( \
-            src0->data, q8_act, dst_d, ids_d, ncols_x, nrows_x, \
-            nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y, \
-            stride_channel_dst, stride_sample_dst)
+        #define TQ_LAUNCH_MOE(L) do {                                                                  \
+            if (expert_tab) {                                                                   \
+                mul_mat_tq4_1s_dp4a_moe<L, true><<<grid_l, block, 0, stream>>>(                  \
+                    (const void *) expert_tab, q8_act, dst_d, ids_d, ncols_x, nrows_x,                 \
+                    nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y,                  \
+                    stride_channel_dst, stride_sample_dst);  \
+            } else {                                                                            \
+                mul_mat_tq4_1s_dp4a_moe<L, false><<<grid_l, block, 0, stream>>>(                 \
+                    src0->data, q8_act, dst_d, ids_d, ncols_x, nrows_x,                       \
+                    nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y,                  \
+                    stride_channel_dst, stride_sample_dst);  \
+            }                                                                                   \
+        } while (0)
 
         switch (lpr) {
             case 32: TQ_LAUNCH_MOE(32); break;
@@ -1066,15 +1111,29 @@ void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx,
         const int64_t stride_channel_y = ncols_x;                                // float elems to next y-channel
         const int64_t stride_sample_y  = (int64_t) nchannels_y * ncols_x;        // float elems to next token
         if (src0->type == GGML_TYPE_TQ3_1S) {
-            mul_mat_tq3_1s_moe<<<grid, block, 0, stream>>>(
-                src0->data, act_buf.get(), dst_d, ids_d, ncols_x, nrows_x,
-                nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y,
-                stride_channel_dst, stride_sample_dst);
+            if (expert_tab) {
+                mul_mat_tq3_1s_moe<true><<<grid, block, 0, stream>>>(
+                    (const void *) expert_tab, act_buf.get(), dst_d, ids_d, ncols_x, nrows_x,
+                    nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y,
+                    stride_channel_dst, stride_sample_dst);
+            } else {
+                mul_mat_tq3_1s_moe<false><<<grid, block, 0, stream>>>(
+                    src0->data, act_buf.get(), dst_d, ids_d, ncols_x, nrows_x,
+                    nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y,
+                    stride_channel_dst, stride_sample_dst);
+            }
         } else {
-            mul_mat_tq4_1s_scalar_moe<<<grid, block, 0, stream>>>(
-                src0->data, act_buf.get(), dst_d, ids_d, ncols_x, nrows_x,
-                nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y,
-                stride_channel_dst, stride_sample_dst);
+            if (expert_tab) {
+                mul_mat_tq4_1s_scalar_moe<true><<<grid, block, 0, stream>>>(
+                    (const void *) expert_tab, act_buf.get(), dst_d, ids_d, ncols_x, nrows_x,
+                    nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y,
+                    stride_channel_dst, stride_sample_dst);
+            } else {
+                mul_mat_tq4_1s_scalar_moe<false><<<grid, block, 0, stream>>>(
+                    src0->data, act_buf.get(), dst_d, ids_d, ncols_x, nrows_x,
+                    nb_expert, ids_stride, nchannels_y, stride_channel_y, stride_sample_y,
+                    stride_channel_dst, stride_sample_dst);
+            }
         }
     }
     CUDA_CHECK(cudaGetLastError());

--- a/ggml/src/ggml-cuda/mmvq-tq.cu
+++ b/ggml/src/ggml-cuda/mmvq-tq.cu
@@ -715,6 +715,38 @@ static __global__ void tq_build_expert_table(
     }
 }
 
+const void ** ggml_backend_cuda_context::moe_expert_table_get(
+        const ggml_tensor * src0, int64_t nb_expert, cudaStream_t stream) {
+    const int n_expert = (int) src0->ne[2];
+    const int dev      = device;
+
+    for (auto & t : moe_tables) {
+        if (t.dev == dev && t.base == src0->data && t.nb_expert == nb_expert && t.n_expert == n_expert) {
+            return t.ptr;
+        }
+        // same weights at a new address or size: retire the old buffer rather than free it, since
+        // a captured graph may still reference it
+        if (t.dev == dev && t.base != nullptr && t.base == src0->data) {
+            moe_tables_retired.push_back({ (char *) t.ptr, (size_t) t.n_expert * sizeof(const void *), t.dev });
+            t.base = nullptr;
+        }
+    }
+
+    moe_expert_table e;
+    e.base      = src0->data;
+    e.nb_expert = nb_expert;
+    e.n_expert  = n_expert;
+    e.dev       = dev;
+    CUDA_CHECK(ggml_cuda_device_malloc((void **) &e.ptr, (size_t) n_expert * sizeof(const void *), dev));
+
+    const int nthr = 64;
+    tq_build_expert_table<<<(n_expert + nthr - 1) / nthr, nthr, 0, stream>>>(
+            (const char *) src0->data, nb_expert, n_expert, e.ptr);
+
+    moe_tables.push_back(e);
+    return e.ptr;
+}
+
 template <bool USE_TABLE>
 static __global__ void mul_mat_tq3_1s_moe(
         const void    * __restrict__ vx,       // all experts, base pointer
@@ -1027,14 +1059,9 @@ void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx,
     // needing to know. Opt-in while this is being brought up.
     static const bool tq_use_expert_table = getenv("GGML_MOE_EXPERT_TABLE") != nullptr;
     const int n_expert_all = (int) ne02;
-    ggml_cuda_pool_alloc<const void *> expert_tab_buf(ctx.pool(id));
-    const void ** expert_tab = nullptr;
-    if (tq_use_expert_table) {
-        expert_tab = expert_tab_buf.alloc(n_expert_all);
-        const int nthr = 64;
-        tq_build_expert_table<<<(n_expert_all + nthr - 1) / nthr, nthr, 0, stream>>>(
-                (const char *) src0->data, nb_expert, n_expert_all, expert_tab);
-    }
+    const void ** expert_tab = tq_use_expert_table
+            ? ctx.moe_expert_table_get(src0, nb_expert, stream)
+            : nullptr;
 
     const int n_act_elements = ncols_x * nchannels_y * n_tokens;
     const dim3 block(WARP_SIZE, MMVQ_TQ_NWARPS);

--- a/ggml/src/ggml-cuda/mmvq-tq.cu
+++ b/ggml/src/ggml-cuda/mmvq-tq.cu
@@ -139,39 +139,6 @@ static __global__ void tq_build_expert_table(
     }
 }
 
-// Copy the experts this call routes to into VRAM slots and point the address table at the copies,
-// so the matmul only ever reads VRAM. This is what makes leaving the expert stack in host memory
-// affordable: measured on gfx90a, a coalesced copy reaches 27.6 GB/s against the 28.6 GB/s of a
-// bulk transfer, while the matmul dereferencing the same host memory in place manages only about
-// 2.7 GB/s. It has to be a kernel rather than a host-issued copy because a captured graph fixes
-// its addresses at capture time and the routing is not known until the graph runs; this reads the
-// routing itself. Decode only for now, and no reuse between calls: every routed expert is copied
-// on every call, which is the worst case the residency policy will improve on.
-static __global__ void tq_page_in_experts(
-        const char    * __restrict__ base,
-        const int64_t                nb_expert,
-        const int32_t * __restrict__ ids,
-        char          * __restrict__ slab,
-        const void   ** __restrict__ table,
-        const int64_t                n_vec) {
-    const int slot   = blockIdx.y;
-    const int expert = ids[slot];
-
-    const uint4 * __restrict__ src = (const uint4 *) (base + (int64_t) expert * nb_expert);
-    uint4       * __restrict__ dst = (uint4       *) (slab + (int64_t) slot   * nb_expert);
-
-    for (int64_t i = (int64_t) blockIdx.x * blockDim.x + threadIdx.x; i < n_vec;
-         i += (int64_t) gridDim.x * blockDim.x) {
-        dst[i] = src[i];
-    }
-
-    // safe to publish from any block: the matmul is a separate launch and cannot start until this
-    // kernel has fully retired
-    if (blockIdx.x == 0 && threadIdx.x == 0) {
-        table[expert] = dst;
-    }
-}
-
 // Direct-mapped residency: expert e lives in slot e % n_slots, so deciding whether it is resident
 // is one comparison rather than a search. The first attempt used a true LRU with a scan over the
 // slots, which measured slower than not caching at all: a single thread walking device memory with
@@ -245,7 +212,12 @@ static __global__ void tq_cache_award(
     }
 }
 
-// Copy only the experts the plan marked as missing.
+// Copy only the experts the plan marked as missing, so the matmul reads VRAM rather than host
+// memory. This is what makes leaving the expert stack in host memory affordable: measured on
+// gfx90a, a coalesced copy reaches 27.6 GB/s against the 28.6 GB/s of a bulk transfer, while the
+// matmul dereferencing the same host memory in place manages only about 2.7 GB/s. It has to be a
+// kernel rather than a host-issued copy because a captured graph fixes its addresses at capture
+// time and the routing is not known until the graph runs; this reads the routing itself.
 static __global__ void tq_page_in_misses(
         const char    * __restrict__ base,
         const int64_t                nb_expert,
@@ -315,6 +287,11 @@ ggml_backend_cuda_context::moe_expert_slab * ggml_backend_cuda_context::moe_expe
         const bool in_host = err == hipSuccess &&
                              (attr.type == hipMemoryTypeHost || attr.type == hipMemoryTypeUnregistered);
         (void) hipGetLastError();
+#elif defined(GGML_USE_MUSA)
+        // MUSA does not expose the pointer-attribute query. Paging is only worth anything when the
+        // expert stack is in host memory, and that query is how we establish it, so stay off there
+        // rather than guess.
+        const bool in_host = false;
 #else
         cudaPointerAttributes attr = {};
         const cudaError_t err = cudaPointerGetAttributes(&attr, src0->data);
@@ -1287,7 +1264,6 @@ void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx,
     // slot or at mapped host memory for an expert that is not resident, without the kernels
     // needing to know. Opt-in while this is being brought up.
     static const bool tq_use_expert_table = getenv("GGML_MOE_EXPERT_TABLE") != nullptr;
-    const int n_expert_all = (int) ne02;
     const void ** expert_tab = tq_use_expert_table
             ? ctx.moe_expert_table_get(src0, nb_expert, stream)
             : nullptr;

--- a/ggml/src/ggml-cuda/mmvq-tq.cu
+++ b/ggml/src/ggml-cuda/mmvq-tq.cu
@@ -288,9 +288,8 @@ ggml_backend_cuda_context::moe_expert_slab * ggml_backend_cuda_context::moe_expe
                              (attr.type == hipMemoryTypeHost || attr.type == hipMemoryTypeUnregistered);
         (void) hipGetLastError();
 #elif defined(GGML_USE_MUSA)
-        // MUSA does not expose the pointer-attribute query. Paging is only worth anything when the
-        // expert stack is in host memory, and that query is how we establish it, so stay off there
-        // rather than guess.
+        // No pointer-attribute query on MUSA; see the note at the paging gate below. This branch
+        // exists so the file compiles there, and the gate is what actually keeps the feature off.
         const bool in_host = false;
 #else
         cudaPointerAttributes attr = {};
@@ -1270,7 +1269,18 @@ void ggml_cuda_mul_mat_id_tq(ggml_backend_cuda_context & ctx,
 
     // Expert paging, off unless asked for. Requires the address table, since paging works by
     // repointing table entries at the slots rather than by moving the tensor.
+#if defined(GGML_USE_MUSA)
+    // Expert paging is off on MUSA, and by omission rather than by measurement. It needs to know
+    // the expert stack is in host memory, which is what the pointer-attribute query establishes,
+    // and MUSA exposes no equivalent: upstream carries no mapping for it and no reference to a
+    // musaPointerGetAttributes, so there is no spelling to copy and a guessed one would only break
+    // the build again on hardware that cannot be tested here. To turn it on, add cudaPointerAttributes,
+    // cudaPointerGetAttributes, cudaMemoryTypeHost and cudaMemoryTypeUnregistered to
+    // vendors/musa.h and delete this block along with the matching one in moe_expert_slab_get.
+    static const bool page_in_on = false;
+#else
     static const bool page_in_on = getenv("GGML_MOE_PAGE_IN") != nullptr;
+#endif
     if (page_in_on && expert_tab && n_tokens == 1 && nb_expert % (int64_t) sizeof(uint4) == 0) {
         const int n_expert_total = (int) src0->ne[2];
         auto * cache = ctx.moe_expert_slab_get(src0, nb_expert, n_expert_total, n_expert_used, stream);


### PR DESCRIPTION
Three patches letting a TurboQuant mixture-of-experts model keep its expert stack
in pinned host memory with the hot experts cached in VRAM, so a model larger than
the card runs without spilling everything to the CPU.

An expert stack is the one weight worth doing this to. A token routes to a
handful of experts out of hundreds, so the traffic is per-expert rather than the
whole tensor, and at that granularity the bus is fast enough that the copies
overlap compute.

**1. Route expert addresses through an optional table.** The MoE kernels find an
expert by arithmetic on the base pointer, which requires every expert to be
resident and contiguous. The table is built on the device (reading it back would
be illegal during a graph capture) and initially reproduces that layout exactly,
so it is a no-op. The point is that an entry can then be pointed elsewhere.

**2. Cache the table per expert tensor**, rather than rebuilding it per call. Raw
device memory, never freed early, retired on replacement, released at teardown,
for the same reason as the pre-rotation caches next to it.

**3. The residency cache.** Per tensor, a slab of n_slots expert-sized slots plus
bookkeeping that stays on the device so the policy runs inside the graph. Each
decode probes the routed experts against the slots, awards a slot to each miss,
copies those in and repoints the table. Anything that loses a slot contest reads
in place from host memory, which is correct if slower.

Measured on an MI210 with a 91 GB TQ3 Qwen3.8-Flash-Next, four expert layers in
host memory:

| | generation |
| --- | --- |
| all experts in VRAM (ceiling) | 34.2 t/s |
| four layers in host, paging off | 22.9 t/s |
| paging on, 16 slots | 31.7 t/s |
| paging on, 64 slots | 32.6 t/s |
| paging on, 128 slots | 32.8 t/s |

43% over reading in place, and 96% of what the same layers cost when they never
left the card.

Correctness was checked by perplexity rather than by reading the output, because
the failure mode here is a wrong expert, which produces fluent text that is
quietly wrong. On 273 KB of prose, perplexity is 3.3453 for all of: experts in
VRAM, experts in host with paging off, and paging on at 64, 16 and 4 slots. Four
slots against ten routed experts per token forces a collision on essentially
every call, which is the condition that matters: the probe reserves a slot it
hits with an atomicMin so a miss mapping to the same slot cannot claim it and
overwrite the contents mid-call. An earlier version of this without the
reservation passed a read-the-output check and was wrong.

Everything is opt-in: GGML_MOE_HOST_EXPERTS to admit host-resident experts,
GGML_MOE_EXPERT_TABLE for the indirection, GGML_MOE_PAGE_IN with
GGML_MOE_PAGE_SLOTS for the paging. With them unset the kernels take the original
contiguous path and the generated code is unchanged.

One known rough edge: the pool allocator half-succeeds when it cannot get what it
asked for, rather than sizing to available VRAM or failing outright. The slot
count behaves monotonically here (16 through 128 improve smoothly), though on a
different kernel I have seen the direct-mapped modulo make it erratic, so a
mixing hash or set-associativity may be worth it later.

TurboQuant-specific, admitted only for the TQ expert path and only on opt-in, so
no upstream question here.
